### PR TITLE
Made REMARK 350 record parsing accept variable spacing between items,

### DIFF
--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/io/mmcif/chem/ResidueType.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/io/mmcif/chem/ResidueType.java
@@ -39,6 +39,7 @@ public enum ResidueType implements Serializable {
    dPeptideLinking(PolymerType.dpeptide, "D-peptide linking"),
    lPeptideLinking(PolymerType.peptide, "L-peptide linking"),
    glycine(PolymerType.peptide,"PEPTIDE LINKING"),
+   peptideLike(PolymerType.otherPolymer, "peptide-like"),
    dPeptideAminoTerminus(PolymerType.dpeptide, "D-peptide NH3 amino terminus"),
    lPeptideAminoTerminus(PolymerType.peptide, "L-peptide NH3 amino terminus"),
    dPeptideCarboxyTerminus(PolymerType.dpeptide, "D-peptide COOH carboxy terminus"),


### PR DESCRIPTION
since there are several cases of inconsistency in the PDB files
(examples: 1GR5, 1M4X).
