### PR TITLE
Fix newline handling when splitting multiple line GenBank feature qualifiers

### DIFF
--- a/biojava3-core/src/main/java/org/biojava3/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava3-core/src/main/java/org/biojava3/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -41,12 +41,12 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 			return line;
 		}
 		if(quote) {  // quote should be true for numerics
-			line = QUALIFIER_INDENT_STR + "/" + key + "=\"" + value + "\"" + lineSep;
+			line = QUALIFIER_INDENT_STR + "/" + key + "=\"" + value + "\"";
 		} else {
-			line = QUALIFIER_INDENT_STR + "/" + key + "=" + value + lineSep;			
+			line = QUALIFIER_INDENT_STR + "/" + key + "=" + value;			
 		}
 		if(line.length() <= MAX_WIDTH) {
-			return line;
+			return line + lineSep;
 		}
 		String goodlines = "";
 		while(!"".equals(line.replaceAll("^\\s+", ""))) {


### PR DESCRIPTION
Currently an extraneous newline is added which creates a blank line in the GenBank (and thus breaks parsing).  This fix removes that extra line.
