### PR TITLE
Minor source cleanup, use jdk 1.6 @Overrides instead of /** {@inheritDoc} */ doc tags

### DIFF
--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/AbstractFastqReader.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/AbstractFastqReader.java
@@ -55,7 +55,7 @@ abstract class AbstractFastqReader
      */
     protected abstract FastqVariant getVariant();
 
-    /** {@inheritDoc} */
+    @Override
     public final <R extends Readable & Closeable> void parse(final InputSupplier<R> supplier,
                                                              final ParseListener listener)
         throws IOException
@@ -63,7 +63,7 @@ abstract class AbstractFastqReader
         FastqParser.parse(supplier, listener);
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final <R extends Readable & Closeable> void stream(final InputSupplier<R> supplier,
                                                               final StreamListener listener)
         throws IOException
@@ -71,7 +71,7 @@ abstract class AbstractFastqReader
         StreamingFastqParser.stream(supplier, getVariant(), listener);
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final Iterable<Fastq> read(final File file) throws IOException
     {
         if (file == null)
@@ -83,7 +83,7 @@ abstract class AbstractFastqReader
         return collect.getResult();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final Iterable<Fastq> read(final URL url) throws IOException
     {
         if (url == null)
@@ -95,7 +95,7 @@ abstract class AbstractFastqReader
         return collect.getResult();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final Iterable<Fastq> read(final InputStream inputStream) throws IOException
     {
         if (inputStream == null)
@@ -105,7 +105,7 @@ abstract class AbstractFastqReader
         Collect collect = new Collect();
         stream(new InputSupplier<InputStreamReader>()
                {
-                   /** {@inheritDoc} */
+                   @Override
                    public InputStreamReader getInput() throws IOException
                    {
                        return new InputStreamReader(inputStream);
@@ -122,7 +122,7 @@ abstract class AbstractFastqReader
         /** List of FASTQ formatted sequences. */
         private final List<Fastq> result = Lists.newLinkedList();
 
-        /** {@inheritDoc} */
+        @Override
         public void fastq(final Fastq fastq)
         {
             result.add(fastq);

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/AbstractFastqWriter.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/AbstractFastqWriter.java
@@ -47,13 +47,13 @@ abstract class AbstractFastqWriter
      */
     protected abstract void validate(final Fastq fastq) throws IOException;
 
-    /** {@inheritDoc} */
+    @Override
     public final <T extends Appendable> T append(final T appendable, final Fastq... fastq) throws IOException
     {
         return append(appendable, Arrays.asList(fastq));
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final <T extends Appendable> T append(final T appendable, final Iterable<Fastq> fastq) throws IOException
     {
         if (appendable == null)
@@ -82,13 +82,13 @@ abstract class AbstractFastqWriter
         return appendable;
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final void write(final File file, final Fastq... fastq) throws IOException
     {
         write(file, Arrays.asList(fastq));
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final void write(final File file, final Iterable<Fastq> fastq) throws IOException
     {
         if (file == null)
@@ -121,13 +121,13 @@ abstract class AbstractFastqWriter
         }
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final void write(final OutputStream outputStream, final Fastq... fastq) throws IOException
     {
         write(outputStream, Arrays.asList(fastq));
     }
 
-    /** {@inheritDoc} */
+    @Override
     public final void write(final OutputStream outputStream, final Iterable<Fastq> fastq) throws IOException
     {
         if (outputStream == null)

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/FastqParser.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/FastqParser.java
@@ -115,13 +115,13 @@ final class FastqParser
             this.state = state;
         }
 
-        /** {@inheritDoc} */
+        @Override
         public Object getResult()
         {
             return null;
         }
 
-        /** {@inheritDoc} */
+        @Override
         public boolean processLine(final String line) throws IOException
         {
             String sequence = null;

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/IlluminaFastqReader.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/IlluminaFastqReader.java
@@ -29,7 +29,7 @@ public final class IlluminaFastqReader
     extends AbstractFastqReader
 {
 
-    /** {@inheritDoc} */
+    @Override
     protected FastqVariant getVariant()
     {
         return FastqVariant.FASTQ_ILLUMINA;

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/IlluminaFastqWriter.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/IlluminaFastqWriter.java
@@ -31,7 +31,7 @@ public final class IlluminaFastqWriter
     extends AbstractFastqWriter
 {
 
-    /** {@inheritDoc} */
+    @Override
     protected void validate(final Fastq fastq) throws IOException
     {
         if (fastq == null)

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/SangerFastqReader.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/SangerFastqReader.java
@@ -29,7 +29,7 @@ public final class SangerFastqReader
     extends AbstractFastqReader
 {
 
-    /** {@inheritDoc} */
+    @Override
     protected FastqVariant getVariant()
     {
         return FastqVariant.FASTQ_SANGER;

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/SangerFastqWriter.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/SangerFastqWriter.java
@@ -31,7 +31,7 @@ public final class SangerFastqWriter
     extends AbstractFastqWriter
 {
 
-    /** {@inheritDoc} */
+    @Override
     protected void validate(final Fastq fastq) throws IOException
     {
         if (fastq == null)

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/SolexaFastqReader.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/SolexaFastqReader.java
@@ -29,7 +29,7 @@ public final class SolexaFastqReader
     extends AbstractFastqReader
 {
 
-    /** {@inheritDoc} */
+    @Override
     protected FastqVariant getVariant()
     {
         return FastqVariant.FASTQ_SOLEXA;

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/SolexaFastqWriter.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/SolexaFastqWriter.java
@@ -31,7 +31,7 @@ public final class SolexaFastqWriter
     extends AbstractFastqWriter
 {
 
-    /** {@inheritDoc} */
+    @Override
     protected void validate(final Fastq fastq) throws IOException
     {
         if (fastq == null)

--- a/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/StreamingFastqParser.java
+++ b/biojava3-sequencing/src/main/java/org/biojava3/sequencing/io/fastq/StreamingFastqParser.java
@@ -62,25 +62,25 @@ final class StreamingFastqParser
         final FastqBuilder builder = new FastqBuilder().withVariant(variant);
         FastqParser.parse(supplier, new ParseListener()
             {
-                /** {@inheritDoc} */
+                @Override
                 public void description(final String description) throws IOException
                 {
                     builder.withDescription(description);
                 }
 
-                /** {@inheritDoc} */
+                @Override
                 public void sequence(final String sequence) throws IOException
                 {
                     builder.withSequence(sequence);
                 }
 
-                /** {@inheritDoc} */
+                @Override
                 public void appendSequence(final String sequence) throws IOException
                 {
                     builder.appendSequence(sequence);
                 }
 
-                /** {@inheritDoc} */
+                @Override
                 public void repeatDescription(final String repeatDescription) throws IOException
                 {
                     String description = builder.getDescription();
@@ -114,21 +114,21 @@ final class StreamingFastqParser
                     }
                 }
 
-                /** {@inheritDoc} */
+                @Override
                 public void quality(final String quality) throws IOException
                 {
                     validateQuality(quality);
                     builder.withQuality(quality);
                 }
 
-                /** {@inheritDoc} */
+                @Override
                 public void appendQuality(final String quality) throws IOException
                 {
                     validateQuality(quality);
                     builder.appendQuality(quality);
                 }
 
-                /** {@inheritDoc} */
+                @Override
                 public void complete() throws IOException
                 {
                     try
@@ -137,8 +137,7 @@ final class StreamingFastqParser
                     }
                     catch (IllegalStateException e)
                     {
-                        throw new IOException("caught an IllegalStateException " + e.getMessage());
-                        //throw new IOException("caught an IllegalStateException", e);  jdk 1.6+
+                        throw new IOException("caught an IllegalStateException", e);
                     }
                 }
             });

--- a/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/AbstractFastqReaderTest.java
+++ b/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/AbstractFastqReaderTest.java
@@ -338,43 +338,43 @@ public abstract class AbstractFastqReaderTest
         final String input = "";
         reader.parse(new InputSupplier<StringReader>()
                      {
-                         /** {@inheritDoc} */
+                         @Override
                          public StringReader getInput() throws IOException {
                              return new StringReader(input);
                          }
                      },
                      new ParseListener() {
-                         /** {@inheritDoc} */
+                         @Override
                          public void description(final String description) throws IOException {
                              // empty
                          }
  
-                         /** {@inheritDoc} */
+                         @Override
                          public void sequence(final String sequence) throws IOException {
                              // empty
                          }
  
-                         /** {@inheritDoc} */
+                         @Override
                          public void appendSequence(final String sequence) throws IOException {
                              // empty
                          }
  
-                         /** {@inheritDoc} */
+                         @Override
                          public void repeatDescription(final String repeatDescription) throws IOException {
                              // empty
                          }
  
-                         /** {@inheritDoc} */
+                         @Override
                          public void quality(final String quality) throws IOException {
                              // empty
                          }
  
-                         /** {@inheritDoc} */
+                         @Override
                          public void appendQuality(final String quality) throws IOException {
                              // empty
                          }
 
-                         /** {@inheritDoc} */
+                         @Override
                          public void complete() throws IOException {
                              // empty
                          }
@@ -388,37 +388,37 @@ public abstract class AbstractFastqReaderTest
         {
             reader.parse((InputSupplier<StringReader>) null,
                          new ParseListener() {
-                             /** {@inheritDoc} */
+                             @Override
                              public void description(final String description) throws IOException {
                                  // empty
                              }
  
-                             /** {@inheritDoc} */
+                             @Override
                              public void sequence(final String sequence) throws IOException {
                                  // empty
                              }
  
-                             /** {@inheritDoc} */
+                             @Override
                              public void appendSequence(final String sequence) throws IOException {
                                  // empty
                              }
  
-                             /** {@inheritDoc} */
+                             @Override
                              public void repeatDescription(final String repeatDescription) throws IOException {
                                  // empty
                              }
  
-                             /** {@inheritDoc} */
+                             @Override
                              public void quality(final String quality) throws IOException {
                                  // empty
                              }
  
-                             /** {@inheritDoc} */
+                             @Override
                              public void appendQuality(final String quality) throws IOException {
                                  // empty
                              }
 
-                             /** {@inheritDoc} */
+                             @Override
                              public void complete() throws IOException {
                                  // empty
                              }
@@ -439,7 +439,7 @@ public abstract class AbstractFastqReaderTest
         {
             reader.parse(new InputSupplier<StringReader>()
                          {
-                             /** {@inheritDoc} */
+                             @Override
                              public StringReader getInput() throws IOException {
                                  return new StringReader(input);
                              }

--- a/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/IlluminaFastqReaderTest.java
+++ b/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/IlluminaFastqReaderTest.java
@@ -32,7 +32,7 @@ public final class IlluminaFastqReaderTest
     extends AbstractFastqReaderTest
 {
 
-    /** {@inheritDoc} */
+    @Override
     public Fastq createFastq()
     {
         return new FastqBuilder()
@@ -43,13 +43,13 @@ public final class IlluminaFastqReaderTest
             .build();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public FastqReader createFastqReader()
     {
         return new IlluminaFastqReader();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public FastqWriter createFastqWriter()
     {
         return new IlluminaFastqWriter();

--- a/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/IlluminaFastqWriterTest.java
+++ b/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/IlluminaFastqWriterTest.java
@@ -29,13 +29,13 @@ public final class IlluminaFastqWriterTest
     extends AbstractFastqWriterTest
 {
 
-    /** {@inheritDoc} */
+    @Override
     public FastqWriter createFastqWriter()
     {
         return new IlluminaFastqWriter();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public Fastq createFastq()
     {
         return new FastqBuilder()

--- a/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/SangerFastqReaderTest.java
+++ b/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/SangerFastqReaderTest.java
@@ -32,7 +32,7 @@ public final class SangerFastqReaderTest
     extends AbstractFastqReaderTest
 {
 
-    /** {@inheritDoc} */
+    @Override
     public Fastq createFastq()
     {
         return new FastqBuilder()
@@ -43,13 +43,13 @@ public final class SangerFastqReaderTest
             .build();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public FastqReader createFastqReader()
     {
         return new SangerFastqReader();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public FastqWriter createFastqWriter()
     {
         return new SangerFastqWriter();

--- a/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/SangerFastqWriterTest.java
+++ b/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/SangerFastqWriterTest.java
@@ -29,13 +29,13 @@ public final class SangerFastqWriterTest
     extends AbstractFastqWriterTest
 {
 
-    /** {@inheritDoc} */
+    @Override
     public FastqWriter createFastqWriter()
     {
         return new SangerFastqWriter();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public Fastq createFastq()
     {
         return new FastqBuilder()

--- a/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/SolexaFastqReaderTest.java
+++ b/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/SolexaFastqReaderTest.java
@@ -32,7 +32,7 @@ public final class SolexaFastqReaderTest
     extends AbstractFastqReaderTest
 {
 
-    /** {@inheritDoc} */
+    @Override
     public Fastq createFastq()
     {
         return new FastqBuilder()
@@ -43,13 +43,13 @@ public final class SolexaFastqReaderTest
             .build();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public FastqReader createFastqReader()
     {
         return new SolexaFastqReader();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public FastqWriter createFastqWriter()
     {
         return new SolexaFastqWriter();

--- a/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/SolexaFastqWriterTest.java
+++ b/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/SolexaFastqWriterTest.java
@@ -29,13 +29,13 @@ public final class SolexaFastqWriterTest
     extends AbstractFastqWriterTest
 {
 
-    /** {@inheritDoc} */
+    @Override
     public FastqWriter createFastqWriter()
     {
         return new SolexaFastqWriter();
     }
 
-    /** {@inheritDoc} */
+    @Override
     public Fastq createFastq()
     {
         return new FastqBuilder()

--- a/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/StreamingFastqParserTest.java
+++ b/biojava3-sequencing/src/test/java/org/biojava3/sequencing/io/fastq/StreamingFastqParserTest.java
@@ -38,7 +38,7 @@ public class StreamingFastqParserTest extends TestCase
         try
         {
             StreamingFastqParser.stream((InputSupplier<StringReader>) null, FastqVariant.FASTQ_SANGER, new StreamListener() {
-                /** {@inheritDoc} */
+                @Override
                 public void fastq(final Fastq fastq) {
                     // empty
                 }
@@ -57,13 +57,13 @@ public class StreamingFastqParserTest extends TestCase
         {
             final String input = "";
             InputSupplier<StringReader> supplier = new InputSupplier<StringReader>() {
-                /** {@inheritDoc} */
+                @Override
                 public StringReader getInput() throws IOException {
                     return new StringReader(input);
                 }
             };
             StreamingFastqParser.stream(supplier, null, new StreamListener() {
-                /** {@inheritDoc} */
+                @Override
                 public void fastq(final Fastq fastq) {
                     // empty
                 }
@@ -82,7 +82,7 @@ public class StreamingFastqParserTest extends TestCase
         {
             final String input = "";
             StreamingFastqParser.stream(new InputSupplier<StringReader>() {
-                /** {@inheritDoc} */
+                @Override
                 public StringReader getInput() throws IOException {
                     return new StringReader(input);
                 }


### PR DESCRIPTION
Minor source cleanup, use jdk 1.6 @Overrides instead of /*\* {@inheritDoc} */ doc tags
