### PR TITLE
fixed misspell in property name

### DIFF
--- a/biojava3-core/src/test/java/org/biojava3/core/sequence/io/GenbankCookbookTest.java
+++ b/biojava3-core/src/test/java/org/biojava3/core/sequence/io/GenbankCookbookTest.java
@@ -58,13 +58,13 @@ public class GenbankCookbookTest {
          */
         //Try with the GenbankProxySequenceReader
         GenbankProxySequenceReader<AminoAcidCompound> genbankProteinReader
-                = new GenbankProxySequenceReader<AminoAcidCompound>(System.getProperty("java.io.tempdir"), "NP_000257", AminoAcidCompoundSet.getAminoAcidCompoundSet());
+                = new GenbankProxySequenceReader<AminoAcidCompound>(System.getProperty("java.io.tmpdir"), "NP_000257", AminoAcidCompoundSet.getAminoAcidCompoundSet());
         ProteinSequence proteinSequence = new ProteinSequence(genbankProteinReader);
         genbankProteinReader.getHeaderParser().parseHeader(genbankProteinReader.getHeader(), proteinSequence);
         System.out.println("Sequence" + "(" + proteinSequence.getAccession() + "," + proteinSequence.getLength() + ")=" + proteinSequence.getSequenceAsString().substring(0, 10) + "...");
 
 	GenbankProxySequenceReader<NucleotideCompound> genbankDNAReader 
-	= new GenbankProxySequenceReader<NucleotideCompound>(System.getProperty("java.io.tempdir"), "NM_001126", DNACompoundSet.getDNACompoundSet());
+	= new GenbankProxySequenceReader<NucleotideCompound>(System.getProperty("java.io.tmpdir"), "NM_001126", DNACompoundSet.getDNACompoundSet());
 	DNASequence dnaSequence = new DNASequence(genbankDNAReader);
 	genbankDNAReader.getHeaderParser().parseHeader(genbankDNAReader.getHeader(), dnaSequence);
 	System.out.println("Sequence" + "(" + dnaSequence.getAccession() + "," + dnaSequence.getLength() + ")=" + dnaSequence.getSequenceAsString().substring(0, 10) + "...");

--- a/biojava3-core/src/test/java/org/biojava3/core/sequence/loader/GenbankProxySequenceReaderTest.java
+++ b/biojava3-core/src/test/java/org/biojava3/core/sequence/loader/GenbankProxySequenceReaderTest.java
@@ -53,7 +53,7 @@ public class GenbankProxySequenceReaderTest {
     public void biojava3() throws Throwable {
         log.info("run test for protein: {}", gi);
         GenbankProxySequenceReader<AminoAcidCompound> genbankReader
-                = new GenbankProxySequenceReader<AminoAcidCompound>(System.getProperty("java.io.tempdir"), 
+                = new GenbankProxySequenceReader<AminoAcidCompound>(System.getProperty("java.io.tmpdir"), 
                                                                     this.gi, 
                                                                     AminoAcidCompoundSet.getAminoAcidCompoundSet());
 


### PR DESCRIPTION
I have just found a misspell in "java.io.tmpdir" name.
