### PR TITLE
Convert org.biojava3.genome to slf4j #155

### DIFF
--- a/biojava3-genome/src/main/java/org/biojava3/genome/App.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/App.java
@@ -1,13 +1,17 @@
 package org.biojava3.genome;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Hello world!
  *
  */
-public class App 
-{
-    public static void main( String[] args )
-    {
-        System.out.println( "Hello World!" );
-    }
+public class App {
+
+	private static final Logger logger = LoggerFactory.getLogger(App.class);
+
+	public static void main(String[] args) {
+		logger.info("Hello World!");
+	}
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/GeneFeatureHelper.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/GeneFeatureHelper.java
@@ -30,12 +30,16 @@ import org.biojava3.genome.parsers.gff.GFF3Reader;
 import org.biojava3.genome.parsers.gff.GeneIDGFF2Reader;
 import org.biojava3.genome.parsers.gff.GeneMarkGTFReader;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  *
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class GeneFeatureHelper {
 
+	private static final Logger logger = LoggerFactory.getLogger(App.class);
 
     static public LinkedHashMap<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromUpperCaseExonFastaFile(File fastaSequenceFile, File uppercaseFastaFile, boolean throwExceptionGeneNotFound) throws Exception {
         LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = new LinkedHashMap<String, ChromosomeSequence>();
@@ -83,7 +87,8 @@ public class GeneFeatureHelper {
             }
 
             if (geneFound) {
-                System.out.println("Gene " + dnaSequence.getAccession().toString() + " found at " + contigDNASequence.getAccession().toString() + " " + bioStart + " " + bioEnd + " " + strand);
+                logger.info("Gene {} found at {} {} {} {}",
+                		dnaSequence.getAccession().toString(), contigDNASequence.getAccession().toString(), bioStart, bioEnd, strand);
                 ChromosomeSequence chromosomeSequence = chromosomeSequenceList.get(accession);
 
                 ArrayList<Integer> exonBoundries = new ArrayList<Integer>();
@@ -142,7 +147,7 @@ public class GeneFeatureHelper {
                 if (throwExceptionGeneNotFound) {
                     throw new Exception(dnaSequence.getAccession().toString() + " not found");
                 }
-                System.out.println("Gene not found " + dnaSequence.getAccession().toString());
+                logger.info("Gene not found {}", dnaSequence.getAccession().toString());
             }
 
         }
@@ -837,19 +842,19 @@ public class GeneFeatureHelper {
                 for (TranscriptSequence transcriptSequence : geneSequence.getTranscripts().values()) {
                     //TODO remove?
 //                    DNASequence dnaCodingSequence = transcriptSequence.getDNACodingSequence();
-//                    System.out.println("CDS=" + dnaCodingSequence.getSequenceAsString());
+//                    logger.info("CDS={}", dnaCodingSequence.getSequenceAsString());
 
                     try {
                         ProteinSequence proteinSequence = transcriptSequence.getProteinSequence();
                        
-//                        System.out.println(proteinSequence.getAccession().getID() + " " + proteinSequence);
+//                        logger.info("{} {}", proteinSequence.getAccession().getID(), proteinSequence);
                         if (proteinSequenceHashMap.containsKey(proteinSequence.getAccession().getID())) {
                             throw new Exception("Duplicate protein sequence id=" + proteinSequence.getAccession().getID() + " found at Gene id=" + geneSequence.getAccession().getID());
                         } else {
                             proteinSequenceHashMap.put(proteinSequence.getAccession().getID(), proteinSequence);
                         }
                     } catch (Exception e) {
-                        e.printStackTrace();
+                        logger.error("Exception: ", e);
                     }
 
                 }
@@ -880,7 +885,7 @@ public class GeneFeatureHelper {
             LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.loadFastaAddGeneFeaturesFromGlimmerGFF3(new File("Scaffolds.fna"), new File("glimmerhmm.gff"));
             LinkedHashMap<String, ProteinSequence> proteinSequenceList = GeneFeatureHelper.getProteinSequences(chromosomeSequenceList.values());
             //  for (ProteinSequence proteinSequence : proteinSequenceList.values()) {
-            //      System.out.println(proteinSequence.getAccession().getID() + " " + proteinSequence);
+            //      logger.info(proteinSequence.getAccession().getID() + " " + proteinSequence);
             //  }
             FastaWriterHelper.writeProteinSequence(new File("predicted_glimmer.faa"), proteinSequenceList.values());
 
@@ -900,7 +905,7 @@ public class GeneFeatureHelper {
             }
 
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Exception: ", e);
         }
 
     }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/homology/GFF3FromUniprotBlastHits.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/homology/GFF3FromUniprotBlastHits.java
@@ -9,9 +9,6 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.Logger;
 
 import org.biojava3.alignment.Alignments;
 import org.biojava3.alignment.Alignments.PairwiseSequenceAlignerType;
@@ -32,6 +29,8 @@ import org.biojava3.core.sequence.features.DatabaseReferenceInterface;
 import org.biojava3.core.sequence.features.FeaturesKeyWordInterface;
 import org.biojava3.core.sequence.loader.UniprotProxySequenceReader;
 import org.biojava3.genome.GeneFeatureHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -40,7 +39,7 @@ import org.biojava3.genome.GeneFeatureHelper;
  */
 public class GFF3FromUniprotBlastHits {
 
-    private static final Logger logger = Logger.getLogger(GFF3FromUniprotBlastHits.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(GFF3FromUniprotBlastHits.class);
 
     public void process(File xmlBlastHits, double ecutoff, LinkedHashMap<String, GeneSequence> geneSequenceHashMap, OutputStream gff3Output) throws Exception {
         LinkedHashMap<String, ArrayList<String>> hits = BlastHomologyHits.getMatches(xmlBlastHits, ecutoff);
@@ -56,14 +55,14 @@ public class GFF3FromUniprotBlastHits {
             if (index == 12) {
                 index = 12;
             }
-            logger.severe(accessionid + " " + index + "/" + size);
+            logger.error(accessionid + " " + index + "/" + size);
             try {
 
                 String[] data = accessionid.split(" ");
                 String id = data[0];
                 GeneSequence geneSequence = geneSequenceHashMap.get(id);
                 if (geneSequence == null) {
-                    logger.severe("Not found " + id);
+                    logger.error("Not found " + id);
                     continue;
                 }
                 ArrayList<String> uniprotProteinHits = hits.get(accessionid);
@@ -85,11 +84,11 @@ public class GFF3FromUniprotBlastHits {
                     }
                     if (!testSequence.equals(predictedProteinSequence) && (!predictedProteinSequence.equals(testSequence.substring(0, testSequence.length() - 1)))) {
                         DNASequence codingSequence = transcriptSequence.getDNACodingSequence();
-                        System.out.println(codingSequence.getSequenceAsString());
-                        System.out.println("Sequence agreement error");
-                        System.out.println("CDS seq=" + testSequence);
-                        System.out.println("PRE seq=" + predictedProteinSequence);
-                        System.out.println("UNI seq=" + hitSequence);
+                        logger.info("Coding Sequence: {}", codingSequence.getSequenceAsString());
+                        logger.info("Sequence agreement error");
+                        logger.info("CDS seq={}", testSequence);
+                        logger.info("PRE seq={}", predictedProteinSequence);
+                        logger.info("UNI seq={}", hitSequence);
                         //  throw new Exception("Protein Sequence compare error " + id);
                     }
 
@@ -249,7 +248,7 @@ public class GFF3FromUniprotBlastHits {
                     }
                 }
             } catch (Exception e) {
-                logger.log(Level.INFO, accessionid, e);
+                logger.info("Accession Id: {}", accessionid, e);
             }
         }
 
@@ -263,7 +262,6 @@ public class GFF3FromUniprotBlastHits {
     public static void main(String[] args) {
         /*
             try {
-                LogManager.getLogManager().getLogger("").setLevel(Level.SEVERE);
                 LinkedHashMap<String, ChromosomeSequence> dnaSequenceList = GeneFeatureHelper.loadFastaAddGeneFeaturesFromGeneMarkGTF(new File("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/454Scaffolds.fna"), new File("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/genemark_hmm.gtf"));
                 LinkedHashMap<String, GeneSequence> geneSequenceList = GeneFeatureHelper.getGeneSequences(dnaSequenceList.values());
                 FileOutputStream fo = new FileOutputStream("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/genemark_uniprot_match.gff3");
@@ -274,31 +272,24 @@ public class GFF3FromUniprotBlastHits {
 
 
             } catch (Exception e) {
-                e.printStackTrace();
+                logger.error("Exception: ", e);
 
 
             }
         */
 
             try {
-                LogManager.getLogManager().getLogger("").setLevel(Level.SEVERE);
                 LinkedHashMap<String, ChromosomeSequence> dnaSequenceHashMap = GeneFeatureHelper.loadFastaAddGeneFeaturesFromGlimmerGFF3(new File("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/454Scaffolds-16.fna"), new File("/Users/Scooter/scripps/dyadic/GlimmerHMM/c1_glimmerhmm-16.gff"));
                 LinkedHashMap<String, GeneSequence> geneSequenceList = GeneFeatureHelper.getGeneSequences(dnaSequenceHashMap.values());
                 FileOutputStream fo = new FileOutputStream("/Users/Scooter/scripps/dyadic/outputGlimmer/genemark_uniprot_match-16.gff3");
                 LinkedHashMap<String, ArrayList<String>> blasthits = BlastHomologyHits.getMatches(new File("/Users/Scooter/scripps/dyadic/blastresults/c1_glimmer_in_uniprot.xml"), 1E-10);
-                logger.severe("Number of uniprot hits " + blasthits.size());
+                logger.error("Number of uniprot hits " + blasthits.size());
 
                 GFF3FromUniprotBlastHits gff3FromUniprotBlastHits = new GFF3FromUniprotBlastHits();
                 gff3FromUniprotBlastHits.process(blasthits, geneSequenceList, fo);
                 fo.close();
-
-
             } catch (Exception e) {
-                e.printStackTrace();
-
-
+            	logger.error("Exception: ", e);
             }
-
-
     }
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/cytoband/CytobandParser.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/cytoband/CytobandParser.java
@@ -27,68 +27,76 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-
 import java.net.URL;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.zip.GZIPInputStream;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/** Parses the cytoband (karyotype) file from UCSC.
+/**
+ * Parses the cytoband (karyotype) file from UCSC.
  *
  */
 public class CytobandParser {
 
+	private static final Logger logger = LoggerFactory
+			.getLogger(CytobandParser.class);
+
 	public static final String DEFAULT_LOCATION = "http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/cytoBand.txt.gz";
 
-	public static void main(String[] args){
+	public static void main(String[] args) {
 
 		CytobandParser me = new CytobandParser();
 		try {
-			SortedSet<Cytoband> cytobands = me.getAllCytobands(new URL(DEFAULT_LOCATION));
+			SortedSet<Cytoband> cytobands = me.getAllCytobands(new URL(
+					DEFAULT_LOCATION));
 			SortedSet<StainType> types = new TreeSet<StainType>();
-			for (Cytoband c : cytobands){
-				System.out.println(c);
-				if ( ! types.contains(c.getType()))
+			for (Cytoband c : cytobands) {
+				logger.info("Cytoband: {}", c);
+				if (!types.contains(c.getType()))
 					types.add(c.getType());
 			}
-			System.out.println(types);
+			logger.info("Strain Type: {}", types);
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
-			e.printStackTrace();
+			logger.error("Exception: ", e);
 		}
-
 
 	}
 
 	public SortedSet<Cytoband> getAllCytobands(URL u) throws IOException {
-		InputStream stream =new GZIPInputStream(u.openStream());
+		InputStream stream = new GZIPInputStream(u.openStream());
 		return getAllCytobands(stream);
 
 	}
 
-	public SortedSet<Cytoband> getAllCytobands(InputStream instream) throws IOException {
-		BufferedReader reader = new BufferedReader(new InputStreamReader(instream));
+	public SortedSet<Cytoband> getAllCytobands(InputStream instream)
+			throws IOException {
+		BufferedReader reader = new BufferedReader(new InputStreamReader(
+				instream));
 		String line = null;
-		SortedSet<Cytoband> cytobands= new TreeSet<Cytoband>();
+		SortedSet<Cytoband> cytobands = new TreeSet<Cytoband>();
 		while ((line = reader.readLine()) != null) {
 			String[] spl = line.split("\t");
-			if ( spl.length != 5){
-				System.err.println("WRONG LINE LENGHT, expected 5, but got " + spl.length + " for: " + line);
+			if (spl.length != 5) {
+				logger.warn(
+						"WRONG LINE LENGHT, expected 5, but got {} for: {}",
+						spl.length, line);
 			}
-
 
 			Cytoband b = new Cytoband();
 			b.setChromosome(spl[0]);
 			b.setStart(Integer.parseInt(spl[1]));
 			b.setEnd(Integer.parseInt(spl[2]));
 			b.setLocus(spl[3]);
-			StainType type = StainType.getStainTypeFromString( spl[4]);
-			if ( type == null)
-				System.err.println("unknown type: " +spl[4]);
+			StainType type = StainType.getStainTypeFromString(spl[4]);
+			if (type == null)
+				logger.warn("unknown type: {}", spl[4]);
 			b.setType(type);
 			cytobands.add(b);
-		} 
+		}
 
 		return cytobands;
 	}

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/geneid/GeneIDXMLReader.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/geneid/GeneIDXMLReader.java
@@ -7,12 +7,14 @@ package org.biojava3.genome.parsers.geneid;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.logging.Logger;
+
 import org.biojava3.core.sequence.AccessionID;
 import org.biojava3.core.sequence.DNASequence;
 import org.biojava3.core.sequence.io.FastaWriterHelper;
 import org.biojava3.core.sequence.ProteinSequence;
 import org.biojava3.core.util.XMLHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -22,19 +24,20 @@ import org.w3c.dom.Element;
  */
 public class GeneIDXMLReader {
 
-    private static final Logger log = Logger.getLogger(GeneIDXMLReader.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(GeneIDXMLReader.class);
+
     Document geneidDoc = null;
 
     public GeneIDXMLReader(String geneidXMLFile) throws Exception {
-        log.info("Start read of " + geneidXMLFile);
+        logger.info("Start read of {}", geneidXMLFile);
         geneidDoc = XMLHelper.loadXML(geneidXMLFile);
-        log.info("Read finished");
+        logger.info("Read finished");
     }
 
     public LinkedHashMap<String, ProteinSequence> getProteinSequences() throws Exception {
         LinkedHashMap<String, ProteinSequence> proteinSequenceList = new LinkedHashMap<String, ProteinSequence>();
         ArrayList<Element> elementList = XMLHelper.selectElements(geneidDoc.getDocumentElement(), "prediction/gene/protein");
-        log.info(elementList.size() + " hits");
+        logger.info("{} hits", elementList.size());
 
         for (Element proteinElement : elementList) {
             Element geneElement = (Element) proteinElement.getParentNode();
@@ -51,7 +54,7 @@ public class GeneIDXMLReader {
     public LinkedHashMap<String, DNASequence> getDNACodingSequences() throws Exception {
         LinkedHashMap<String, DNASequence> dnaSequenceList = new LinkedHashMap<String, DNASequence>();
         ArrayList<Element> elementList = XMLHelper.selectElements(geneidDoc.getDocumentElement(), "prediction/gene/cDNA");
-        log.info(elementList.size() + " hits");
+        logger.info("{} hits", elementList.size());
 
         for (Element dnaElement : elementList) {
             Element geneElement = (Element) dnaElement.getParentNode();
@@ -75,7 +78,7 @@ public class GeneIDXMLReader {
             FastaWriterHelper.writeNucleotideSequence(new File("/Users/Scooter/scripps/dyadic/geneid/geneid/c1_geneid.fna"), dnaSequenceHashMap.values());
 
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Exception: ", e);
         }
     }
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/genename/GeneChromosomePositionParser.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/genename/GeneChromosomePositionParser.java
@@ -27,13 +27,14 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.biojava3.core.util.InputStreamProvider;
+import org.biojava3.genome.App;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A parser that parses a file from the UCSC genome browser that contains mapping of gene name to chromosome positions
  * 
@@ -42,23 +43,25 @@ import org.biojava3.core.util.InputStreamProvider;
  */
 public class GeneChromosomePositionParser {
 
+	private static final Logger logger = LoggerFactory.getLogger(App.class);
+
 	public static final String DEFAULT_MAPPING_URL="http://hgdownload.cse.ucsc.edu/goldenPath/hg19/database/refFlat.txt.gz";
 
 	public static void main(String[] args){
 		try {
 
 			List<GeneChromosomePosition> genePositions=	getChromosomeMappings();
-			System.out.println("got " + genePositions.size() + " gene positions") ;
+			logger.info("got {} gene positions", genePositions.size());
 			
 			for (GeneChromosomePosition pos : genePositions){
 				if ( pos.getGeneName().equals("FOLH1")) {
-					System.out.println(pos);
+					logger.info("Gene Position: {}", pos);
 					break;
 				}
 			}
 			
 		} catch(Exception e){
-			e.printStackTrace();
+			logger.error("Exception: ", e);
 		}
 	}
 
@@ -96,8 +99,7 @@ public class GeneChromosomePositionParser {
 		String[] spl = line.split("\t");
 
 		if ( spl.length != 11) {
-			System.err.println("Line does not have 11 data items, but " + spl.length);
-			System.err.println(line);
+			logger.warn("Line does not have 11 data items, but {}: {}", spl.length, line);
 			return null;
 		}
 

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/genename/GeneNamesParser.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/genename/GeneNamesParser.java
@@ -29,10 +29,11 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.biojava3.core.util.InputStreamProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Parses a file from the www.genenames.org website that contains a mapping of human gene names to other databases
  * 
@@ -40,6 +41,9 @@ import org.biojava3.core.util.InputStreamProvider;
  *
  */
 public class GeneNamesParser {
+	
+	private static final Logger logger = LoggerFactory.getLogger(GeneNamesParser.class);
+
 	public static final String DEFAULT_GENENAMES_URL = "http://www.genenames.org/cgi-bin/download?title=HGNC+output+data&hgnc_dbtag=on&col=gd_app_sym&col=gd_app_name&col=gd_status&col=gd_prev_sym&col=gd_prev_name&col=gd_aliases&col=gd_pub_chrom_map&col=gd_pub_acc_ids&col=md_mim_id&col=gd_pub_refseq_ids&col=md_ensembl_id&col=md_prot_id&col=gd_hgnc_id" +
 			 "&status=Approved&status_opt=2&where=((gd_pub_chrom_map%20not%20like%20%27%patch%%27%20and%20gd_pub_chrom_map%20not%20like%20%27%ALT_REF%%27)%20or%20gd_pub_chrom_map%20IS%20NULL)%20and%20gd_locus_group%20%3d%20%27protein-coding%20gene%27&order_by=gd_app_sym_sort&format=text&limit=&submit=submit&.cgifields=&.cgifields=chr&.cgifields=status&.cgifields=hgnc_dbtag";
 
@@ -53,18 +57,17 @@ public class GeneNamesParser {
 						
 			List<GeneName> geneNames = getGeneNames();
 						
-			System.out.println("got " + geneNames.size() + " gene names");
-			
-			
+			logger.info("got {} gene names", geneNames.size());
+						
 			for ( GeneName g : geneNames){
 				if ( g.getApprovedSymbol().equals("FOLH1"))
-					System.out.println(g);
+					logger.info("Gene Name: {}", g);
 			}
 			// and returns a list of beans that contains key-value pairs for each gene name
 			
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
-			e.printStackTrace();
+			logger.error("Exception: ", e);
 		}
 		
 	}
@@ -121,9 +124,8 @@ public class GeneNamesParser {
 		String[] s = line.split("\t");
 		
 		if ( s.length != 13) {
-			System.err.println("WARNING line does not contain 13 data items but " + s.length+"."  );
-			System.err.println(line);
-			System.err.println(line.replaceAll("\t", "|---|"));
+			logger.warn("Line does not contain 13 data items, but {}: {}", s.length, line);
+			logger.warn(line.replaceAll("\t", "|---|"));
 			return null;
 		}
 		GeneName gn = new GeneName();

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/GFF3Reader.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/GFF3Reader.java
@@ -1,10 +1,14 @@
 package org.biojava3.genome.parsers.gff;
 
-
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,9 +33,10 @@ import java.util.logging.Logger;
  * @author Hanno Hinsch
  */
 public class GFF3Reader {
-	private static final  Pattern p = Pattern.compile("\t");
+	
+	private static final Logger logger = LoggerFactory.getLogger(GFF3Reader.class);
 
-    private static final Logger log = Logger.getLogger(GFF3Reader.class.getName());
+	private static final  Pattern p = Pattern.compile("\t");
 
     /**
      * Read a file into a FeatureList. Each line of the file becomes one Feature object.
@@ -42,7 +47,7 @@ public class GFF3Reader {
      */
     
     public static FeatureList read(String filename, List<String> indexes) throws IOException {
-    	log.info("Gff.read(): Reading " + filename);
+    	logger.info("Reading: {}", filename);
 
         FeatureList features = new FeatureList();
         features.addIndexes(indexes);
@@ -150,8 +155,8 @@ public class GFF3Reader {
         @SuppressWarnings("unused")
 		FeatureList listGenes = GFF3Reader.read("/home/melo/workspace/release/stdout.combined.checked2.gtf");
         long stop = System.currentTimeMillis();
-        System.out.println("Loading = "+ (stop-start));
-//        System.out.println(listGenes);
+        logger.info("Loading = {}", stop-start);
+//        logger.info(listGenes);
         //	GeneMarkGTF.write( list, args[1] );
     }
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/GeneIDGFF2Reader.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/GeneIDGFF2Reader.java
@@ -1,9 +1,14 @@
 package org.biojava3.genome.parsers.gff;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ListIterator;
 
-import java.io.*;
-import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * http://www.bioperl.org/wiki/GTF
@@ -28,7 +33,7 @@ import java.util.logging.Logger;
  */
 public class GeneIDGFF2Reader {
 
-    private static final Logger log = Logger.getLogger(GeneIDGFF2Reader.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(GeneIDGFF2Reader.class);
 
     /**
      * Read a file into a FeatureList. Each line of the file becomes one Feature object.
@@ -38,7 +43,7 @@ public class GeneIDGFF2Reader {
      * @throws IOException Something went wrong -- check exception detail message.
      */
     public static FeatureList read(String filename) throws IOException {
-        log.info("Gff.read(): Reading " + filename);
+        logger.info("Reading: {}", filename);
 
         FeatureList features = new FeatureList();
         BufferedReader br = new BufferedReader(new FileReader(filename));
@@ -145,7 +150,7 @@ public class GeneIDGFF2Reader {
      * @throws IOException Something went wrong -- check exception detail message.
      */
     public static void write(FeatureList features, String filename) throws IOException {
-        log.info("Writing " + filename);
+        logger.info("Writing: {}", filename);
 
         BufferedWriter bw = new BufferedWriter(new FileWriter(filename));
 
@@ -184,11 +189,11 @@ public class GeneIDGFF2Reader {
     public static void main(String args[]) throws Exception {
 
         FeatureList listGenes = GeneIDGFF2Reader.read("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/genemark_hmm.gtf");
-        System.out.println("Features");
+
         for(FeatureI feature : listGenes){
-            System.out.println(feature);
+            logger.info("Gene Feature: {}", feature);
         }
-//        System.out.println(listGenes);
+//        logger.info(listGenes);
         //	GeneMarkGTF.write( list, args[1] );
     }
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/GeneMarkGTFReader.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/GeneMarkGTFReader.java
@@ -1,10 +1,11 @@
 package org.biojava3.genome.parsers.gff;
 
-
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.logging.Logger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * http://www.bioperl.org/wiki/GTF
@@ -29,7 +30,7 @@ import java.util.logging.Logger;
  */
 public class GeneMarkGTFReader {
 
-    private static final Logger log = Logger.getLogger(GeneMarkGTFReader.class.getName());
+	private static final Logger logger = LoggerFactory.getLogger(GeneMarkGTFReader.class);
 
     /**
      * Read a file into a FeatureList. Each line of the file becomes one Feature object.
@@ -39,7 +40,7 @@ public class GeneMarkGTFReader {
      * @throws IOException Something went wrong -- check exception detail message.
      */
     public static FeatureList read(String filename) throws IOException {
-        log.info("Gff.read(): Reading " + filename);
+        logger.info("Reading: {}", filename);
 
         FeatureList features = new FeatureList();
         BufferedReader br = new BufferedReader(new FileReader(filename));
@@ -137,7 +138,7 @@ public class GeneMarkGTFReader {
 /*
 
     public static void write(FeatureList features, String filename) throws IOException {
-        log.info("Writing " + filename);
+        logger.info("Writing: {}", filename);
 
         BufferedWriter bw = new BufferedWriter(new FileWriter(filename));
 
@@ -176,11 +177,11 @@ public class GeneMarkGTFReader {
     public static void main(String args[]) throws Exception {
 
         FeatureList listGenes = GeneMarkGTFReader.read("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/genemark_hmm.gtf");
-        System.out.println("Features");
+
         for(FeatureI feature : listGenes){
-            System.out.println(feature);
+            logger.info("Gene Feature: {}", feature);
         }
-//        System.out.println(listGenes);
+//        logger.info(listGenes);
         //	GeneMarkGTFReader.write( list, args[1] );
     }
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/LocIterator.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/LocIterator.java
@@ -1,9 +1,10 @@
 package org.biojava3.genome.parsers.gff;
 
-
 import java.util.Iterator;
-import java.util.logging.Logger;
 
+import org.biojava3.genome.App;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
 * Move a sliding window over a Location.
@@ -13,9 +14,9 @@ import java.util.logging.Logger;
 *
 * @author Hanno Hinsch
 */
-public class LocIterator implements Iterator<Location>
-{
-        private static final Logger log = Logger.getLogger(LocIterator.class.getName());
+public class LocIterator implements Iterator<Location> {
+	private static final Logger logger = LoggerFactory.getLogger(App.class);
+
 	Location mBounds;
 	int mPosition;			
 	int mWindowSize;			
@@ -231,111 +232,107 @@ public class LocIterator implements Iterator<Location>
         
        Location r= new Location( 10, 21 );
        
-       log.info( "10 to 21, 1 by 1" );
-       for( Location t: r.window( 1, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 1 by 1" );
+       for( Location t: r.window( 1, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by 3" );
-       for( Location t: r.window( 3, 3 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by 3" );
+       for( Location t: r.window( 3, 3 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by 1" );
-       for( Location t: r.window( 3, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by 1" );
+       for( Location t: r.window( 3, 1 )) { logger.info( t.toString() ); }
      
-       log.info( "10 to 21, 11 by 1" );
-       for( Location t: r.window( 11, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 11 by 1" );
+       for( Location t: r.window( 11, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 12 by 1" );
-       for( Location t: r.window( 12, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 12 by 1" );
+       for( Location t: r.window( 12, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 1 by -1" );
-       for( Location t: r.window( 1, -1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 1 by -1" );
+       for( Location t: r.window( 1, -1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by -3" );
-       for( Location t: r.window( 3, -3 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by -3" );
+       for( Location t: r.window( 3, -3 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by -1" );
-       for( Location t: r.window( 3, -1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by -1" );
+       for( Location t: r.window( 3, -1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 1 by 1" );
-       for( Location t: r.window( 1, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 1 by 1" );
+       for( Location t: r.window( 1, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by 3" );
-       for( Location t: r.window( 3, 3 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by 3" );
+       for( Location t: r.window( 3, 3 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by 1" );
-       for( Location t: r.window( 3, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by 1" );
+       for( Location t: r.window( 3, 1 )) { logger.info( t.toString() ); }
      
-       log.info( "10 to 21, 11 by 1" );
-       for( Location t: r.window( 11, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 11 by 1" );
+       for( Location t: r.window( 11, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 12 by 1" );
-       for( Location t: r.window( 12, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 12 by 1" );
+       for( Location t: r.window( 12, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 1 by -1" );
-       for( Location t: r.window( 1, -1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 1 by -1" );
+       for( Location t: r.window( 1, -1 )) { logger.info( t.toString() ); }
        
        //reverse strand
        r= r.opposite();
-       log.info( "reverse strand" );
+       logger.info( "reverse strand" );
        
-       log.info( "10 to 21, 1 by 1" );
-       for( Location t: r.window( 1, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 1 by 1" );
+       for( Location t: r.window( 1, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by 3" );
-       for( Location t: r.window( 3, 3 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by 3" );
+       for( Location t: r.window( 3, 3 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by 1" );
-       for( Location t: r.window( 3, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by 1" );
+       for( Location t: r.window( 3, 1 )) { logger.info( t.toString() ); }
      
-       log.info( "10 to 21, 11 by 1" );
-       for( Location t: r.window( 11, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 11 by 1" );
+       for( Location t: r.window( 11, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 12 by 1" );
-       for( Location t: r.window( 12, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 12 by 1" );
+       for( Location t: r.window( 12, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 1 by -1" );
-       for( Location t: r.window( 1, -1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 1 by -1" );
+       for( Location t: r.window( 1, -1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by -3" );
-       for( Location t: r.window( 3, -3 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by -3" );
+       for( Location t: r.window( 3, -3 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by -1" );
-       for( Location t: r.window( 3, -1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by -1" );
+       for( Location t: r.window( 3, -1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 1 by 1" );
-       for( Location t: r.window( 1, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 1 by 1" );
+       for( Location t: r.window( 1, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by 3" );
-       for( Location t: r.window( 3, 3 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by 3" );
+       for( Location t: r.window( 3, 3 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 3 by 1" );
-       for( Location t: r.window( 3, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 3 by 1" );
+       for( Location t: r.window( 3, 1 )) { logger.info( t.toString() ); }
      
-       log.info( "10 to 21, 11 by 1" );
-       for( Location t: r.window( 11, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 11 by 1" );
+       for( Location t: r.window( 11, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 12 by 1" );
-       for( Location t: r.window( 12, 1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 12 by 1" );
+       for( Location t: r.window( 12, 1 )) { logger.info( t.toString() ); }
        
-       log.info( "10 to 21, 1 by -1" );
-       for( Location t: r.window( 1, -1 )) { log.info( t.toString() ); }
+       logger.info( "10 to 21, 1 by -1" );
+       for( Location t: r.window( 1, -1 )) { logger.info( t.toString() ); }
        
-       
-       log.info("");
-       log.info( "10 to 21, 1 by 1 (+2)" );
+       logger.info( "10 to 21, 1 by 1 (+2)" );
        LocIterator i= r.iterator();
        int chunk= 1;
        while( i.hasNext( 1, chunk ) )
        {
         Location t= i.next( 1, chunk );
-        log.info( t.toString() );
+        logger.info( t.toString() );
         chunk+= 2;
        }
        
        //FIXME test remainder()
        
-       log.info( "JavaGene.LocIterator Passed." );
- 
+       logger.info("JavaGene.LocIterator Passed.");
     }
 
-	
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/Location.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/parsers/gff/Location.java
@@ -1,5 +1,9 @@
 package org.biojava3.genome.parsers.gff;
 
+import org.biojava3.genome.App;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 
 /**
  * A location on a sequence.
@@ -48,7 +52,8 @@ package org.biojava3.genome.parsers.gff;
  */
 public class Location implements Iterable<Location>
 {
-	
+	private static final Logger logger = LoggerFactory.getLogger(App.class);
+
 	private int mStart;
 	private int mEnd;
 
@@ -941,8 +946,7 @@ public class Location implements Iterable<Location>
 		
 		//fromBio, etc.
 		
-		System.out.println( "JavaGene.Location Passed." );
-		
+		logger.info("JavaGene.Location Passed.");
 	}
 	
 }		

--- a/biojava3-genome/src/main/java/org/biojava3/genome/query/BlastXMLQuery.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/query/BlastXMLQuery.java
@@ -7,8 +7,10 @@ package org.biojava3.genome.query;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.logging.Logger;
+
 import org.biojava3.core.util.XMLHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -17,20 +19,22 @@ import org.w3c.dom.Element;
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class BlastXMLQuery {
-    private static final Logger log = Logger.getLogger(BlastXMLQuery.class.getName());
-    Document blastDoc = null;
+
+	private static final Logger logger = LoggerFactory.getLogger(BlastXMLQuery.class);
+
+	Document blastDoc = null;
 
     public BlastXMLQuery(String blastFile) throws Exception {
-        log.info("Start read of " + blastFile);
+        logger.info("Start read of {}", blastFile);
         blastDoc = XMLHelper.loadXML(blastFile);
-        log.info("Read finished");
+        logger.info("Read finished");
     }
 
     public LinkedHashMap<String, ArrayList<String>> getHitsQueryDef(double maxEScore) throws Exception {
         LinkedHashMap<String, ArrayList<String>> hitsHashMap = new LinkedHashMap<String, ArrayList<String>>();
-        log.info("Query for hits");
+        logger.info("Query for hits");
         ArrayList<Element> elementList = XMLHelper.selectElements(blastDoc.getDocumentElement(), "BlastOutput_iterations/Iteration[Iteration_hits]");
-        log.info(elementList.size() + " hits");
+        logger.info("{} hits", elementList.size());
 
         for (Element element : elementList) {
             Element iterationquerydefElement = XMLHelper.selectSingleElement(element, "Iteration_query-def");
@@ -65,9 +69,9 @@ public class BlastXMLQuery {
         try {
             BlastXMLQuery blastXMLQuery = new BlastXMLQuery("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/c1-454Scaffolds-hits-uniprot_fungi.xml");
             LinkedHashMap<String, ArrayList<String>> hits = blastXMLQuery.getHitsQueryDef(1E-10);
-            System.out.println(hits);
+            logger.info("Hits: {}", hits);
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Execution: ", e);
         }
     }
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/query/OutputHitsGFF.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/query/OutputHitsGFF.java
@@ -7,16 +7,21 @@ package org.biojava3.genome.query;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+
 import org.biojava3.genome.parsers.gff.Feature;
 import org.biojava3.genome.parsers.gff.FeatureI;
 import org.biojava3.genome.parsers.gff.FeatureList;
 import org.biojava3.genome.parsers.gff.GeneMarkGTFReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class OutputHitsGFF {
+
+	private static final Logger logger = LoggerFactory.getLogger(OutputHitsGFF.class);
 
     public void process(File blastXMLFile, File gffFile, File gffOutputFile, double maxEScore, double percentageAligned, boolean includeFrameShift, boolean includeNegativeStrand) throws Exception {
         BlastXMLQuery blastXMLQuery = new BlastXMLQuery(blastXMLFile.getAbsolutePath());
@@ -62,7 +67,7 @@ public class OutputHitsGFF {
 
 
         } catch (Exception e) {
-            e.printStackTrace();
+            logger.error("Execution: ", e);
         }
     }
 }

--- a/biojava3-genome/src/main/java/org/biojava3/genome/uniprot/UniprotToFasta.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/uniprot/UniprotToFasta.java
@@ -10,6 +10,8 @@ import java.util.HashMap;
 import org.biojava3.core.sequence.AccessionID;
 import org.biojava3.core.sequence.ProteinSequence;
 import org.biojava3.core.sequence.io.FastaWriterHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * To change this template, choose Tools | Templates
@@ -22,6 +24,8 @@ import org.biojava3.core.sequence.io.FastaWriterHelper;
  */
 public class UniprotToFasta {
 
+	private static final Logger logger = LoggerFactory.getLogger(UniprotToFasta.class);
+
     public static void main( String[] args ){
         try{
             String uniprotDatFileName = "uniprot_trembl_fungi.dat";
@@ -29,7 +33,7 @@ public class UniprotToFasta {
             UniprotToFasta uniprotToFasta = new UniprotToFasta();
             uniprotToFasta.process(uniprotDatFileName, fastaFileName);
         }catch(Exception e){
-            e.printStackTrace();
+            logger.error("Exception: ", e);
         }
     }
 
@@ -79,7 +83,7 @@ public class UniprotToFasta {
                     sequence = new StringBuffer();
                     count++;
                     if(count % 100 == 0)
-                        System.out.println(count);
+                        logger.info("Count: ", count);
                     String[] parts = id.split("_");
                     uniqueGenes.put(parts[0], "");
                     uniqueSpecies.put(parts[1],"");

--- a/biojava3-genome/src/main/java/org/biojava3/genome/util/SplitFasta.java
+++ b/biojava3-genome/src/main/java/org/biojava3/genome/util/SplitFasta.java
@@ -8,9 +8,12 @@ package org.biojava3.genome.util;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+
 import org.biojava3.core.sequence.DNASequence;
 import org.biojava3.core.sequence.io.FastaReaderHelper;
 import org.biojava3.core.sequence.io.FastaWriterHelper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -18,6 +21,8 @@ import org.biojava3.core.sequence.io.FastaWriterHelper;
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class SplitFasta {
+
+	private static final Logger logger = LoggerFactory.getLogger(SplitFasta.class);
 
     public void processNucleotides(File fastaFileName,String uniqueid, File outputDirectory ) throws Exception{
         if(!outputDirectory.exists())
@@ -43,7 +48,7 @@ public class SplitFasta {
             SplitFasta splitFasta = new SplitFasta();
             splitFasta.processNucleotides(new File("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/454Scaffolds.fna"), "", new File("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/individual"));
         }catch(Exception e){
-            e.printStackTrace();
+            logger.error("Exception: ", e);
         }
     }
 

--- a/biojava3-genome/src/main/resources/log4j2.xml
+++ b/biojava3-genome/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration status="WARN">
+	<appenders>
+		<Console name="Console" target="SYSTEM_ERR">
+			<PatternLayout pattern="%d{HH:mm:ss} [%t] %-5level %logger{36} - %msg%n"/>
+		</Console>
+	</appenders>
+	<loggers>
+		<root level="warn">
+			<appender-ref ref="Console"/>
+		</root>
+	</loggers>
+</configuration>

--- a/biojava3-genome/src/test/java/org/biojava3/genome/GeneFeatureHelperTest.java
+++ b/biojava3-genome/src/test/java/org/biojava3/genome/GeneFeatureHelperTest.java
@@ -18,12 +18,16 @@ import org.biojava3.core.sequence.io.FastaWriterHelper;
 import org.biojava3.genome.parsers.gff.FeatureList;
 import org.biojava3.genome.parsers.gff.GFF3Reader;
 import org.biojava3.genome.parsers.gff.GFF3Writer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * 
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class GeneFeatureHelperTest extends TestCase {
+
+	private static final Logger logger = LoggerFactory.getLogger(GeneFeatureHelperTest.class);
 
     public GeneFeatureHelperTest(String testName) {
         super(testName);
@@ -52,7 +56,7 @@ public class GeneFeatureHelperTest extends TestCase {
      */
 
     public void testLoadFastaAddGeneFeaturesFromUpperCaseExonFastaFile() throws Exception {
-        // System.out.println("loadFastaAddGeneFeaturesFromUpperCaseExonFastaFile");
+        // logger.info("loadFastaAddGeneFeaturesFromUpperCaseExonFastaFile");
         File fastaSequenceFile = new File("src/test/resources/volvox_all.fna");
         File uppercaseFastaFile = new File("src/test/resources/volvox_all_genes_exon_uppercase.fna");
         boolean throwExceptionGeneNotFound = false;
@@ -73,7 +77,7 @@ public class GeneFeatureHelperTest extends TestCase {
      * Test of outputFastaSequenceLengthGFF3 method, of class GeneFeatureHelper.
      */
     public void testOutputFastaSequenceLengthGFF3() throws Exception {
-        // System.out.println("outputFastaSequenceLengthGFF3");
+        // logger.info("outputFastaSequenceLengthGFF3");
 
         File fastaSequenceFile = new File("src/test/resources/volvox_all.fna");
         File gffFile = File.createTempFile("volvox_length", "gff3");
@@ -96,8 +100,7 @@ public class GeneFeatureHelperTest extends TestCase {
                         "src/test/resources/volvox.gff3"), false);
         ChromosomeSequence ctgASequence = chromosomeSequenceList.get("ctgA");
         GeneSequence edenGeneSequence = ctgASequence.getGene("EDEN");
-        System.out.println("Note " + edenGeneSequence.getNotesList());
-
+        logger.info("Note {}", edenGeneSequence.getNotesList());
     }
 
     /**
@@ -113,7 +116,7 @@ public class GeneFeatureHelperTest extends TestCase {
         LinkedHashMap<String, ProteinSequence> proteinSequenceList = GeneFeatureHelper
                 .getProteinSequences(chromosomeSequenceList.values());
         // for(ProteinSequence proteinSequence : proteinSequenceList.values()){
-        // System.out.println("Output=" + proteinSequence.getSequenceAsString());
+        // logger.info("Output={}", proteinSequence.getSequenceAsString());
         // }
         File tmp = File.createTempFile("volvox_all", "faa");
         tmp.deleteOnExit();
@@ -126,7 +129,7 @@ public class GeneFeatureHelperTest extends TestCase {
      * Test of getGeneSequences method, of class GeneFeatureHelper.
      */
     public void testGetGeneSequences() throws Exception {
-        // System.out.println("getGeneSequences");
+        // logger.info("getGeneSequences");
         LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper
                 .loadFastaAddGeneFeaturesFromGmodGFF3(new File("src/test/resources/volvox_all.fna"), new File(
                         "src/test/resources/volvox.gff3"), true);

--- a/biojava3-genome/src/test/resources/log4j2.xml
+++ b/biojava3-genome/src/test/resources/log4j2.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_ERR">
+            <PatternLayout pattern="%d{HH:mm:ss} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <!-- 
+        <Logger name="org.biojava3.core.sequence.loader.GenbankProxySequenceReader" level="debug">
+            <AppenderRef ref="Console"/>
+        </Logger>
+        -->
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Converted all non-commented print and printStackTrace in org.biojava3.genome package to use slf4j. Removed several instances of java.util.logging (and replaced with slf4j).
