### PR TITLE
Wait for start

### DIFF
--- a/biojava3-core/src/main/java/org/biojava3/core/sequence/transcription/TranscriptionEngine.java
+++ b/biojava3-core/src/main/java/org/biojava3/core/sequence/transcription/TranscriptionEngine.java
@@ -190,8 +190,9 @@ public class TranscriptionEngine {
 		private boolean trimStop = true;
 		private boolean translateNCodons = true;
 		private boolean decorateRna = false;
-		//Set at false for backwards compatibility
+		// Set at false for backwards compatibility
 		private boolean stopAtStopCodons = false;
+		private boolean waitForStartCodon = false;
 
 		/**
 		 * The method to finish any calls to the builder with which returns a
@@ -284,9 +285,21 @@ public class TranscriptionEngine {
 			return this;
 		}
 
-		/**	If set, then the last codon translated in the resulting peptide sequence will be the stop codon */
+		/**
+		 * If set, then the last codon translated in the resulting peptide
+		 * sequence will be the stop codon
+		 */
 		public Builder stopAtStopCodons(boolean stopAtStopCodons) {
 			this.stopAtStopCodons = stopAtStopCodons;
+			return this;
+		}
+
+		/**
+		 * If set, then translation will not start until a start codon is
+		 * encountered
+		 */
+		public Builder waitForStartCodon(boolean waitForStartCodon) {
+			this.waitForStartCodon = waitForStartCodon;
 			return this;
 		}
 
@@ -337,7 +350,8 @@ public class TranscriptionEngine {
 			return new RNAToAminoAcidTranslator(getProteinCreator(),
 					getRnaCompounds(), getCodons(), getAminoAcidCompounds(),
 					getTable(), isTrimStop(), isInitMet(),
-					isTranslateNCodons(), isStopAtStopCodons());
+					isTranslateNCodons(), isStopAtStopCodons(),
+					isWaitForStartCodon());
 		}
 
 		private CompoundSet<Codon> getCodons() {
@@ -385,6 +399,10 @@ public class TranscriptionEngine {
 
 		private boolean isStopAtStopCodons() {
 			return stopAtStopCodons;
+		}
+
+		private boolean isWaitForStartCodon() {
+			return waitForStartCodon;
 		}
 	}
 }

--- a/biojava3-core/src/test/java/org/biojava3/core/sequence/TranslationTest.java
+++ b/biojava3-core/src/test/java/org/biojava3/core/sequence/TranslationTest.java
@@ -184,6 +184,20 @@ public class TranslationTest {
 		String testpep = volvoxPep.getSequenceAsString().split("\\*")[0];
 		assertThat("Translation stops at Stop", pep, is(testpep));
 	}
+	
+	@Test
+	public void waitForStartCodon(){
+		//Should not start translation until a start codon is encountered
+		TranscriptionEngine e = new TranscriptionEngine.Builder().waitForStartCodon(true).build();
+		RNASequence rna = new RNASequence("UCCAUGAGC");
+		String pep = rna.getProteinSequence(e).getSequenceAsString();
+		assertThat("Translation starts at Start Codon",pep, is("MS"));
+		
+		//And should start at start of sequence (NB this is implied by success of all other tests)
+		e = new TranscriptionEngine.Builder().waitForStartCodon(false).build();
+		pep = rna.getProteinSequence(e).getSequenceAsString();
+		assertThat("Translation starts at start of sequence", pep, is("SMS"));
+	}
 
 	@Test
 	public void translateInitMet() {


### PR DESCRIPTION
Added an additional 'waitForStartCodon' option to the RNAToAminoAcidTranslator class.  This is similar to the previously added stopAtStopCodons option, allowing the user to optionally specify that translation will not start until a valid start codon in the current codon table and reading frame is encountered.  The start codon will be translated as the first residue in the resulting ProteinSequence object.

The TranscriptionEngine#Builder class has been updated to allow setting the new option.

A test case has been added to TranslationTest.

Default is set to 'false', in order to maintain backwards compatability with existing code.

If accepted, would suggest removing the intermediate constructor from the RNAToAminoAcidTranslator class in the released version, as would not be needed.
