### PR TITLE
Non-unique selection in alignment jmol

### DIFF
--- a/biojava3-structure-gui/src/main/java/org/biojava/bio/structure/align/gui/aligpanel/AligPanel.java
+++ b/biojava3-structure-gui/src/main/java/org/biojava/bio/structure/align/gui/aligpanel/AligPanel.java
@@ -445,8 +445,9 @@ public void paintComponent(Graphics g){
                   cmd.append(", ");
 
                cmd.append(select1);
-               cmd.append(", ");
+               cmd.append("/1, ");
                cmd.append(select2);
+               cmd.append("/2");
                nrSelected++;
             }
          }


### PR DESCRIPTION
This fixes bug #8 where aligned structures with identically
numbered residues would both be selected.
