### PR TITLE
Changing maven package for protein-comparison-tool to shade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,11 @@
 
 				</plugin>
 				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-shade-plugin</artifactId>
+					<version>2.3</version>
+				</plugin>
+				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
 					<version>2.4</version>
 					<configuration>

--- a/protein-comparison-tool/pom.xml
+++ b/protein-comparison-tool/pom.xml
@@ -74,7 +74,70 @@
 
 	<build>
 		<plugins>
+
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<!-- Minimizing removes jmol and log4j -->
+							<minimizeJar>false</minimizeJar>
+							<artifactSet>
+								<excludes>
+									<exclude>junit:junit</exclude>
+								</excludes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>net.sourceforge.jmol:jmol</artifact>
+									<excludes>
+										<exclude>javax/vecmath/**</exclude>
+									</excludes>
+								</filter>
+								<filter>
+									<artifact>org.biojava:biojava3-structure</artifact>
+									<excludes>
+										<exclude>demo/DemoFATCAT*</exclude>
+										<exclude>demo/DemoCE*</exclude>
+									</excludes>
+								</filter>
+								<filter>
+									<!-- Exclude signature files -->
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<transformers>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<manifestEntries>
+										<Specification-Vendor>Open Bioinformatics Foundation</Specification-Vendor>
+										<Implementation-Vendor>Open Bioinformatics Foundation</Implementation-Vendor>
+										<Specification-Version>${project.version}</Specification-Version>
+										<Implementation-Version>${project.version}</Implementation-Version>
+										<Specification-Title>${project.name}</Specification-Title>
+										<Implementation-Title>${project.name}</Implementation-Title>
+										<Main-Class>org.biojava.bio.structure.align.gui.AlignmentGui</Main-Class>
+									</manifestEntries>
+								</transformer>
+								<!-- This bit merges the various META-INF/services files -->
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<descriptors>
@@ -91,14 +154,15 @@
 							<goal>single</goal>
 						</goals>
 						<configuration>
-							<finalName>${project.name}_${timestamp}</finalName>
+							<finalName>${project.artifactId}-${project.version}</finalName>
 							<appendAssemblyId>false</appendAssemblyId>
 						</configuration>
 					</execution>
 				</executions>
 
 			</plugin>
-	</plugins>
+
+		</plugins>
 	</build>
 	
 </project>

--- a/protein-comparison-tool/src/main/assembly/assembly.xml
+++ b/protein-comparison-tool/src/main/assembly/assembly.xml
@@ -7,56 +7,45 @@
 		<format>tar.gz</format>
 	</formats>
 
-<!-- 	<moduleSets>
-	
-		<moduleSet>
-		<useAllReactorProjects>true</useAllReactorProjects>	 
-			<includes>
-				<include>${groupId}:biojava3-core</include>
-				<include>${groupId}:biojava3-alignment</include>
-				<include>${groupId}:biojava3-structure</include>
-				<include>${groupId}:biojava3-structure-gui</include>				
-			</includes>
-			<binaries>
-				<outputDirectory>modules/${artifactId}</outputDirectory>
-				<outputDirectory>./modules/</outputDirectory>
-				<unpack>false</unpack>
-				<includeDependencies>true</includeDependencies>
-				   <dependencySets>
-                    <dependencySet>
-                        <unpack>false</unpack>
-                        <scope>compile</scope>
-                        
-                    </dependencySet>
-                </dependencySets>
-			</binaries>
-			  
-		</moduleSet>
-	</moduleSets> -->
 	<fileSets>
 		<fileSet>
 			<directory>${project.basedir}/src/main/assembly/</directory>
 			<outputDirectory>.</outputDirectory>
 			<includes>
-				<include>*.sh</include>
 				<include>db.out</include>
 				<include>example.lst</include>
 				<include>LICENSE</include>
 			</includes>
 		</fileSet>
+		<fileSet>
+			<directory>${project.build.directory}</directory>
+			<outputDirectory>.</outputDirectory>
+			<includes>
+				<include>${project.build.finalName}.jar</include>
+			</includes>
+		</fileSet>
+		
 	</fileSets>
-	<dependencySets>
-		  <dependencySet>
-            <outputDirectory>jars</outputDirectory>
-            <includes>                               
-				<include>${groupId}:biojava3-core</include>
-				<include>${groupId}:biojava3-alignment</include>
-				<include>${groupId}:biojava3-structure</include>
-				<include>${groupId}:biojava3-structure-gui</include>				
-				<include>net.sourceforge.jmol:jmol</include>
-				<include>javaws:javaws</include>
-            </includes>
-        </dependencySet>
-	</dependencySets>
-
+	<!-- Shell scripts must be filtered for the correct jar name -->
+	<files>
+		<file>
+			<source>src/main/assembly/runCE.sh</source>
+			<outputDirectory>/</outputDirectory>
+			<filtered>true</filtered>
+			<fileMode>0755</fileMode>
+		</file>
+		<file>
+			<source>src/main/assembly/runFATCAT.sh</source>
+			<outputDirectory>/</outputDirectory>
+			<filtered>true</filtered>
+			<fileMode>0755</fileMode>
+		</file>
+		<file>
+			<source>src/main/assembly/startFarmJob.sh</source>
+			<outputDirectory>/</outputDirectory>
+			<filtered>true</filtered>
+			<fileMode>0755</fileMode>
+		</file>
+	</files>
+	
 </assembly>

--- a/protein-comparison-tool/src/main/assembly/runCE.sh
+++ b/protein-comparison-tool/src/main/assembly/runCE.sh
@@ -33,8 +33,15 @@
 # bash runCE.sh -pdbFilePath /tmp/ -showDBresult db.out
 
 
-# send the arguments to the java app
-# allows to specify a different config file
-args="$*"
+### Execute jar ###
 
-java -Xmx500M -cp "$PWD/jars/*" org.biojava.bio.structure.align.ce.CeMain $args
+# Get the base directory of the argument.
+# Can resolve single symlinks if readlink is installed
+function scriptdir {
+    cd "$(dirname "$1")"
+    cd "$(dirname "$(readlink "$1" 2>/dev/null || basename "$1" )")"
+    pwd
+}
+DIR="$(scriptdir "$0" )"
+# send the arguments to the java app
+java -Xmx500M -cp "$DIR/${project.build.finalName}.jar" org.biojava.bio.structure.align.ce.CeMain "$@"

--- a/protein-comparison-tool/src/main/assembly/runFATCAT.sh
+++ b/protein-comparison-tool/src/main/assembly/runFATCAT.sh
@@ -12,7 +12,17 @@
 # for more examples see runCE.sh
 # jCE works almost exactly the same...
 
-# send the arguments to the java app
-args="$*"
 
-java -Xmx500M -cp "$PWD/jars/*" org.biojava.bio.structure.align.fatcat.FatCat $args
+### Execute jar ###
+
+
+# Get the base directory of the argument.
+# Can resolve single symlinks if readlink is installed
+function scriptdir {
+    cd "$(dirname "$1")"
+    cd "$(dirname "$(readlink "$1" 2>/dev/null || basename "$1" )")"
+    pwd
+}
+DIR="$(scriptdir "$0" )"
+# send the arguments to the java app
+java -Xmx500M -cp "$DIR/${project.build.finalName}.jar" org.biojava.bio.structure.align.fatcat.FatCat "$@"

--- a/protein-comparison-tool/src/main/assembly/startFarmJob.sh
+++ b/protein-comparison-tool/src/main/assembly/startFarmJob.sh
@@ -15,7 +15,7 @@ else
      else
         which java
         java -version
-        java  -Xmx1G -cp "$PWD/jars/*" org.biojava.bio.structure.align.FarmJob $args
+        java  -Xmx1G -cp "./${project.build.finalName}.jar" org.biojava.bio.structure.align.FarmJob $args
     fi
 fi
 


### PR DESCRIPTION
Rather than copy all the jars individually using the maven assembly
plugin, we use the shade plugin to combine them all into a single jar
file, then assemble that. Since all our dependencies are
lgpl-compatible, this should be OK.

This fixes #197.

I've also included improvements to the run scripts which let you run
them from any directory, not just the current one. Maven handles
replacing the jar filename at assembly time.

Finally, I changed the name of the assembly. They are now named like
'protein-comparison-tool-4.0.0.jar' rather than including a timestamp.
