### PR TITLE
Correction to Warning Suppression

### DIFF
--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/align/ce/OptimalCECPParameters.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/align/ce/OptimalCECPParameters.java
@@ -92,7 +92,7 @@ public class OptimalCECPParameters extends CeParameters {
 		return params;
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings("rawtypes")
 	public List<Class> getUserConfigTypes() {
 		List<Class> params = super.getUserConfigTypes();
 		params.add(Boolean.class);


### PR DESCRIPTION
According to Java 7, the wrong warning was being suppressed and the code failed to compile.
