### PR TITLE
Added stopAtStopCodons

### DIFF
--- a/biojava3-core/src/main/java/org/biojava3/core/sequence/transcription/RNAToAminoAcidTranslator.java
+++ b/biojava3-core/src/main/java/org/biojava3/core/sequence/transcription/RNAToAminoAcidTranslator.java
@@ -60,16 +60,10 @@ public class RNAToAminoAcidTranslator extends
 	private final AminoAcidCompound unknownAminoAcidCompound;
 	private final AminoAcidCompound methionineAminoAcidCompound;
 	private final boolean translateNCodons;
-
 	// If true, then translation will stop at the first stop codon encountered
 	// in the reading frame (the stop codon will be included as the last residue
 	// in the resulting ProteinSequence, unless removed by #trimStops)
 	private final boolean stopAtStopCodons;
-
-	// If true, then translation will not start until the first start codon
-	// encountered in the reading frame. The start codon will be included as the
-	// first residue in the resulting ProteinSequence
-	private final boolean waitForStartCodon;
 
 	/**
 	 * @deprecated Retained for backwards compatability, setting
@@ -109,10 +103,8 @@ public class RNAToAminoAcidTranslator extends
 		methionineAminoAcidCompound = aminoAcids.getCompoundForString("M");
 		// Set to false for backwards compatability
 		stopAtStopCodons = false;
-		waitForStartCodon = false;
 	}
 
-	@Deprecated
 	public RNAToAminoAcidTranslator(
 			SequenceCreatorInterface<AminoAcidCompound> creator,
 			CompoundSet<NucleotideCompound> nucleotides,
@@ -146,44 +138,6 @@ public class RNAToAminoAcidTranslator extends
 		unknownAminoAcidCompound = aminoAcids.getCompoundForString("X");
 		methionineAminoAcidCompound = aminoAcids.getCompoundForString("M");
 		this.stopAtStopCodons = stopAtStopCodons;
-		// Set for backwards compatibility
-		waitForStartCodon = false;
-	}
-
-	public RNAToAminoAcidTranslator(
-			SequenceCreatorInterface<AminoAcidCompound> creator,
-			CompoundSet<NucleotideCompound> nucleotides,
-			CompoundSet<Codon> codons,
-			CompoundSet<AminoAcidCompound> aminoAcids, Table table,
-			boolean trimStops, boolean initMetOnly, boolean translateNCodons,
-			boolean stopAtStopCodons, boolean waitForStartCodon) {
-
-		super(creator, nucleotides, aminoAcids);
-		this.trimStops = trimStops;
-		this.initMetOnly = initMetOnly;
-		this.translateNCodons = translateNCodons;
-
-		quickLookup = new HashMap<Table.CaseInsensitiveTriplet, Codon>(codons
-				.getAllCompounds().size());
-		aminoAcidToCodon = new HashMap<AminoAcidCompound, List<Codon>>();
-
-		List<Codon> codonList = table.getCodons(nucleotides, aminoAcids);
-		for (Codon codon : codonList) {
-			quickLookup.put(codon.getTriplet(), codon);
-			codonArray[codon.getTriplet().intValue()] = codon;
-
-			List<Codon> codonL = aminoAcidToCodon.get(codon.getAminoAcid());
-			if (codonL == null) {
-				codonL = new ArrayList<Codon>();
-				aminoAcidToCodon.put(codon.getAminoAcid(), codonL);
-			}
-			codonL.add(codon);
-
-		}
-		unknownAminoAcidCompound = aminoAcids.getCompoundForString("X");
-		methionineAminoAcidCompound = aminoAcids.getCompoundForString("M");
-		this.stopAtStopCodons = stopAtStopCodons;
-		this.waitForStartCodon = waitForStartCodon;
 	}
 
 	/**
@@ -203,9 +157,6 @@ public class RNAToAminoAcidTranslator extends
 
 		boolean first = true;
 
-		// If not waiting for a start codon, start translating immediately
-		boolean doTranslate = !waitForStartCodon;
-
 		for (SequenceView<NucleotideCompound> element : iter) {
 			AminoAcidCompound aminoAcid = null;
 
@@ -217,28 +168,19 @@ public class RNAToAminoAcidTranslator extends
 			Codon target = null;
 
 			target = quickLookup.get(triplet);
-
-			// Check for a start
-			if (doTranslate == false && target.isStart()) {
-				doTranslate = true;
-			}
-			
-			if (doTranslate) {
-				if (target != null)
-					aminoAcid = target.getAminoAcid();
-				if (aminoAcid == null && translateNCodons()) {
-					aminoAcid = unknownAminoAcidCompound;
-				} else {
-					if (first && initMetOnly && target.isStart()) {
-						aminoAcid = methionineAminoAcidCompound;
-					}
+			if (target != null)
+				aminoAcid = target.getAminoAcid();
+			if (aminoAcid == null && translateNCodons()) {
+				aminoAcid = unknownAminoAcidCompound;
+			} else {
+				if (first && initMetOnly && target.isStart()) {
+					aminoAcid = methionineAminoAcidCompound;
 				}
-
-				addCompoundsToList(Arrays.asList(aminoAcid), workingList);
 			}
 
-			if (doTranslate && stopAtStopCodons && target.isStop()) {
-				// Check if we need to stop, but dont stop until started!
+			addCompoundsToList(Arrays.asList(aminoAcid), workingList);
+
+			if (stopAtStopCodons && target.isStop()) {
 				break;
 			}
 

--- a/biojava3-core/src/main/java/org/biojava3/core/sequence/transcription/TranscriptionEngine.java
+++ b/biojava3-core/src/main/java/org/biojava3/core/sequence/transcription/TranscriptionEngine.java
@@ -190,9 +190,8 @@ public class TranscriptionEngine {
 		private boolean trimStop = true;
 		private boolean translateNCodons = true;
 		private boolean decorateRna = false;
-		// Set at false for backwards compatibility
+		//Set at false for backwards compatibility
 		private boolean stopAtStopCodons = false;
-		private boolean waitForStartCodon = false;
 
 		/**
 		 * The method to finish any calls to the builder with which returns a
@@ -285,21 +284,9 @@ public class TranscriptionEngine {
 			return this;
 		}
 
-		/**
-		 * If set, then the last codon translated in the resulting peptide
-		 * sequence will be the stop codon
-		 */
+		/**	If set, then the last codon translated in the resulting peptide sequence will be the stop codon */
 		public Builder stopAtStopCodons(boolean stopAtStopCodons) {
 			this.stopAtStopCodons = stopAtStopCodons;
-			return this;
-		}
-
-		/**
-		 * If set, then translation will not start until a start codon is
-		 * encountered
-		 */
-		public Builder waitForStartCodon(boolean waitForStartCodon) {
-			this.waitForStartCodon = waitForStartCodon;
 			return this;
 		}
 
@@ -350,8 +337,7 @@ public class TranscriptionEngine {
 			return new RNAToAminoAcidTranslator(getProteinCreator(),
 					getRnaCompounds(), getCodons(), getAminoAcidCompounds(),
 					getTable(), isTrimStop(), isInitMet(),
-					isTranslateNCodons(), isStopAtStopCodons(),
-					isWaitForStartCodon());
+					isTranslateNCodons(), isStopAtStopCodons());
 		}
 
 		private CompoundSet<Codon> getCodons() {
@@ -399,10 +385,6 @@ public class TranscriptionEngine {
 
 		private boolean isStopAtStopCodons() {
 			return stopAtStopCodons;
-		}
-
-		private boolean isWaitForStartCodon() {
-			return waitForStartCodon;
 		}
 	}
 }

--- a/biojava3-core/src/test/java/org/biojava3/core/sequence/TranslationTest.java
+++ b/biojava3-core/src/test/java/org/biojava3/core/sequence/TranslationTest.java
@@ -184,20 +184,6 @@ public class TranslationTest {
 		String testpep = volvoxPep.getSequenceAsString().split("\\*")[0];
 		assertThat("Translation stops at Stop", pep, is(testpep));
 	}
-	
-	@Test
-	public void waitForStartCodon(){
-		//Should not start translation until a start codon is encountered
-		TranscriptionEngine e = new TranscriptionEngine.Builder().waitForStartCodon(true).build();
-		RNASequence rna = new RNASequence("UCCAUGAGC");
-		String pep = rna.getProteinSequence(e).getSequenceAsString();
-		assertThat("Translation starts at Start Codon",pep, is("MS"));
-		
-		//And should start at start of sequence (NB this is implied by success of all other tests)
-		e = new TranscriptionEngine.Builder().waitForStartCodon(false).build();
-		pep = rna.getProteinSequence(e).getSequenceAsString();
-		assertThat("Translation starts at start of sequence", pep, is("SMS"));
-	}
 
 	@Test
 	public void translateInitMet() {


### PR DESCRIPTION
Implements enhancement suggested in issue #137
Added stopAtStopCodons option to RNAToAminoAcidTranslator, retaining existing behaviour.
Updated TranscriptionEngine#Builder with appropriate methods to use setting
Added a test case to TranslationTest to test that if this flag is set, translation stops. (The negative test is tested for by an existing test, which also therefore tests for the default to retain existing behaviour)
