### PR TITLE
Initialize list of bonds lazily. The bond list in an Atom is now

### DIFF
--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/Atom.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/Atom.java
@@ -222,6 +222,12 @@ public interface Atom extends Cloneable, PDBRecord {
      */
     public Group getGroup();
     
+    /** Adds a bond
+     * @param bond to be added
+     * @see #getBonds()
+     */
+    public void addBond(Bond bond);
+    
     /**
      * Gets all {@link Bond}s this atom is part of.
      * 

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/AtomImpl.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/AtomImpl.java
@@ -25,6 +25,7 @@ package org.biojava.bio.structure;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.biojava.bio.structure.io.FileConvert;
@@ -68,8 +69,9 @@ public class AtomImpl implements Atom,Serializable, PDBRecord {
         occupancy  = 0.0       ;
         tempfactor = 0.0       ;
         altLoc = new Character(' ');
+        altLoc = null;
         parent = null;
-        bonds = new ArrayList<Bond>(0);
+        bonds = Collections.emptyList();
     }
     /** Get the Hibernate database ID.
      *
@@ -256,5 +258,14 @@ public class AtomImpl implements Atom,Serializable, PDBRecord {
 	@Override
 	public List<Bond> getBonds() {
 		return bonds;
+	}
+	
+	@Override
+	public void addBond(Bond bond) {
+		if (bonds.size() == 0) {
+			// most atoms have a maximum of 3 heavy atom neighbors, so use this as the default size
+			bonds = new ArrayList<Bond>(3);
+		}
+		bonds.add(bond);
 	}
 }

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/Bond.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/Bond.java
@@ -75,8 +75,8 @@ public class Bond {
 	 */
 	// TODO first check if those bonds haven't been made already
 	public void addSelfToAtoms() {
-		atomA.getBonds().add(this);
-		atomB.getBonds().add(this);
+		atomA.addBond(this);
+		atomB.addBond(this);
 	}
 
 	/**

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/io/PDBFileParser.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/io/PDBFileParser.java
@@ -2952,7 +2952,9 @@ COLUMNS   DATA TYPE         FIELD          DEFINITION
 		for (Chain chain : structure.getChains()) {
 			for (Group group : chain.getAtomGroups()) {
 				for (Atom atom : group.getAtoms()) {
-					((ArrayList<Bond>) atom.getBonds()).trimToSize();
+					if (atom.getBonds().size() > 0) {
+						((ArrayList<Bond>) atom.getBonds()).trimToSize();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
initialized with Collections.emptyList(), rather than an ArrayList. This
doubles the speed of allocating Atoms, since the bond list is not
created.
