### PR TITLE
Get rid of a few debugging println calls

### DIFF
--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/cath/CathInstallation.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/cath/CathInstallation.java
@@ -633,7 +633,7 @@ public class CathInstallation implements CathDatabase{
     }
 
     protected void downloadFileFromRemote(URL remoteURL, File localFile) throws FileNotFoundException, IOException{
-        System.out.println("downloading " + remoteURL + " to: " + localFile);
+//        System.out.println("downloading " + remoteURL + " to: " + localFile);
         
         long timeS = System.currentTimeMillis();
     	File tempFile  = File.createTempFile(FileDownloadUtils.getFilePrefix(localFile), "."+ FileDownloadUtils.getFileExtension(localFile));

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/io/mmcif/DownloadChemCompProvider.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/io/mmcif/DownloadChemCompProvider.java
@@ -215,7 +215,7 @@ public class DownloadChemCompProvider implements ChemCompProvider {
 
 			String filename = getLocalFileName(recordName);
 
-			System.out.println("reading " + filename);
+//			System.out.println("reading " + filename);
 			InputStreamProvider isp = new InputStreamProvider();
 
 			InputStream inStream = isp.getInputStream(filename);
@@ -314,7 +314,7 @@ public class DownloadChemCompProvider implements ChemCompProvider {
 
 		String u = serverLocation + recordName + ".cif";
 
-		System.out.println("downloading " + u);
+//		System.out.println("downloading " + u);
 
 		try {
 

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/io/util/FileDownloadUtils.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/io/util/FileDownloadUtils.java
@@ -99,7 +99,7 @@ public class FileDownloadUtils {
 		File tempFile  = File.createTempFile(getFilePrefix(destination), "."+ getFileExtension(destination));
 
 		try {
-			System.out.println("downloading " + url + " to " + tempFile.getAbsolutePath());
+//			System.out.println("downloading " + url + " to " + tempFile.getAbsolutePath());
 			FileOutputStream outPut = new FileOutputStream(tempFile);
 			GZIPOutputStream gzOutPut = new GZIPOutputStream(outPut);
 			PrintWriter pw = new PrintWriter(gzOutPut);
@@ -127,7 +127,7 @@ public class FileDownloadUtils {
 		}
 		// copy file name to **real** location (without the tmpFileName)
 		// prepare destination
-		System.out.println("copying to " + destination);
+//		System.out.println("copying to " + destination);
 
 		copy(tempFile, destination);
 


### PR DESCRIPTION
I imagine very few people really want us taking up their console with information about what Biojava is downloading. If anything, these should be optional and by default not printed out.
