### PR TITLE
Fix #244: AtomPositionMap bug fixes

### DIFF
--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/AtomPositionMap.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/AtomPositionMap.java
@@ -23,18 +23,16 @@
 
 package org.biojava.bio.structure;
 
-import org.biojava.bio.structure.io.mmcif.chem.ResidueType;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
-import java.util.Set;
 import java.util.TreeMap;
-import java.util.TreeSet;
+
+import org.biojava.bio.structure.io.mmcif.chem.PolymerType;
+import org.biojava.bio.structure.io.mmcif.chem.ResidueType;
 
 /**
  * A map from {@link ResidueNumber ResidueNumbers} to ATOM record positions in a PDB file.
@@ -53,11 +51,6 @@ public class AtomPositionMap {
 	private HashMap<ResidueNumber, Integer> hashMap;
 	private TreeMap<ResidueNumber, Integer> treeMap;
 
-	public static final Set<String> AMINO_ACID_NAMES = new TreeSet<String>();
-	static {
-		AMINO_ACID_NAMES.addAll(Arrays.asList("ALA", "ARG", "ASN", "ASP", "CYS", "GLU", "GLN", "GLY", "HIS", "ILE", "LEU", "LYS", "MET", "PHE", "PRO", "SER", "THR", "TRP", "TYR", "VAL"));
-		AMINO_ACID_NAMES.addAll(Arrays.asList("ASX", "GLX", "XLE", "XAA"));
-	}
 
 	public static interface GroupMatcher {
 		boolean matches(Group group);
@@ -67,7 +60,7 @@ public class AtomPositionMap {
 		@Override
 		public boolean matches(Group group) {
 			ResidueType type = group.getChemComp().getResidueType();
-			return group.hasAtom(StructureTools.CA_ATOM_NAME) || AMINO_ACID_NAMES.contains(group.getPDBName()) || type == ResidueType.lPeptideLinking || type == ResidueType.glycine || type == ResidueType.lPeptideAminoTerminus || type == ResidueType.lPeptideCarboxyTerminus || type == ResidueType.dPeptideLinking || type == ResidueType.dPeptideAminoTerminus || type == ResidueType.dPeptideCarboxyTerminus;
+			return PolymerType.PROTEIN_ONLY.contains(type.getPolymerType());
 		}
 	};
 

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/AtomPositionMap.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/AtomPositionMap.java
@@ -132,18 +132,6 @@ public class AtomPositionMap {
 	 * @param startingChain
 	 * @return
 	 */
-	public int calcLength(int positionA, int positionB, char startingChain) {
-		return calcLength(positionA, positionB, String.valueOf(startingChain));
-	}
-
-	/**
-	 * This is <strong>not</em> the same as subtracting {@link #getPosition(ResidueNumber)} for {@code positionB} from {@link #getPosition(ResidueNumber)} for {@code positionA}.
-	 * The latter considers only positions of ATOM entries in the PDB file and ignores chains. This method only includes ATOMs from the same chain.
-	 * @param positionA
-	 * @param positionB
-	 * @param startingChain
-	 * @return
-	 */
 	public int calcLength(int positionA, int positionB, String startingChain) {
 		int positionStart, positionEnd;
 		if (positionA <= positionB) {
@@ -173,17 +161,7 @@ public class AtomPositionMap {
 	 * @param startingChain
 	 * @return
 	 */
-	public int calcLengthDirectional(int positionStart, int positionEnd, char startingChain) {
-		return calcLengthDirectional(positionStart, positionEnd, String.valueOf(startingChain));
-	}
 
-	/**
-	 * Calculates the distance between {@code positionStart} and {@code positionEnd}. Will return a negative value if the start is past the end.
-	 * @param positionStart
-	 * @param positionEnd
-	 * @param startingChain
-	 * @return
-	 */
 	public int calcLengthDirectional(int positionStart, int positionEnd, String startingChain) {
 		int count = 0;
 		for (Map.Entry<ResidueNumber, Integer> entry : treeMap.entrySet()) {
@@ -203,7 +181,7 @@ public class AtomPositionMap {
 	 * @param positionA
 	 * @param positionB
 	 * @return
-	 * @see #calcLength(int, int, char)
+	 * @see #calcLength(int, int, String)
 	 */
 	public int calcLength(ResidueNumber positionA, ResidueNumber positionB) {
 		int pA = hashMap.get(positionA);

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/AtomPositionMap.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/AtomPositionMap.java
@@ -47,6 +47,9 @@ import org.biojava.bio.structure.io.mmcif.chem.ResidueType;
  * int pos = map.getPosition(start);
  * int length = map.calcLength(start, end);
  * </pre>
+ * 
+ * <p>Note: The getLength() methods were introduced in BioJava 4.0.0 to replace
+ * the calcLength methods, which returned the length-1
  * @author dmyerstu
  */
 public class AtomPositionMap {
@@ -148,7 +151,7 @@ public class AtomPositionMap {
 	 * @param startingChain Case-sensitive chain
 	 * @return The number of atoms between A and B inclusive belonging to the given chain
 	 */
-	public int calcLength(int positionA, int positionB, String startingChain) {
+	public int getLength(int positionA, int positionB, String startingChain) {
 		
 		int positionStart, positionEnd;
 		if (positionA <= positionB) {
@@ -181,8 +184,8 @@ public class AtomPositionMap {
 	 * @param startingChain Case-sensitive chain
 	 * @return The number of atoms from A to B inclusive belonging to the given chain
 	 */
-	public int calcLengthDirectional(int positionStart, int positionEnd, String startingChain) {
-		int count = calcLength(positionStart,positionEnd,startingChain);
+	public int getLengthDirectional(int positionStart, int positionEnd, String startingChain) {
+		int count = getLength(positionStart,positionEnd,startingChain);
 		if(positionStart <= positionEnd) {
 			return count;
 		} else {
@@ -199,7 +202,7 @@ public class AtomPositionMap {
 	 * @throws IllegalArgumentException if start and end are on different chains,
 	 *  or if either of the residues doesn't exist
 	 */
-	public int calcLength(ResidueNumber start, ResidueNumber end) {
+	public int getLength(ResidueNumber start, ResidueNumber end) {
 		if( ! start.getChainId().equals(end.getChainId())) {
 			throw new IllegalArgumentException(String.format(
 					"Chains differ between %s and %s. Unable to calculate length.",
@@ -213,7 +216,7 @@ public class AtomPositionMap {
 		if(endPos == null) {
 			throw new IllegalArgumentException("Residue "+start+" was not found.");
 		}
-		return calcLength(startPos,endPos, start.getChainId());
+		return getLength(startPos,endPos, start.getChainId());
 	}
 
 	/**
@@ -226,7 +229,7 @@ public class AtomPositionMap {
 	 * @throws IllegalArgumentException if start and end are on different chains,
 	 *  or if either of the residues doesn't exist
 	 */
-	public int calcLengthDirectional(ResidueNumber start, ResidueNumber end) {
+	public int getLengthDirectional(ResidueNumber start, ResidueNumber end) {
 		if( ! start.getChainId().equals(end.getChainId())) {
 			throw new IllegalArgumentException(String.format(
 					"Chains differ between %s and %s. Unable to calculate length.",
@@ -240,7 +243,7 @@ public class AtomPositionMap {
 		if(endPos == null) {
 			throw new IllegalArgumentException("Residue "+start+" was not found.");
 		}
-		return calcLengthDirectional(startPos,endPos, start.getChainId());
+		return getLengthDirectional(startPos,endPos, start.getChainId());
 	}
 
 
@@ -309,7 +312,7 @@ public class AtomPositionMap {
 		for (ResidueNumber rn : treeMap.keySet()) {
 			if (!rn.getChainId().equals(currentChain)) {
 				if (first != null) {
-					ResidueRangeAndLength newRange = new ResidueRangeAndLength(currentChain, first, prev, this.calcLength(first, prev));
+					ResidueRangeAndLength newRange = new ResidueRangeAndLength(currentChain, first, prev, this.getLength(first, prev));
 					ranges.add(newRange);
 				}
 				first = rn;
@@ -317,7 +320,7 @@ public class AtomPositionMap {
 			prev = rn;
 			currentChain = rn.getChainId();
 		}
-		ResidueRangeAndLength newRange = new ResidueRangeAndLength(currentChain, first, prev, this.calcLength(first, prev));
+		ResidueRangeAndLength newRange = new ResidueRangeAndLength(currentChain, first, prev, this.getLength(first, prev));
 		ranges.add(newRange);
 		return ranges;
 	}

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/ResidueRange.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/ResidueRange.java
@@ -44,7 +44,17 @@ public class ResidueRange {
 	private final ResidueNumber end;
 	private final ResidueNumber start;
 
-	public static final String RANGE_REGEX = "^([a-zA-Z])+[_:](?:(-?\\d+[a-zA-Z]?)-(-?\\d+[a-zA-Z]?))?$";
+	public static final Pattern RANGE_REGEX = Pattern.compile(
+			"^\\s*([a-zA-Z0-9]+|_)" + //chain ID. Be flexible here, rather than restricting to 4-char IDs
+			"(?:" + //begin range, this is a "non-capturing group"
+				"(?::|_|:$|_$|$)" + //colon or underscore, could be at the end of a line, another non-capt. group.
+				"(?:"+ // another non capturing group for the residue range
+					"([-+]?[0-9]+[A-Za-z]?)" + // first residue
+					"\\s*-\\s*" + // -
+					"([-+]?[0-9]+[A-Za-z]?)" + // second residue
+				")?+"+
+			")?" + //end range
+			"\\s*");
 
 	/**
 	 * @param s
@@ -54,7 +64,7 @@ public class ResidueRange {
 	public static ResidueRange parse(String s) {
 		ResidueNumber start = null, end = null;
 		String chain = null;
-		Matcher matcher = match(s);
+		Matcher matcher = RANGE_REGEX.matcher(s);
 		if (matcher.matches()) {
 			try {
 				chain = matcher.group(1);
@@ -304,25 +314,6 @@ public class ResidueRange {
 			if (i < ranges.size() - 1) sb.append(",");
 		}
 		return sb.toString();
-	}
-	
-	/**
-	 * Matches the string with a regex pattern that matches all recognizable range formats.
-	 * @param s A string to match against
-	 * @return A Matcher run against {@code s}; contains 1 or 3 groups: {@code matcher.group(1)} is the chain Id, and optionally {@code matcher.group(2)} and {@code matcher.group(3)} are the start and end residues, respectively.
-	 */
-	public static Matcher match(String s) {
-		Pattern pattern = Pattern.compile(RANGE_REGEX);
-		Matcher matcher = pattern.matcher(s);
-		matcher.find();
-		return matcher;
-	}
-	
-	/**
-	 * Determines whether a String is of a recognizable range format
-	 */
-	public static boolean looksLikeRange(String s) {
-		return match(s).matches();
 	}
 
 }

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/ResidueRangeAndLength.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/ResidueRangeAndLength.java
@@ -29,16 +29,7 @@ public class ResidueRangeAndLength extends ResidueRange {
 	 */
 	@Override
 	public Iterator<ResidueNumber> iterator(AtomPositionMap map) {
-		return super.iterator(map, length); // just a bit faster
-	}
-
-	/**
-	 * Returns a new Iterator over every {@link ResidueNumber} in this ResidueRange.
-	 * Stores the contents of {@code map} until the iterator is finished, so calling code should set the iterator to {@code null} if it did not finish.
-	 */
-	@Override
-	public Iterator<ResidueNumber> iterator(AtomPositionMap map, Integer length) {
-		return super.iterator(map, length); // just a bit faster
+		return super.iterator(map); // just a bit faster
 	}
 
 	/**
@@ -73,7 +64,7 @@ public class ResidueRangeAndLength extends ResidueRange {
 		// get a non-null start and end
 		// if it's the whole chain, choose the first and last residue numbers in the chain
 		if (start==null) {
-			if (rr.getChainId() == null) {
+			if (rr.getChainId() == null) {//TODO || rr.getChainId() == '_'
 				start = map.getFirst();
 			} else {
 				start = map.getFirst(rr.getChainId());
@@ -93,7 +84,7 @@ public class ResidueRangeAndLength extends ResidueRange {
 		int length = map.calcLength(start, end);
 
 		// to avoid confusing the user, don't add the start and end if they weren't specified in the string s
-		return new ResidueRangeAndLength(rr.getChainId(), rr.getStart(), rr.getEnd(), length);
+		return new ResidueRangeAndLength(rr.getChainId(), start, end, length);
 	}
 
 	public static List<ResidueRangeAndLength> parseMultiple(List<String> ranges, AtomPositionMap map) {

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/ResidueRangeAndLength.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/ResidueRangeAndLength.java
@@ -4,12 +4,16 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * A chain, a start residue, and an end residue.
  *
  * Also stores a length. Because of insertion codes, this length is not necessarily {@code end − start}.
  */
 public class ResidueRangeAndLength extends ResidueRange {
+	private static final Logger logger = LoggerFactory.getLogger(ResidueRangeAndLength.class);
 
 	private final int length;
 
@@ -53,6 +57,11 @@ public class ResidueRangeAndLength extends ResidueRange {
 	}
 
 	/**
+	 * Parses a residue range.
+	 * 
+	 * The AtomPositionMap is used to calculate the length and fill in missing
+	 * information, such as for whole chains ('A:'). Supports the special chain
+	 * name '_' for single-chain structures.
 	 * @param s
 	 *            A string of the form chain_start-end. For example: <code>A.5-100</code>.
 	 * @return The unique ResidueRange corresponding to {@code s}.
@@ -60,31 +69,38 @@ public class ResidueRangeAndLength extends ResidueRange {
 	public static ResidueRangeAndLength parse(String s, AtomPositionMap map) {
 		ResidueRange rr = parse(s);
 		ResidueNumber start = rr.getStart();
+		
+		String chain = rr.getChainId();
+		
+		// handle special "_" chain
+		if(chain == null || chain.equals("_")) {
+			ResidueNumber first = map.getNavMap().firstKey();
+			chain = first.getChainId();
+			// Quick check for additional chains. Not guaranteed.
+			if( ! map.getNavMap().lastKey().getChainId().equals(chain) ) {
+				logger.warn("Multiple possible chains match '_'. Using chain {}",chain);
+			}
+		}
 
 		// get a non-null start and end
 		// if it's the whole chain, choose the first and last residue numbers in the chain
 		if (start==null) {
-			if (rr.getChainId() == null) {//TODO || rr.getChainId() == '_'
-				start = map.getFirst();
-			} else {
-				start = map.getFirst(rr.getChainId());
-			}
+			start = map.getFirst(chain);
 		}
 		ResidueNumber end = rr.getEnd();
 		if (end==null) { // should happen iff start==null
-			if (rr.getChainId() == null) {
-				end = map.getLast();
-			} else {
-				end = map.getLast(rr.getChainId());
-			}
+			end = map.getLast(chain);
 		}
 
+		// Replace '_'
+		start.setChainId(chain);
+		end.setChainId(chain);
+		
 		// now use those to calculate the length
 		// if start or end is null, will throw NPE
 		int length = map.calcLength(start, end);
 
-		// to avoid confusing the user, don't add the start and end if they weren't specified in the string s
-		return new ResidueRangeAndLength(rr.getChainId(), start, end, length);
+		return new ResidueRangeAndLength(chain, start, end, length);
 	}
 
 	public static List<ResidueRangeAndLength> parseMultiple(List<String> ranges, AtomPositionMap map) {

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/ResidueRangeAndLength.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/ResidueRangeAndLength.java
@@ -98,7 +98,7 @@ public class ResidueRangeAndLength extends ResidueRange {
 		
 		// now use those to calculate the length
 		// if start or end is null, will throw NPE
-		int length = map.calcLength(start, end);
+		int length = map.getLength(start, end);
 
 		return new ResidueRangeAndLength(chain, start, end, length);
 	}

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/StructureTools.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/StructureTools.java
@@ -117,23 +117,6 @@ public class StructureTools {
 	//	private static  SymbolTokenization oneLetter ;
 
 
-	/**
-	 * Pattern to describe subranges. Matches "A", "A:", "A:7-53","A_7-53", etc.
-	 * @see #getSubRanges(Structure, String)
-	 */
-	public static final Pattern pdbNumRangeRegex = Pattern.compile(
-			"^\\s*(\\w)" + //chain ID
-					"(?:" + //begin range, this is a "non-capturing group"
-					"(?::|_|:$|_$|$)" + //colon or underscore, could be at the end of a line, another non-capt. group.
-					"(?:"+ // another non capturing group for the residue range
-					"([-+]?[0-9]+[A-Za-z]?)" + // first residue
-					"\\s*-\\s*" + // -
-					"([-+]?[0-9]+[A-Za-z]?)" + // second residue
-					")?+"+
-					")?" + //end range
-			"\\s*");
-
-
 	static {
 		nucleotides30 = new HashMap<String,Integer>();
 		nucleotides30.put("DA",1);
@@ -916,7 +899,7 @@ public class StructureTools {
 
 			// Match a single range, eg "A_4-27"
 
-			Matcher matcher = pdbNumRangeRegex.matcher(r);
+			Matcher matcher = ResidueRange.RANGE_REGEX.matcher(r);
 			if( ! matcher.matches() ){
 				throw new StructureException("wrong range specification, should be provided as chainID_pdbResnum1-pdbRensum2: "+ranges);
 			}

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/align/ce/CECPParameters.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/align/ce/CECPParameters.java
@@ -33,9 +33,7 @@ public class CECPParameters extends CeParameters {
 	
 	public CECPParameters() {
 		super();
-		duplicationHint = DuplicationHint.SHORTER;
-		minCPLength = DEFAULT_MIN_CP_LENGTH;
-		setMaxGapSize(0);
+		// super calls reset();
 	}
 
 	@Override

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/io/PDBFileParser.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/io/PDBFileParser.java
@@ -2723,6 +2723,7 @@ COLUMNS   DATA TYPE         FIELD          DEFINITION
 		atomCount = 0;
 		atomOverflow = false;
 		linkRecords = new ArrayList<LinkRecord>();
+		siteToResidueMap.clear();
 
 		parseCAonly = params.isParseCAOnly();
 

--- a/biojava3-structure/src/main/java/org/biojava/bio/structure/io/mmcif/chem/ResidueType.java
+++ b/biojava3-structure/src/main/java/org/biojava/bio/structure/io/mmcif/chem/ResidueType.java
@@ -72,6 +72,12 @@ public enum ResidueType implements Serializable {
    public final PolymerType polymerType;
 
    /**
+    * Gets the associated PolymerType, which are less specific
+    * @return
+    */
+   public PolymerType getPolymerType() {return polymerType;}
+   
+   /**
     * String value of the type
     */
    public final String chem_comp_type;

--- a/biojava3-structure/src/test/java/org/biojava/bio/structure/AtomPositionMapTest.java
+++ b/biojava3-structure/src/test/java/org/biojava/bio/structure/AtomPositionMapTest.java
@@ -66,7 +66,7 @@ public class AtomPositionMapTest {
 		for (ResidueNumber n : navMap.keySet()) {
 			assertEquals("An element is missing", map.getPosition(n).intValue(), navMap.get(n).intValue());
 		}
-		int realLength = map.calcLength(start, end);
+		int realLength = map.getLength(start, end);
 		assertEquals("Real atom length is wrong", length, realLength);
 	}
 
@@ -89,86 +89,86 @@ public class AtomPositionMapTest {
 		// Single residue
 		start = 0;
 		end = 0;
-		len = map.calcLength(new ResidueNumber("A",start+1,null), new ResidueNumber("A",end+1,null));
+		len = map.getLength(new ResidueNumber("A",start+1,null), new ResidueNumber("A",end+1,null));
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
-		len = map.calcLength(start, end,"A");
+		len = map.getLength(start, end,"A");
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
-		len = map.calcLengthDirectional(start, end, "A");
+		len = map.getLengthDirectional(start, end, "A");
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
-		len = map.calcLengthDirectional(end, start, "A");
+		len = map.getLengthDirectional(end, start, "A");
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
 
 		// Short range
 		start = 2;
 		end = 4;
-		len = map.calcLength(new ResidueNumber("A",start+1,null), new ResidueNumber("A",end+1,null));
+		len = map.getLength(new ResidueNumber("A",start+1,null), new ResidueNumber("A",end+1,null));
 		assertEquals("Bad length for ("+start+","+end+")",3, len);
-		len = map.calcLength(start, end,"A");
+		len = map.getLength(start, end,"A");
 		assertEquals("Bad length for ("+start+","+end+")",3, len);
-		len = map.calcLengthDirectional(start, end, "A");
+		len = map.getLengthDirectional(start, end, "A");
 		assertEquals("Bad length for ("+start+","+end+")",3, len);
-		len = map.calcLengthDirectional(end, start, "A");
+		len = map.getLengthDirectional(end, start, "A");
 		assertEquals("Bad length for ("+start+","+end+")",-3, len);
 
 		//Full chain
 		start = 0;
 		end = chainAlen-1;
-		len = map.calcLength(new ResidueNumber("A",start+1,null), new ResidueNumber("A",end+1,null));
+		len = map.getLength(new ResidueNumber("A",start+1,null), new ResidueNumber("A",end+1,null));
 		assertEquals("Bad length for ("+start+","+end+")",chainAlen, len);
-		len = map.calcLength(start, end,"A");
+		len = map.getLength(start, end,"A");
 		assertEquals("Bad length for ("+start+","+end+")",chainAlen, len);
-		len = map.calcLengthDirectional(start, end, "A");
+		len = map.getLengthDirectional(start, end, "A");
 		assertEquals("Bad length for ("+start+","+end+")",chainAlen, len);
-		len = map.calcLengthDirectional(end, start, "A");
+		len = map.getLengthDirectional(end, start, "A");
 		assertEquals("Bad length for ("+start+","+end+")",-chainAlen, len);
 
 		// Chain spanning
 		start = chainAlen-1;
 		end = chainAlen;
 		try {
-			len = map.calcLength(new ResidueNumber("A",chainAlen,null), new ResidueNumber("B",1,null));
+			len = map.getLength(new ResidueNumber("A",chainAlen,null), new ResidueNumber("B",1,null));
 			fail("Not the same chain");
 		} catch( IllegalArgumentException e) {}
-		len = map.calcLength(start, end,"A");
+		len = map.getLength(start, end,"A");
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
-		len = map.calcLengthDirectional(start, end, "A");
+		len = map.getLengthDirectional(start, end, "A");
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
-		len = map.calcLengthDirectional(end, start, "A");
+		len = map.getLengthDirectional(end, start, "A");
 		assertEquals("Bad length for ("+start+","+end+")",-1, len);
-		len = map.calcLengthDirectional(start,end, "B");
+		len = map.getLengthDirectional(start,end, "B");
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
 		
 		start = chainAlen-2; //2 residues of A
 		end = chainAlen+2; // 3 residues of B
-		len = map.calcLengthDirectional(start, end, "A");
+		len = map.getLengthDirectional(start, end, "A");
 		assertEquals("Bad length for ("+start+","+end+")",2, len);
-		len = map.calcLengthDirectional(end, start, "A");
+		len = map.getLengthDirectional(end, start, "A");
 		assertEquals("Bad length for ("+start+","+end+")",-2, len);
-		len = map.calcLengthDirectional(start, end, "B");
+		len = map.getLengthDirectional(start, end, "B");
 		assertEquals("Bad length for ("+start+","+end+")",3, len);
-		len = map.calcLengthDirectional(end, start, "B");
+		len = map.getLengthDirectional(end, start, "B");
 		assertEquals("Bad length for ("+start+","+end+")",-3, len);
 
 		start = 0;
 		end = chainAlen;
 		try {
-			len = map.calcLength(new ResidueNumber("A",start+1,null), new ResidueNumber("A",end+1,null));
+			len = map.getLength(new ResidueNumber("A",start+1,null), new ResidueNumber("A",end+1,null));
 			fail("Residue found from the wrong chain");
 		} catch( IllegalArgumentException e) {
 			// end residue should be B1, not A142
 		}
 		// Chain Spanning
-		len = map.calcLength(start, end,"B");
+		len = map.getLength(start, end,"B");
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
-		len = map.calcLengthDirectional(start, end, "B");
+		len = map.getLengthDirectional(start, end, "B");
 		assertEquals("Bad length for ("+start+","+end+")",1, len);
-		len = map.calcLengthDirectional(end, start, "B");
+		len = map.getLengthDirectional(end, start, "B");
 		assertEquals("Bad length for ("+start+","+end+")",-1, len);
-		len = map.calcLength(start, end,"A");
+		len = map.getLength(start, end,"A");
 		assertEquals("Bad length for ("+start+","+end+")",chainAlen, len);
-		len = map.calcLengthDirectional(start, end, "A");
+		len = map.getLengthDirectional(start, end, "A");
 		assertEquals("Bad length for ("+start+","+end+")",chainAlen, len);
-		len = map.calcLengthDirectional(end, start, "A");
+		len = map.getLengthDirectional(end, start, "A");
 		assertEquals("Bad length for ("+start+","+end+")",-chainAlen, len);
 	}
 
@@ -196,12 +196,12 @@ public class AtomPositionMapTest {
 		ResidueNumber start = new ResidueNumber("A", 246, null);
 		ResidueNumber mid = new ResidueNumber("A", 85, 'S');
 		ResidueNumber end = new ResidueNumber("A", 300, null);
-		int realLength1 = map.calcLength(start, mid);
+		int realLength1 = map.getLength(start, mid);
 		assertEquals("Real atom length is wrong", length1, realLength1);
-		int realLength2 = map.calcLength(start, end);
+		int realLength2 = map.getLength(start, end);
 		assertEquals("Real atom length is wrong", length2, realLength2);
 		
-		int realLength = map.calcLength(new ResidueNumber("A",6,'P'),new ResidueNumber("A",338,null));
+		int realLength = map.getLength(new ResidueNumber("A",6,'P'),new ResidueNumber("A",338,null));
 		assertEquals("Full length wrong",430,realLength);
 	}
 
@@ -215,7 +215,7 @@ public class AtomPositionMapTest {
 		try {
 			start = new ResidueNumber("A",6,'P');
 			end = new ResidueNumber("B",338,null);
-			map.calcLength(start, end);
+			map.getLength(start, end);
 			fail("Chain missmatch");
 		} catch(IllegalArgumentException e) {
 			// Expected
@@ -223,7 +223,7 @@ public class AtomPositionMapTest {
 		try {
 			start = new ResidueNumber("A",6,'P');
 			end = new ResidueNumber("B",338,null);
-			map.calcLengthDirectional(start, end);
+			map.getLengthDirectional(start, end);
 			fail("Chain missmatch");
 		} catch(IllegalArgumentException e) {
 			// Expected
@@ -232,7 +232,7 @@ public class AtomPositionMapTest {
 		// With integers, only count matching chain atoms
 		start = new ResidueNumber("A",338,null);
 		end = new ResidueNumber("B",6,'P');
-		int len = map.calcLength(map.getPosition(start),map.getPosition(end),"A");
+		int len = map.getLength(map.getPosition(start),map.getPosition(end),"A");
 		assertEquals(1, len);
 	}
 }

--- a/biojava3-structure/src/test/java/org/biojava/bio/structure/ResidueRangeTest.java
+++ b/biojava3-structure/src/test/java/org/biojava/bio/structure/ResidueRangeTest.java
@@ -111,6 +111,16 @@ public class ResidueRangeTest {
 	}
 	
 	@Test
+	public void testLengths() throws IOException, StructureException {
+		String pdbId = "1w0p";
+		String rangeStr = "A:25-26";
+		Atom[] atoms = cache.getAtoms(pdbId);
+		AtomPositionMap map = new AtomPositionMap(atoms);
+		ResidueRangeAndLength range = ResidueRangeAndLength.parse(rangeStr, map);
+		assertEquals(2,range.getLength());
+	}
+	
+	@Test
 	public void testIterator() throws IOException, StructureException {
 		String pdbId = "2eke";
 		String[] expected = new String[] {"C_1023", "C_1024", "C_1025", "C_1026", "C_1027", "C_1028", "C_1029", "C_1030", "C_1031", "C_1032", "C_1033", "C_1034", "C_1035", "C_1036", "C_1037", "C_1038", "C_1039", "C_1040", "C_1041", "C_1042", "C_1043", "C_1044", "C_1045", "C_1046", "C_1047", "C_1048", "C_1049", "C_1050", "C_1051", "C_1052", "C_1053", "C_1054", "C_1055", "C_1056", "C_1057", "C_1058", "C_1059", "C_1060", "C_1061", "C_1062", "C_1063"};

--- a/biojava3-structure/src/test/java/org/biojava/bio/structure/ResidueRangeTest.java
+++ b/biojava3-structure/src/test/java/org/biojava/bio/structure/ResidueRangeTest.java
@@ -179,14 +179,23 @@ public class ResidueRangeTest {
 	}
 	
 	@Test
-	public void testLooksLikeRange() {
-		String[] yes = new String[] {"A_", "A:", "ABC:", "abc:", "A_5-100", "A_5-100S", "A_5S-100", "A_5S-100S", "A_-5-100", "A_-5--100", "A_-5S--100S", "ABC:-5--200S"};
+	public void testRangeRegex() {
+		// Valid ranges
+		String[] yes = new String[] {"A_", "A:", "ABC:", "abc:", "A_5-100",
+				"A_5-100S", "A_5S-100", "A_5S-100S", "A_-5-100", "A_-5--100",
+				"A_-5S--100S", "ABC:-5--200S",
+				"A","ABCD","A1", //valid multi-char chain name
+				"3A:1-100", // Weird chain name
+				"_","_:1-10","__-2--1", "__"//catch-all chain
+				};
 		for (String s : yes) {
-			assertTrue(s + " was not considered a valid range format", ResidueRange.looksLikeRange(s));
+			assertTrue(s + " was not considered a valid range format", ResidueRange.RANGE_REGEX.matcher(s).matches());
 		}
-		String[] no = new String[] {"A", "A1", "A_1", "A_1-", "A_1S-", "A_1-100-", "A_-10-1000_", "", "3A:1-100"};
+		// invalid ranges
+		String[] no = new String[] { "A_1", "A_1-", "A_1S-", "A_1-100-",
+				"A_-10-1000_", "","-","___","__:"};
 		for (String s : no) {
-			assertFalse(s + " was considered a valid range format", ResidueRange.looksLikeRange(s));
+			assertFalse(s + " was considered a valid range format", ResidueRange.RANGE_REGEX.matcher(s).matches());
 		}
 	}
 	

--- a/biojava3-structure/src/test/java/org/biojava/bio/structure/ResidueRangeTest.java
+++ b/biojava3-structure/src/test/java/org/biojava/bio/structure/ResidueRangeTest.java
@@ -49,7 +49,7 @@ public class ResidueRangeTest {
 	@Before
 	public void setUp() throws Exception {
 		cache = new AtomCache(); // TODO Should mock instead of depending on
-									// real data from AtomCache
+		// real data from AtomCache
 		cache.setObsoleteBehavior(ObsoleteBehavior.FETCH_OBSOLETE);
 	}
 
@@ -64,7 +64,7 @@ public class ResidueRangeTest {
 
 	@Test
 	public void testPartialChainWithMap() throws IOException,
-			StructureException {
+	StructureException {
 		String pdbId = "1cph";
 		AtomPositionMap map = new AtomPositionMap(cache.getAtoms(pdbId));
 		String range = "B:1-30";
@@ -93,8 +93,8 @@ public class ResidueRangeTest {
 	@Test
 	public void testWithLengths() throws IOException, StructureException {
 		String[] ids = new String[] { "1w0p", "3qq3", "3chc", "2ei7" }; // more:
-																		// ,
-																		// "2qbr"
+		// ,
+		// "2qbr"
 		String[] chains = new String[] { "A", "B", "A", "L" };
 		ResidueNumber[] starts = new ResidueNumber[] {
 				new ResidueNumber("A", 5, ' '),
@@ -265,7 +265,7 @@ public class ResidueRangeTest {
 	 */
 	@Test
 	public void testParseAndEqualWithLengths() throws IOException,
-			StructureException {
+	StructureException {
 		String rangeStr;
 		List<ResidueRangeAndLength> ranges;
 		ResidueRangeAndLength range;
@@ -285,6 +285,31 @@ public class ResidueRangeTest {
 		assertEquals(new ResidueRangeAndLength("C", new ResidueNumber("C", 105,
 				null), new ResidueNumber("C", 1095, null), 91), ranges.get(2));
 
+		// Wildcard chains
+
+		pdbId = "4r61"; // A:8-52,58-109,119-161
+		map = new AtomPositionMap(cache.getAtoms(pdbId));
+		rangeStr = "_,__,_:52-58";
+		ranges = ResidueRangeAndLength.parseMultiple(rangeStr, map);
+		range = ranges.get(0);
+		assertEquals("Error parsing " + rangeStr, "A", range.getChainId());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("A",8,null),range.getStart());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("A",161,null),range.getEnd());
+		range = ranges.get(1);
+		assertEquals("Error parsing " + rangeStr, "A", range.getChainId());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("A",8,null),range.getStart());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("A",161,null),range.getEnd());
+		range = ranges.get(2);
+		assertEquals("Error parsing " + rangeStr, "A", range.getChainId());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("A", 52,null), range.getStart());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("A", 58,null), range.getEnd());
+
+		// wildcards not converted without the map
+		ResidueRange range2 = ResidueRange.parse("_");
+		assertEquals("Error parsing " + rangeStr, "_", range2.getChainId());
+		assertNull("Error parsing " + rangeStr,range2.getStart());
+		assertNull("Error parsing " + rangeStr,range2.getEnd());
+
 	}
 
 	@Test
@@ -293,9 +318,9 @@ public class ResidueRangeTest {
 		String[] yes = new String[] { "A_", "A:", "ABC:", "abc:", "A_5-100",
 				"A_5-100S", "A_5S-100", "A_5S-100S", "A_-5-100", "A_-5--100",
 				"A_-5S--100S", "ABC:-5--200S", "A", "ABCD", "A1", // valid
-																	// multi-char
-																	// chain
-																	// name
+				// multi-char
+				// chain
+				// name
 				"3A:1-100", // Weird chain name
 				"_", "_:1-10", "__-2--1", "__"// catch-all chain
 		};

--- a/biojava3-structure/src/test/java/org/biojava/bio/structure/ResidueRangeTest.java
+++ b/biojava3-structure/src/test/java/org/biojava/bio/structure/ResidueRangeTest.java
@@ -24,6 +24,7 @@
 package org.biojava.bio.structure;
 
 import org.biojava.bio.structure.align.util.AtomCache;
+import org.biojava.bio.structure.io.LocalPDBDirectory.FetchBehavior;
 import org.biojava.bio.structure.io.LocalPDBDirectory.ObsoleteBehavior;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,23 +34,22 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * A unit test for {@link ResidueRange}.
+ * 
  * @author dmyerstu
  *
  */
 public class ResidueRangeTest {
 
 	private AtomCache cache;
-	
+
 	@Before
 	public void setUp() throws Exception {
-		cache = new AtomCache(); // TODO Should mock instead of depending on real data from AtomCache
+		cache = new AtomCache(); // TODO Should mock instead of depending on
+									// real data from AtomCache
 		cache.setObsoleteBehavior(ObsoleteBehavior.FETCH_OBSOLETE);
 	}
 
@@ -63,7 +63,8 @@ public class ResidueRangeTest {
 	}
 
 	@Test
-	public void testPartialChainWithMap() throws IOException, StructureException {
+	public void testPartialChainWithMap() throws IOException,
+			StructureException {
 		String pdbId = "1cph";
 		AtomPositionMap map = new AtomPositionMap(cache.getAtoms(pdbId));
 		String range = "B:1-30";
@@ -82,8 +83,8 @@ public class ResidueRangeTest {
 		String range = "B:";
 		ResidueRange rr = ResidueRangeAndLength.parse(range, map);
 		assertEquals("Wrong chain Id", "B", rr.getChainId());
-		assertNull("Wrong start", rr.getStart());
-		assertNull("Wrong end", rr.getEnd());
+		assertEquals("Wrong start", new ResidueNumber("B",1,null),rr.getStart());
+		assertEquals("Wrong end", new ResidueNumber("B",30,null),rr.getEnd());
 	}
 
 	/**
@@ -91,55 +92,89 @@ public class ResidueRangeTest {
 	 */
 	@Test
 	public void testWithLengths() throws IOException, StructureException {
-		String[] ids = new String[] {"1w0p", "3qq3", "3chc", "2ei7"}; // more: , "2qbr"
-		String[] chains = new String[] {"A", "B", "A", "L"};
-		ResidueNumber[] starts = new ResidueNumber[] {new ResidueNumber("A", 5, ' '), new ResidueNumber("B", 10, 's'), new ResidueNumber("A", 15, 'm'), new ResidueNumber("L", 44, ' ')};
-		ResidueNumber[] ends = new ResidueNumber[] {new ResidueNumber("A", 117, ' '), new ResidueNumber("B", 200, 's'), new ResidueNumber("A", 464, 'q'), new ResidueNumber("L", 254, 't')};
-		int[] lengths = new int[] {117-5, 200-10, 111, 55};
+		String[] ids = new String[] { "1w0p", "3qq3", "3chc", "2ei7" }; // more:
+																		// ,
+																		// "2qbr"
+		String[] chains = new String[] { "A", "B", "A", "L" };
+		ResidueNumber[] starts = new ResidueNumber[] {
+				new ResidueNumber("A", 5, ' '),
+				new ResidueNumber("B", 10, 's'),
+				new ResidueNumber("A", 15, 'm'),
+				new ResidueNumber("L", 44, ' ') };
+		ResidueNumber[] ends = new ResidueNumber[] {
+				new ResidueNumber("A", 117, ' '),
+				new ResidueNumber("B", 200, 's'),
+				new ResidueNumber("A", 464, 'q'),
+				new ResidueNumber("L", 254, 't') };
+		int[] lengths = new int[] { 117 - 5, 200 - 10, 111, 55 };
 		int totalLength = 0;
-		List<ResidueRangeAndLength> ranges = new ArrayList<ResidueRangeAndLength>(ids.length);
+		List<ResidueRangeAndLength> ranges = new ArrayList<ResidueRangeAndLength>(
+				ids.length);
 		for (int i = 0; i < ids.length; i++) {
-			ResidueRangeAndLength rr = new ResidueRangeAndLength(chains[i], starts[i], ends[i], lengths[i]);
+			ResidueRangeAndLength rr = new ResidueRangeAndLength(chains[i],
+					starts[i], ends[i], lengths[i]);
 			assertEquals("The chain is incorrect", chains[i], rr.getChainId());
 			assertEquals("The start is incorrect", starts[i], rr.getStart());
 			assertEquals("The end is incorrect", ends[i], rr.getEnd());
 			assertEquals("The length is incorrect", lengths[i], rr.getLength());
 			ranges.add(rr);
 			totalLength += lengths[i];
-			assertEquals("Total length is wrong", totalLength, ResidueRangeAndLength.calcLength(ranges));
+			assertEquals("Total length is wrong", totalLength,
+					ResidueRangeAndLength.calcLength(ranges));
 		}
 	}
-	
+
 	@Test
 	public void testLengths() throws IOException, StructureException {
 		String pdbId = "1w0p";
 		String rangeStr = "A:25-26";
 		Atom[] atoms = cache.getAtoms(pdbId);
 		AtomPositionMap map = new AtomPositionMap(atoms);
-		ResidueRangeAndLength range = ResidueRangeAndLength.parse(rangeStr, map);
-		assertEquals(2,range.getLength());
+		ResidueRangeAndLength range = ResidueRangeAndLength
+				.parse(rangeStr, map);
+		assertEquals(2, range.getLength());
 	}
-	
+
 	@Test
 	public void testIterator() throws IOException, StructureException {
 		String pdbId = "2eke";
-		String[] expected = new String[] {"C_1023", "C_1024", "C_1025", "C_1026", "C_1027", "C_1028", "C_1029", "C_1030", "C_1031", "C_1032", "C_1033", "C_1034", "C_1035", "C_1036", "C_1037", "C_1038", "C_1039", "C_1040", "C_1041", "C_1042", "C_1043", "C_1044", "C_1045", "C_1046", "C_1047", "C_1048", "C_1049", "C_1050", "C_1051", "C_1052", "C_1053", "C_1054", "C_1055", "C_1056", "C_1057", "C_1058", "C_1059", "C_1060", "C_1061", "C_1062", "C_1063"};
+		String[] expected = new String[] { "C_1023", "C_1024", "C_1025",
+				"C_1026", "C_1027", "C_1028", "C_1029", "C_1030", "C_1031",
+				"C_1032", "C_1033", "C_1034", "C_1035", "C_1036", "C_1037",
+				"C_1038", "C_1039", "C_1040", "C_1041", "C_1042", "C_1043",
+				"C_1044", "C_1045", "C_1046", "C_1047", "C_1048", "C_1049",
+				"C_1050", "C_1051", "C_1052", "C_1053", "C_1054", "C_1055",
+				"C_1056", "C_1057", "C_1058", "C_1059", "C_1060", "C_1061",
+				"C_1062", "C_1063" };
 		ResidueRange rr = ResidueRange.parse("C_1023-1063");
 		AtomPositionMap map = new AtomPositionMap(cache.getAtoms(pdbId));
 		Iterator<ResidueNumber> iter = rr.iterator(map);
 		int i = 0;
 		while (iter.hasNext()) {
 			ResidueNumber rn = iter.next();
+			assertTrue(i<expected.length);
 			assertEquals(expected[i], rn.printFull());
 			i++;
 		}
+		assertEquals(expected.length,i);
 	}
 
 	@Test
 	public void testMultiIterator() throws IOException, StructureException {
 		String pdbId = "1qdm";
-		String[] expected = new String[] {"A_3S", "A_4S", "A_5S", "A_6S", "A_7S", "A_8S", "A_9S", "A_10S", "A_11S", "A_12S", "A_13S", "A_14S", "A_15S", "A_16S", "A_17S", "A_18S", "A_19S", "A_20S", "A_21S", "A_22S", "A_23S", "A_24S", "A_25S", "A_26S", "A_27S", "A_28S", "A_29S", "A_30S", "A_31S", "A_32S", "A_33S", "A_34S", "A_35S", "A_36S", "A_37S", "A_65S", "A_66S", "A_67S", "A_68S", "A_69S", "A_70S", "A_71S", "A_72S", "A_73S", "A_74S", "A_75S", "A_76S", "A_77S", "A_78S", "A_79S", "A_80S", "A_81S", "A_82S", "A_83S", "A_84S", "A_85S", "A_86S", "A_87S", "A_88S", "A_89S", "A_90S", "A_91S", "A_92S", "A_93S", "A_94S", "A_95S", "A_96S", "A_97S", "A_98S", "A_99S"};
-		List<ResidueRange> rrs = ResidueRange.parseMultiple("A_3S-37S,A_65S-99S");
+		String[] expected = new String[] { "A_3S", "A_4S", "A_5S", "A_6S",
+				"A_7S", "A_8S", "A_9S", "A_10S", "A_11S", "A_12S", "A_13S",
+				"A_14S", "A_15S", "A_16S", "A_17S", "A_18S", "A_19S", "A_20S",
+				"A_21S", "A_22S", "A_23S", "A_24S", "A_25S", "A_26S", "A_27S",
+				"A_28S", "A_29S", "A_30S", "A_31S", "A_32S", "A_33S", "A_34S",
+				"A_35S", "A_36S", "A_37S", "A_65S", "A_66S", "A_67S", "A_68S",
+				"A_69S", "A_70S", "A_71S", "A_72S", "A_73S", "A_74S", "A_75S",
+				"A_76S", "A_77S", "A_78S", "A_79S", "A_80S", "A_81S", "A_82S",
+				"A_83S", "A_84S", "A_85S", "A_86S", "A_87S", "A_88S", "A_89S",
+				"A_90S", "A_91S", "A_92S", "A_93S", "A_94S", "A_95S", "A_96S",
+				"A_97S", "A_98S", "A_99S" };
+		List<ResidueRange> rrs = ResidueRange
+				.parseMultiple("A_3S-37S,A_65S-99S");
 		AtomPositionMap map = new AtomPositionMap(cache.getAtoms(pdbId));
 		Iterator<ResidueNumber> iter = ResidueRange.multiIterator(map, rrs);
 		int i = 0;
@@ -149,64 +184,132 @@ public class ResidueRangeTest {
 			i++;
 		}
 	}
-	
+
 	/**
 	 * Tests {@link ResidueRange#parseMultiple(String)}.
 	 */
 	@Test
 	public void testParseAndEqual() {
+		String rangeStr;
+		List<ResidueRange> ranges;
+		ResidueRange range;
 
-		//String pdbId1 = "2eke";
-		String string1 = "C_1023-1063,C_1064-1084";
-		List<ResidueRange> list1 = ResidueRange.parseMultiple(string1);
-		assertEquals(new ResidueRange("C", new ResidueNumber("C", 1023, null), new ResidueNumber("C", 1063, null)), list1.get(0));
-		assertEquals(new ResidueRange("C", new ResidueNumber("C", 1064, null), new ResidueNumber("C", 1084, null)), list1.get(1));
+		// String pdbId1 = "2eke";
+		rangeStr = "C_1023-1063,C_1064-1084";
+		ranges = ResidueRange.parseMultiple(rangeStr);
+		assertEquals(new ResidueRange("C", new ResidueNumber("C", 1023, null),
+				new ResidueNumber("C", 1063, null)), ranges.get(0));
+		assertEquals(new ResidueRange("C", new ResidueNumber("C", 1064, null),
+				new ResidueNumber("C", 1084, null)), ranges.get(1));
 
-		//String pdbId = "1qdm";
-		String string2 = "A_3S-37S,A_65S-99S";
-		List<ResidueRange> list2 = ResidueRange.parseMultiple(string2);
-		assertEquals(new ResidueRange("A", new ResidueNumber("A", 3, 'S'), new ResidueNumber("A", 37, 'S')), list2.get(0));
-		assertEquals(new ResidueRange("A", new ResidueNumber("A", 65, 'S'), new ResidueNumber("A", 99, 'S')), list2.get(1));
+		// String pdbId = "1qdm";
+		rangeStr = "A_3S-37S,A_65S-99S";
+		ranges = ResidueRange.parseMultiple(rangeStr);
+		assertEquals(new ResidueRange("A", new ResidueNumber("A", 3, 'S'),
+				new ResidueNumber("A", 37, 'S')), ranges.get(0));
+		assertEquals(new ResidueRange("A", new ResidueNumber("A", 65, 'S'),
+				new ResidueNumber("A", 99, 'S')), ranges.get(1));
+
+		// Multi-character chains
+		rangeStr = "AB,A1,ABCD_1-55,NotAG00dID:-5-1R";
+		ranges = ResidueRange.parseMultiple(rangeStr);
+		range = ranges.get(0);
+		assertEquals("Error parsing " + rangeStr, "AB", range.getChainId());
+		assertNull("Error parsing " + rangeStr, range.getStart());
+		assertNull("Error parsing " + rangeStr, range.getEnd());
+		range = ranges.get(1);
+		assertEquals("Error parsing " + rangeStr, "A1", range.getChainId());
+		assertNull("Error parsing " + rangeStr, range.getStart());
+		assertNull("Error parsing " + rangeStr, range.getEnd());
+		range = ranges.get(2);
+		assertEquals("Error parsing " + rangeStr, "ABCD", range.getChainId());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("ABCD", 1,
+				null), range.getStart());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("ABCD", 55,
+				null), range.getEnd());
+		range = ranges.get(3);
+		assertEquals("Error parsing " + rangeStr, "NotAG00dID",
+				range.getChainId());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber(
+				"NotAG00dID", -5, null), range.getStart());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber(
+				"NotAG00dID", 1, 'R'), range.getEnd());
+
+		// Wildcard chains
+		rangeStr = "_,__,_:1-5";
+		ranges = ResidueRange.parseMultiple(rangeStr);
+		range = ranges.get(0);
+		assertEquals("Error parsing " + rangeStr, "_", range.getChainId());
+		assertNull("Error parsing " + rangeStr, range.getStart());
+		assertNull("Error parsing " + rangeStr, range.getEnd());
+		range = ranges.get(1);
+		assertEquals("Error parsing " + rangeStr, "_", range.getChainId());
+		assertNull("Error parsing " + rangeStr, range.getStart());
+		assertNull("Error parsing " + rangeStr, range.getEnd());
+		range = ranges.get(2);
+		assertEquals("Error parsing " + rangeStr, "_", range.getChainId());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("_", 1,
+				null), range.getStart());
+		assertEquals("Error parsing " + rangeStr, new ResidueNumber("_", 5,
+				null), range.getEnd());
+
 	}
 
 	/**
-	 * Tests {@link org.biojava.bio.structure.ResidueRangeAndLength#parseMultiple(String, org.biojava.bio.structure.AtomPositionMap)}.
-	 * @throws StructureException 
-	 * @throws IOException 
+	 * Tests
+	 * {@link org.biojava.bio.structure.ResidueRangeAndLength#parseMultiple(String, org.biojava.bio.structure.AtomPositionMap)}
+	 * .
+	 * 
+	 * @throws StructureException
+	 * @throws IOException
 	 */
 	@Test
-	public void testParseAndEqualWithLengths() throws IOException, StructureException {
+	public void testParseAndEqualWithLengths() throws IOException,
+			StructureException {
+		String rangeStr;
+		List<ResidueRangeAndLength> ranges;
+		ResidueRangeAndLength range;
 
 		AtomPositionMap map;
-		
-		String pdbId1 = "2eke";
-		map = new AtomPositionMap(cache.getAtoms(pdbId1));
-		String string1 = "C_1023-1063,C_1064-1084";
-		List<ResidueRangeAndLength> list1 = ResidueRangeAndLength.parseMultiple(string1, map);
-		assertEquals(new ResidueRangeAndLength("C", new ResidueNumber("C", 1023, null), new ResidueNumber("C", 1063, null), 1063-1023), list1.get(0));
-		assertEquals(new ResidueRangeAndLength("C", new ResidueNumber("C", 1064, null), new ResidueNumber("C", 1084, null), 1084-1064), list1.get(1));
+
+		String pdbId = "2eke";
+		map = new AtomPositionMap(cache.getAtoms(pdbId));
+		rangeStr = "C_1023-1063,C_1064-1084,C";//C is 105-112,1013-1095
+		ranges = ResidueRangeAndLength.parseMultiple(rangeStr, map);
+		assertEquals(new ResidueRangeAndLength("C", new ResidueNumber("C",
+				1023, null), new ResidueNumber("C", 1063, null), 1063 - 1023+1),
+				ranges.get(0));
+		assertEquals(new ResidueRangeAndLength("C", new ResidueNumber("C",
+				1064, null), new ResidueNumber("C", 1084, null), 1084 - 1064+1),
+				ranges.get(1));
+		assertEquals(new ResidueRangeAndLength("C", new ResidueNumber("C", 105,
+				null), new ResidueNumber("C", 1095, null), 91), ranges.get(2));
 
 	}
-	
+
 	@Test
 	public void testRangeRegex() {
 		// Valid ranges
-		String[] yes = new String[] {"A_", "A:", "ABC:", "abc:", "A_5-100",
+		String[] yes = new String[] { "A_", "A:", "ABC:", "abc:", "A_5-100",
 				"A_5-100S", "A_5S-100", "A_5S-100S", "A_-5-100", "A_-5--100",
-				"A_-5S--100S", "ABC:-5--200S",
-				"A","ABCD","A1", //valid multi-char chain name
+				"A_-5S--100S", "ABC:-5--200S", "A", "ABCD", "A1", // valid
+																	// multi-char
+																	// chain
+																	// name
 				"3A:1-100", // Weird chain name
-				"_","_:1-10","__-2--1", "__"//catch-all chain
-				};
+				"_", "_:1-10", "__-2--1", "__"// catch-all chain
+		};
 		for (String s : yes) {
-			assertTrue(s + " was not considered a valid range format", ResidueRange.RANGE_REGEX.matcher(s).matches());
+			assertTrue(s + " was not considered a valid range format",
+					ResidueRange.RANGE_REGEX.matcher(s).matches());
 		}
 		// invalid ranges
 		String[] no = new String[] { "A_1", "A_1-", "A_1S-", "A_1-100-",
-				"A_-10-1000_", "","-","___","__:"};
+				"A_-10-1000_", "", "-", "___", "__:" };
 		for (String s : no) {
-			assertFalse(s + " was considered a valid range format", ResidueRange.RANGE_REGEX.matcher(s).matches());
+			assertFalse(s + " was considered a valid range format",
+					ResidueRange.RANGE_REGEX.matcher(s).matches());
 		}
 	}
-	
+
 }

--- a/biojava3-structure/src/test/java/org/biojava/bio/structure/align/util/AtomCacheTest.java
+++ b/biojava3-structure/src/test/java/org/biojava/bio/structure/align/util/AtomCacheTest.java
@@ -93,9 +93,8 @@ public class AtomCacheTest {
 		assertEquals(2, structure.getChains().size());
 		Chain a = structure.getChainByPDB("A");
 		Chain b = structure.getChainByPDB("B");
-		// we're one off because getAtomGroups().size() includes the last Group
-		assertEquals(expectedLengthA, a.getAtomGroups().size()-1);
-		assertEquals(expectedLengthB, b.getAtomGroups().size()-1);
+		assertEquals(expectedLengthA, a.getAtomGroups().size());
+		assertEquals(expectedLengthB, b.getAtomGroups().size());
 	}
 
 	/**
@@ -113,9 +112,8 @@ public class AtomCacheTest {
 		assertEquals(2, structure.getChains().size());
 		Chain a = structure.getChainByPDB("A");
 		Chain b = structure.getChainByPDB("B");
-		// we're one off because getAtomGroups().size() includes the last Group
-		assertEquals(expectedLengthA, a.getAtomGroups().size()-1);
-		assertEquals(expectedLengthB, b.getAtomGroups().size()-1);
+		assertEquals(expectedLengthA, a.getAtomGroups().size());
+		assertEquals(expectedLengthB, b.getAtomGroups().size());
 		List<Group> ligandsA = StructureTools.filterLigands(b.getAtomGroups());
 		assertEquals(0, ligandsA.size());
 		List<Group> ligandsB = StructureTools.filterLigands(b.getAtomGroups());
@@ -135,8 +133,7 @@ public class AtomCacheTest {
 		Structure structure = cache.getStructureForDomain("d1i3oe_");
 		assertEquals(1, structure.getChains().size());
 		Chain e = structure.getChainByPDB("E");
-		// we're one off because getAtomGroups().size() includes the last Group
-		assertEquals(expectedLengthE, e.getAtomGroups().size()-1);
+		assertEquals(expectedLengthE, e.getAtomGroups().size());
 		List<Group> ligandsE = StructureTools.filterLigands(e.getAtomGroups());
 		assertEquals(1, ligandsE.size());
 	}

--- a/integrationtest/src/test/java/org/biojava/structure/test/StructureToolsTest.java
+++ b/integrationtest/src/test/java/org/biojava/structure/test/StructureToolsTest.java
@@ -22,22 +22,24 @@
  */
 package org.biojava.structure.test;
 
+import static org.junit.Assume.assumeNoException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import junit.framework.TestCase;
+
 import org.biojava.bio.structure.Atom;
 import org.biojava.bio.structure.Chain;
+import org.biojava.bio.structure.ResidueRange;
 import org.biojava.bio.structure.Structure;
 import org.biojava.bio.structure.StructureException;
 import org.biojava.bio.structure.StructureTools;
 import org.biojava.bio.structure.align.util.AtomCache;
 import org.biojava.bio.structure.io.FileParsingParameters;
 import org.biojava.bio.structure.io.PDBFileParser;
-import static org.junit.Assume.*;
-
-import junit.framework.TestCase;
 
 public class StructureToolsTest extends TestCase {
 
@@ -53,6 +55,7 @@ public class StructureToolsTest extends TestCase {
 		PDBFileParser pdbpars = new PDBFileParser();
 		FileParsingParameters params = new FileParsingParameters();
 		params.setAlignSeqRes(false);
+		params.setLoadChemCompInfo(false);
 
 		pdbpars.setFileParsingParameters(params);
 
@@ -79,7 +82,7 @@ public class StructureToolsTest extends TestCase {
 
 		inStream.close();
 
-		// Load structure2
+		// Load structure3
 		inStream = this.getClass().getResourceAsStream("/1a4w.pdb");
 		assertNotNull(inStream);
 
@@ -251,7 +254,7 @@ public class StructureToolsTest extends TestCase {
 	public void testStructureToolsRegexp(){
 
 
-		Pattern p =  StructureTools.pdbNumRangeRegex;
+		Pattern p =  ResidueRange.RANGE_REGEX;
 
 		String t2 = "A_10-20";
 		Matcher m2 = p.matcher(t2);

--- a/integrationtest/src/test/resources/1a4w.pdb
+++ b/integrationtest/src/test/resources/1a4w.pdb
@@ -1,6 +1,6 @@
-HEADER    COMPLEX (SERINE PROTEASE/INHIBITORS)    06-FEB-98   1A4W              
-TITLE     CRYSTAL STRUCTURES OF THROMBIN WITH THIAZOLE-CONTAINING               
-TITLE    2 INHIBITORS: PROBES OF THE S1' BINDING SITE                           
+HEADER    HYDROLASE/HYDROLASE INHIBITOR           06-FEB-98   1A4W              
+TITLE     CRYSTAL STRUCTURES OF THROMBIN WITH THIAZOLE-CONTAINING INHIBITORS:   
+TITLE    2 PROBES OF THE S1' BINDING SITE                                       
 COMPND    MOL_ID: 1;                                                            
 COMPND   2 MOLECULE: ALPHA-THROMBIN (SMALL SUBUNIT);                            
 COMPND   3 CHAIN: L;                                                            
@@ -26,26 +26,26 @@ SOURCE  10 ORGANISM_TAXID: 9606;
 SOURCE  11 ORGAN: BLOOD;                                                        
 SOURCE  12 TISSUE: BLOOD;                                                       
 SOURCE  13 MOL_ID: 3                                                            
-KEYWDS    COMPLEX (SERINE PROTEASE/INHIBITORS), BLOOD COAGULATION               
+KEYWDS    SERINE PROTEASE-INHIBITOR, BLOOD COAGULATION, HYDROLASE-HYDROLASE     
+KEYWDS   2 INHIBITOR COMPLEX                                                    
 EXPDTA    X-RAY DIFFRACTION                                                     
-AUTHOR    J.H.MATTHEWS,R.KRISHNAN,M.J.COSTANZO,B.E.MARYANOFF,                   
-AUTHOR   2 A.TULINSKY                                                           
+AUTHOR    J.H.MATTHEWS,R.KRISHNAN,M.J.COSTANZO,B.E.MARYANOFF,A.TULINSKY         
+REVDAT   3   13-JUL-11 1A4W    1       VERSN                                    
 REVDAT   2   24-FEB-09 1A4W    1       VERSN                                    
 REVDAT   1   29-APR-98 1A4W    0                                                
 JRNL        AUTH   J.H.MATTHEWS,R.KRISHNAN,M.J.COSTANZO,B.E.MARYANOFF,          
 JRNL        AUTH 2 A.TULINSKY                                                   
-JRNL        TITL   CRYSTAL STRUCTURES OF THROMBIN WITH                          
-JRNL        TITL 2 THIAZOLE-CONTAINING INHIBITORS: PROBES OF THE S1'            
-JRNL        TITL 3 BINDING SITE.                                                
+JRNL        TITL   CRYSTAL STRUCTURES OF THROMBIN WITH THIAZOLE-CONTAINING      
+JRNL        TITL 2 INHIBITORS: PROBES OF THE S1' BINDING SITE.                  
 JRNL        REF    BIOPHYS.J.                    V.  71  2830 1996              
 JRNL        REFN                   ISSN 0006-3495                               
 JRNL        PMID   8913620                                                      
 REMARK   1                                                                      
 REMARK   1 REFERENCE 1                                                          
 REMARK   1  AUTH   J.VIJAYALAKSHMI,K.P.PADMANABHAN,K.G.MANN,A.TULINSKY          
-REMARK   1  TITL   THE ISOMORPHOUS STRUCTURES OF PRETHROMBIN2,                  
-REMARK   1  TITL 2 HIRUGEN-, AND PPACK-THROMBIN: CHANGES ACCOMPANYING           
-REMARK   1  TITL 3 ACTIVATION AND EXOSITE BINDING TO THROMBIN                   
+REMARK   1  TITL   THE ISOMORPHOUS STRUCTURES OF PRETHROMBIN2, HIRUGEN-, AND    
+REMARK   1  TITL 2 PPACK-THROMBIN: CHANGES ACCOMPANYING ACTIVATION AND EXOSITE  
+REMARK   1  TITL 3 BINDING TO THROMBIN                                          
 REMARK   1  REF    PROTEIN SCI.                  V.   3  2254 1994              
 REMARK   1  REFN                   ISSN 0961-8368                               
 REMARK   1 REFERENCE 2                                                          
@@ -55,11 +55,10 @@ REMARK   1  REF    BLOOD COAGULATION             V.   4   305 1993
 REMARK   1  REF  2 FIBRINOLYSIS                                                 
 REMARK   1  REFN                   ISSN 0957-5235                               
 REMARK   1 REFERENCE 3                                                          
-REMARK   1  AUTH   X.QIU,K.P.PADMANABHAN,V.E.CARPEROS,A.TULINSKY,               
-REMARK   1  AUTH 2 T.KLINE,J.M.MARAGANORE,J.W.FENTON II                         
-REMARK   1  TITL   STRUCTURE OF THE HIRULOG 3-THROMBIN COMPLEX AND              
-REMARK   1  TITL 2 NATURE OF THE S' SUBSITES OF SUBSTRATES AND                  
-REMARK   1  TITL 3 INHIBITORS                                                   
+REMARK   1  AUTH   X.QIU,K.P.PADMANABHAN,V.E.CARPEROS,A.TULINSKY,T.KLINE,       
+REMARK   1  AUTH 2 J.M.MARAGANORE,J.W.FENTON II                                 
+REMARK   1  TITL   STRUCTURE OF THE HIRULOG 3-THROMBIN COMPLEX AND NATURE OF    
+REMARK   1  TITL 2 THE S' SUBSITES OF SUBSTRATES AND INHIBITORS                 
 REMARK   1  REF    BIOCHEMISTRY                  V.  31 11689 1992              
 REMARK   1  REFN                   ISSN 0006-2960                               
 REMARK   2                                                                      
@@ -94,9 +93,9 @@ REMARK   3   FREE R VALUE TEST SET COUNT   (NO CUTOFF) : NULL
 REMARK   3   TOTAL NUMBER OF REFLECTIONS   (NO CUTOFF) : NULL                   
 REMARK   3                                                                      
 REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
-REMARK   3   PROTEIN ATOMS            : 2080                                    
+REMARK   3   PROTEIN ATOMS            : 2238                                    
 REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
-REMARK   3   HETEROGEN ATOMS          : 198                                     
+REMARK   3   HETEROGEN ATOMS          : 44                                      
 REMARK   3   SOLVENT ATOMS            : 157                                     
 REMARK   3                                                                      
 REMARK   3  B VALUES.                                                           
@@ -145,7 +144,7 @@ REMARK   3   SIDE-CHAIN ANGLE              (A**2) : 4.100 ; 2.500
 REMARK   3                                                                      
 REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
 REMARK   4                                                                      
-REMARK   4 1A4W COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
+REMARK   4 1A4W COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
 REMARK 100                                                                      
 REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY BNL.                                
 REMARK 200                                                                      
@@ -258,13 +257,10 @@ REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000
 REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
 REMARK 400                                                                      
 REMARK 400 COMPOUND                                                             
-REMARK 400                                                                      
 REMARK 400 THROMBIN IS CLEAVED BETWEEN RESIDUES 15 AND 16.  CHAIN               
 REMARK 400 IDENTIFIER *L* IS USED FOR RESIDUES 1H - 15 AND CHAIN                
 REMARK 400 IDENTIFIER *H* IS USED FOR RESIDUES 16 - 247.  CHAIN                 
 REMARK 400 IDENTIFIER *I* IS USED FOR HIRUGEN, THE CARBOXYL.                    
-REMARK 400 RESIDUES DAN R 373, ARG R 350, PIP R 375, AND TZL R 377              
-REMARK 400 CONSTITUTE THE ACTIVE SITE INHIBITOR.                                
 REMARK 465                                                                      
 REMARK 465 MISSING RESIDUES                                                     
 REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
@@ -298,14 +294,14 @@ REMARK 465     GLY I   354
 REMARK 465     LEU I   364                                                      
 REMARK 470                                                                      
 REMARK 470 MISSING ATOM                                                         
-REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS(M=MODEL NUMBER;            
+REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS (M=MODEL NUMBER;           
 REMARK 470 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
 REMARK 470 I=INSERTION CODE):                                                   
 REMARK 470   M RES CSSEQI  ATOMS                                                
 REMARK 470     LYS L  14A   CG   CD   CE   NZ                                   
 REMARK 470     ARG L  14D   CG   CD   NE   CZ   NH1  NH2                        
 REMARK 470     ILE L  14K   CB   CG1  CG2  CD1                                  
-REMARK 470     ASN H  62    CB   CG   OD1  ND2                                  
+REMARK 470     ASN H  62    CB   CG   OD1                                       
 REMARK 470     ARG H  75    CB   CG   CD   NE   CZ   NH1  NH2                   
 REMARK 470     ARG H  77A   CB   CG   CD   NE   CZ   NH1  NH2                   
 REMARK 470     LYS H 110    CG   CD   CE   NZ                                   
@@ -430,8 +426,8 @@ REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;
 REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
 REMARK 500                                                                      
 REMARK 500  M RES CSSEQI        RMS     TYPE                                    
-REMARK 500    ARG H  73         0.12    SIDE_CHAIN                              
-REMARK 500    PHE H 232         0.08    SIDE_CHAIN                              
+REMARK 500    ARG H  73         0.12    SIDE CHAIN                              
+REMARK 500    PHE H 232         0.08    SIDE CHAIN                              
 REMARK 500                                                                      
 REMARK 500 REMARK: NULL                                                         
 REMARK 500                                                                      
@@ -439,7 +435,7 @@ REMARK 500 GEOMETRY AND STEREOCHEMISTRY
 REMARK 500 SUBTOPIC: MAIN CHAIN PLANARITY                                       
 REMARK 500                                                                      
 REMARK 500 THE FOLLOWING RESIDUES HAVE A PSEUDO PLANARITY                       
-REMARK 500 TORSION, C(I) - CA(I) - N(I+1) - O(I), GREATER                       
+REMARK 500 TORSION ANGLE, C(I) - CA(I) - N(I+1) - O(I), GREATER                 
 REMARK 500 10.0 DEGREES. (M=MODEL NUMBER; RES=RESIDUE NAME;                     
 REMARK 500 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;                            
 REMARK 500 I=INSERTION CODE).                                                   
@@ -449,23 +445,28 @@ REMARK 500    SER H  20         11.04
 REMARK 500    GLN H 151         10.60                                           
 REMARK 500                                                                      
 REMARK 500 REMARK: NULL                                                         
-REMARK 525                                                                      
-REMARK 525 SOLVENT                                                              
-REMARK 525                                                                      
-REMARK 525 THE SOLVENT MOLECULES HAVE CHAIN IDENTIFIERS THAT                    
-REMARK 525 INDICATE THE POLYMER CHAIN WITH WHICH THEY ARE MOST                  
-REMARK 525 CLOSELY ASSOCIATED. THE REMARK LISTS ALL THE SOLVENT                 
-REMARK 525 MOLECULES WHICH ARE MORE THAN 5A AWAY FROM THE                       
-REMARK 525 NEAREST POLYMER CHAIN (M = MODEL NUMBER;                             
-REMARK 525 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE                  
-REMARK 525 NUMBER; I=INSERTION CODE):                                           
-REMARK 525                                                                      
-REMARK 525  M RES CSSEQI                                                        
-REMARK 525    HOH H 537        DISTANCE =  5.46 ANGSTROMS                       
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CHIRAL CENTERS                                             
+REMARK 500                                                                      
+REMARK 500 UNEXPECTED CONFIGURATION OF THE FOLLOWING CHIRAL                     
+REMARK 500 CENTER(S) USING IMPROPER CA--C--CB--N CHIRALITY                      
+REMARK 500 FOR AMINO ACIDS AND C1'--O4'--N1(N9)--C2' FOR                        
+REMARK 500 NUCLEIC ACIDS OR EQUIVALENT ANGLE                                    
+REMARK 500 M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN                            
+REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE                   
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,6X,F5.1,6X,A1,10X,A1,3X,A16)       
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI    IMPROPER   EXPECTED   FOUND DETAILS                 
+REMARK 500    SER L  11        24.6      L          L   OUTSIDE RANGE           
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
 REMARK 620                                                                      
 REMARK 620 METAL COORDINATION                                                   
-REMARK 620  (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;              
-REMARK 620  SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                            
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
 REMARK 620                                                                      
 REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
 REMARK 620                              NA H 541  NA                            
@@ -488,33 +489,44 @@ REMARK 620 4 HOH H 467   O   171.9  94.2  96.9
 REMARK 620 5 PHE H 204A  O    97.8  93.6  78.7  90.3                            
 REMARK 620 6 HOH H 515   O    74.9  84.0 102.2  97.0 172.5                      
 REMARK 620 N                    1     2     3     4     5                       
+REMARK 630                                                                      
+REMARK 630 MOLECULE TYPE: NULL                                                  
+REMARK 630 MOLECULE NAME: AMINO{[(4S)-4-({[5-(DIMETHYLAMINO)NAPHTHALEN-1-YL]    
+REMARK 630 SULFONYL}AMINO)-5-OXO-5-{(2R)-2-[3-OXO-3-(1,3-THIAZOL-2-YL)PROPYL]   
+REMARK 630 PIPERIDIN-1-YL}PENTYL]AMINO}METHANIMINIUM                            
+REMARK 630 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 630  SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                           
+REMARK 630                                                                      
+REMARK 630   M RES C SSSEQI                                                     
+REMARK 630     QWE H   373                                                      
+REMARK 630 SOURCE: NULL                                                         
+REMARK 630 TAXONOMY: NULL                                                       
+REMARK 630 SUBCOMP:    ANS ARG 5TP                                              
+REMARK 630 DETAILS: NULL                                                        
 REMARK 800                                                                      
 REMARK 800 SITE                                                                 
 REMARK 800 SITE_IDENTIFIER: CAT                                                 
 REMARK 800 EVIDENCE_CODE: UNKNOWN                                               
 REMARK 800 SITE_DESCRIPTION: ACTIVE SITE                                        
+REMARK 800                                                                      
 REMARK 800 SITE_IDENTIFIER: AC1                                                 
 REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
 REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE NA H 541                  
+REMARK 800                                                                      
 REMARK 800 SITE_IDENTIFIER: AC2                                                 
 REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
 REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE NA H 542                  
+REMARK 800                                                                      
 REMARK 800 SITE_IDENTIFIER: AC3                                                 
 REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
-REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ANS H 373                 
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE QWE H 373                 
+REMARK 800                                                                      
 REMARK 800 SITE_IDENTIFIER: AC4                                                 
 REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
-REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE DAR H 350                 
-REMARK 800 SITE_IDENTIFIER: AC5                                                 
-REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
-REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE 2EP H 375                 
-REMARK 800 SITE_IDENTIFIER: AC6                                                 
-REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
-REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE KTH H 377                 
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR CHAIN I OF HIRUGEN                
 DBREF  1A4W L    1H   14N UNP    P00734   THRB_HUMAN     328    363             
 DBREF  1A4W H   16   247  UNP    P00734   THRB_HUMAN     364    622             
 DBREF  1A4W I  353   364  UNP    P09945   ITH3_HIRME      60     71             
-SEQADV 1A4W TYS I  363  UNP  P09945    TYR    70 CONFLICT                       
 SEQRES   1 L   36  THR PHE GLY SER GLY GLU ALA ASP CYS GLY LEU ARG PRO          
 SEQRES   2 L   36  LEU PHE GLU LYS LYS SER LEU GLU ASP LYS THR GLU ARG          
 SEQRES   3 L   36  GLU LEU LEU GLU SER TYR ILE ASP GLY ARG                      
@@ -543,25 +555,18 @@ MODRES 1A4W TYS I  363  TYR  O-SULFO-L-TYROSINE
 HET    TYS  I 363      16                                                       
 HET     NA  H 541       1                                                       
 HET     NA  H 542       1                                                       
-HET    ANS  H 373      16                                                       
-HET    DAR  H 350      11                                                       
-HET    2EP  H 375       8                                                       
-HET    KTH  H 377       7                                                       
+HET    QWE  H 373      42                                                       
 HETNAM     TYS O-SULFO-L-TYROSINE                                               
 HETNAM      NA SODIUM ION                                                       
-HETNAM     ANS 5-(DIMETHYLAMINO)-1-NAPHTHALENESULFONIC ACID(DANSYL              
-HETNAM   2 ANS  ACID)                                                           
-HETNAM     DAR D-ARGININE                                                       
-HETNAM     2EP 2-ETHYLPIPERIDINE                                                
-HETNAM     KTH 2-KETOTHIAZOLE                                                   
-HETSYN     ANS DANSYL ACID                                                      
+HETNAM     QWE AMINO{[(4S)-4-({[5-(DIMETHYLAMINO)NAPHTHALEN-1-                  
+HETNAM   2 QWE  YL]SULFONYL}AMINO)-5-OXO-5-{(2R)-2-[3-OXO-3-(1,3-               
+HETNAM   3 QWE  THIAZOL-2-YL)PROPYL]PIPERIDIN-1-                                
+HETNAM   4 QWE  YL}PENTYL]AMINO}METHANIMINIUM                                   
+HETSYN     QWE RWJ-50215                                                        
 FORMUL   3  TYS    C9 H11 N O6 S                                                
 FORMUL   4   NA    2(NA 1+)                                                     
-FORMUL   6  ANS    C12 H13 N O3 S                                               
-FORMUL   6  DAR    C6 H15 N4 O2 1+                                              
-FORMUL   6  2EP    C7 H15 N                                                     
-FORMUL   7  KTH    C4 H3 N O S                                                  
-FORMUL   8  HOH   *157(H2 O)                                                    
+FORMUL   6  QWE    C29 H40 N7 O4 S2 1+                                          
+FORMUL   7  HOH   *157(H2 O)                                                    
 HELIX    1  H1 ALA H   55  LEU H   60  1                                   6    
 HELIX    2  H2 GLU H  164  SER H  171  1                                   8    
 HELIX    3  H3 ASP H  125  LEU H  129C 1                                   8    
@@ -585,9 +590,6 @@ SSBOND   2 CYS H   42    CYS H   58                          1555   1555  2.06
 SSBOND   3 CYS H  168    CYS H  182                          1555   1555  2.06  
 SSBOND   4 CYS H  191    CYS H  220                          1555   1555  2.09  
 LINK         N   TYS I 363                 C   GLU I 362     1555   1555  1.33  
-LINK         S   ANS H 373                 N   DAR H 350     1555   1555  1.91  
-LINK         N1  2EP H 375                 C   DAR H 350     1555   1555  1.42  
-LINK         C2' 2EP H 375                 C2' KTH H 377     1555   1555  1.48  
 LINK        NA    NA H 541                 O   LYS H 224     1555   1555  2.32  
 LINK        NA    NA H 542                 O   LYS H 169     1555   1555  2.36  
 LINK        NA    NA H 542                 O   THR H 172     1555   1555  2.33  
@@ -606,13 +608,14 @@ SITE     1 AC1  6 ARG H 221A LYS H 224  HOH H 403  HOH H 460
 SITE     2 AC1  6 HOH H 464  HOH H 497                                          
 SITE     1 AC2  6 LYS H 169  THR H 172  PHE H 204A HOH H 467                    
 SITE     2 AC2  6 HOH H 515  HOH H 518                                          
-SITE     1 AC3  8 TYR H  60A GLU H  97A LEU H  99  TRP H 215                    
-SITE     2 AC3  8 GLY H 216  GLY H 219  DAR H 350  HOH H 448                    
-SITE     1 AC4  8 ASP H 189  ALA H 190  TRP H 215  GLY H 216                    
-SITE     2 AC4  8 GLY H 219  ANS H 373  2EP H 375  HOH H 471                    
-SITE     1 AC5  4 TRP H  60D LEU H  99  DAR H 350  KTH H 377                    
-SITE     1 AC6  5 HIS H  57  TRP H  60D LYS H  60F 2EP H 375                    
-SITE     2 AC6  5 HOH H 532                                                     
+SITE     1 AC3 14 HIS H  57  TYR H  60A TRP H  60D LYS H  60F                   
+SITE     2 AC3 14 GLU H  97A LEU H  99  ASP H 189  ALA H 190                    
+SITE     3 AC3 14 TRP H 215  GLY H 216  GLY H 219  HOH H 448                    
+SITE     4 AC3 14 HOH H 471  HOH H 532                                          
+SITE     1 AC4 14 PHE H  34  ARG H  67  ARG H  73  THR H  74                    
+SITE     2 AC4 14 ARG H  75  TYR H  76  LYS H  81  ILE H  82                    
+SITE     3 AC4 14 HOH H 393  HOH H 432  HOH I 419  HOH I 435                    
+SITE     4 AC4 14 HOH I 476  HOH I 504                                          
 CRYST1   71.470   72.000   73.390  90.00 101.13  90.00 C 1 2 1       4          
 ORIGX1      1.000000  0.000000  0.000000        0.00000                         
 ORIGX2      0.000000  1.000000  0.000000        0.00000                         
@@ -2863,48 +2866,48 @@ HETATM 2240  O   TYS I 363      18.126   0.587  -2.682  1.00 44.82           O
 TER    2241      TYS I 363                                                      
 HETATM 2242 NA    NA H 541       5.845 -14.122  30.560  0.88 23.48          NA  
 HETATM 2243 NA    NA H 542      18.411 -16.475  38.464  0.88 24.77          NA  
-HETATM 2244  C1  ANS H 373      17.735 -17.178  22.612  1.00 26.29           C  
-HETATM 2245  C2  ANS H 373      18.543 -17.350  21.462  1.00 26.22           C  
-HETATM 2246  C3  ANS H 373      19.877 -17.046  21.558  1.00 26.06           C  
-HETATM 2247  C4  ANS H 373      20.401 -16.566  22.766  1.00 26.60           C  
-HETATM 2248  C4A ANS H 373      19.613 -16.358  23.893  1.00 27.46           C  
-HETATM 2249  C5  ANS H 373      20.084 -15.791  25.046  1.00 28.32           C  
-HETATM 2250  C6  ANS H 373      19.241 -15.568  26.114  1.00 27.47           C  
-HETATM 2251  C7  ANS H 373      17.893 -15.971  26.028  1.00 27.79           C  
-HETATM 2252  C8  ANS H 373      17.370 -16.510  24.879  1.00 26.51           C  
-HETATM 2253  C8A ANS H 373      18.205 -16.689  23.809  1.00 26.70           C  
-HETATM 2254  N   ANS H 373      21.383 -15.285  25.104  1.00 29.72           N  
-HETATM 2255  CM1 ANS H 373      21.898 -14.217  24.214  1.00 30.75           C  
-HETATM 2256  CM2 ANS H 373      22.635 -16.213  25.496  1.00 31.28           C  
-HETATM 2257  S   ANS H 373      15.909 -17.581  22.417  1.00 26.82           S  
-HETATM 2258  O1S ANS H 373      15.988 -18.013  21.010  1.00 27.08           O  
-HETATM 2259  O2S ANS H 373      14.998 -18.191  23.402  1.00 25.52           O  
-HETATM 2260  N   DAR H 350      14.893 -15.970  22.485  1.00 26.45           N  
-HETATM 2261  CA  DAR H 350      15.193 -15.114  21.296  1.00 26.19           C  
-HETATM 2262  CB  DAR H 350      13.942 -14.354  20.879  1.00 23.76           C  
-HETATM 2263  CG  DAR H 350      13.232 -13.686  22.058  1.00 25.01           C  
-HETATM 2264  CD  DAR H 350      11.892 -13.133  21.595  1.00 23.01           C  
-HETATM 2265  NE  DAR H 350      11.218 -12.647  22.780  1.00 21.45           N  
-HETATM 2266  CZ  DAR H 350      11.457 -11.554  23.483  1.00 20.16           C  
-HETATM 2267  NH1 DAR H 350      12.359 -10.674  23.045  1.00 20.04           N  
-HETATM 2268  NH2 DAR H 350      10.723 -11.336  24.566  1.00 20.85           N  
-HETATM 2269  C   DAR H 350      16.307 -14.167  21.752  1.00 26.27           C  
-HETATM 2270  O   DAR H 350      16.212 -13.781  22.914  1.00 24.70           O  
-HETATM 2271  N1  2EP H 375      17.280 -13.692  20.830  1.00 27.91           N  
-HETATM 2272  C2  2EP H 375      17.043 -14.033  19.327  1.00 30.31           C  
-HETATM 2273  C3  2EP H 375      18.421 -14.472  18.809  1.00 29.73           C  
-HETATM 2274  C4  2EP H 375      19.610 -13.417  19.194  1.00 29.33           C  
-HETATM 2275  C5  2EP H 375      19.696 -13.083  20.765  1.00 28.57           C  
-HETATM 2276  C6  2EP H 375      18.351 -12.680  21.310  1.00 28.50           C  
-HETATM 2277  C1' 2EP H 375      16.593 -13.014  18.550  1.00 33.08           C  
-HETATM 2278  C2' 2EP H 375      15.941 -13.425  17.179  1.00 37.01           C  
-HETATM 2279  S1  KTH H 377      15.783 -14.904  14.458  1.00 43.62           S  
-HETATM 2280  O2  KTH H 377      17.488 -11.922  16.287  1.00 41.38           O  
-HETATM 2281  C5  KTH H 377      17.059 -15.583  13.508  1.00 43.74           C  
-HETATM 2282  C2  KTH H 377      16.864 -13.556  14.739  1.00 42.63           C  
-HETATM 2283  C2' KTH H 377      16.825 -12.903  16.107  1.00 40.59           C  
-HETATM 2284  C4  KTH H 377      18.146 -14.734  13.451  1.00 43.96           C  
-HETATM 2285  N3  KTH H 377      18.049 -13.554  14.106  1.00 43.46           N  
+HETATM 2244  C1  QWE H 373      17.735 -17.178  22.612  1.00 26.29           C  
+HETATM 2245  C2  QWE H 373      18.543 -17.350  21.462  1.00 26.22           C  
+HETATM 2246  C3  QWE H 373      19.877 -17.046  21.558  1.00 26.06           C  
+HETATM 2247  C4  QWE H 373      20.401 -16.566  22.766  1.00 26.60           C  
+HETATM 2248  C4A QWE H 373      19.613 -16.358  23.893  1.00 27.46           C  
+HETATM 2249  C5  QWE H 373      20.084 -15.791  25.046  1.00 28.32           C  
+HETATM 2250  C6  QWE H 373      19.241 -15.568  26.114  1.00 27.47           C  
+HETATM 2251  C7  QWE H 373      17.893 -15.971  26.028  1.00 27.79           C  
+HETATM 2252  C8  QWE H 373      17.370 -16.510  24.879  1.00 26.51           C  
+HETATM 2253  C8A QWE H 373      18.205 -16.689  23.809  1.00 26.70           C  
+HETATM 2254  N   QWE H 373      21.383 -15.285  25.104  1.00 29.72           N  
+HETATM 2255  CM1 QWE H 373      21.898 -14.217  24.214  1.00 30.75           C  
+HETATM 2256  CM2 QWE H 373      22.635 -16.213  25.496  1.00 31.28           C  
+HETATM 2257  S   QWE H 373      15.909 -17.581  22.417  1.00 26.82           S  
+HETATM 2258  O1S QWE H 373      15.988 -18.013  21.010  1.00 27.08           O  
+HETATM 2259  O2S QWE H 373      14.998 -18.191  23.402  1.00 25.52           O  
+HETATM 2260  N1  QWE H 373      14.893 -15.970  22.485  1.00 26.45           N  
+HETATM 2261  CA  QWE H 373      15.193 -15.114  21.296  1.00 26.19           C  
+HETATM 2262  C   QWE H 373      16.307 -14.167  21.752  1.00 26.27           C  
+HETATM 2263  O   QWE H 373      16.212 -13.781  22.914  1.00 24.70           O  
+HETATM 2264  CB  QWE H 373      13.942 -14.354  20.879  1.00 23.76           C  
+HETATM 2265  CG  QWE H 373      13.232 -13.686  22.058  1.00 25.01           C  
+HETATM 2266  CD  QWE H 373      11.892 -13.133  21.595  1.00 23.01           C  
+HETATM 2267  NE  QWE H 373      11.218 -12.647  22.780  1.00 21.45           N  
+HETATM 2268  CZ  QWE H 373      11.457 -11.554  23.483  1.00 20.16           C  
+HETATM 2269  NH1 QWE H 373      12.359 -10.674  23.045  1.00 20.04           N  
+HETATM 2270  NH2 QWE H 373      10.723 -11.336  24.566  1.00 20.85           N  
+HETATM 2271  N11 QWE H 373      17.280 -13.692  20.830  1.00 27.91           N  
+HETATM 2272  C21 QWE H 373      17.043 -14.033  19.327  1.00 30.31           C  
+HETATM 2273  C31 QWE H 373      18.421 -14.472  18.809  1.00 29.73           C  
+HETATM 2274  C41 QWE H 373      19.610 -13.417  19.194  1.00 29.33           C  
+HETATM 2275  C51 QWE H 373      19.696 -13.083  20.765  1.00 28.57           C  
+HETATM 2276  C61 QWE H 373      18.351 -12.680  21.310  1.00 28.50           C  
+HETATM 2277  C1' QWE H 373      16.593 -13.014  18.550  1.00 33.08           C  
+HETATM 2278  C2' QWE H 373      15.941 -13.425  17.179  1.00 37.01           C  
+HETATM 2279  S1  QWE H 373      15.783 -14.904  14.458  1.00 43.62           S  
+HETATM 2280  O2  QWE H 373      17.488 -11.922  16.287  1.00 41.38           O  
+HETATM 2281  C52 QWE H 373      17.059 -15.583  13.508  1.00 43.74           C  
+HETATM 2282  C22 QWE H 373      16.864 -13.556  14.739  1.00 42.63           C  
+HETATM 2283 C2'1 QWE H 373      16.825 -12.903  16.107  1.00 40.59           C  
+HETATM 2284  C42 QWE H 373      18.146 -14.734  13.451  1.00 43.96           C  
+HETATM 2285  N3  QWE H 373      18.049 -13.554  14.106  1.00 43.46           N  
 HETATM 2286  O   HOH L 382      -2.186  12.007  23.167  0.90 17.26           O  
 HETATM 2287  O   HOH L 391      -6.499   6.251  26.260  0.86 24.38           O  
 HETATM 2288  O   HOH L 408      -2.832   0.680  34.246  0.94 22.88           O  
@@ -3112,17 +3115,17 @@ CONECT 2257 2244 2258 2259 2260
 CONECT 2258 2257                                                                
 CONECT 2259 2257                                                                
 CONECT 2260 2257 2261                                                           
-CONECT 2261 2260 2262 2269                                                      
-CONECT 2262 2261 2263                                                           
-CONECT 2263 2262 2264                                                           
-CONECT 2264 2263 2265                                                           
+CONECT 2261 2260 2262 2264                                                      
+CONECT 2262 2261 2263 2271                                                      
+CONECT 2263 2262                                                                
+CONECT 2264 2261 2265                                                           
 CONECT 2265 2264 2266                                                           
-CONECT 2266 2265 2267 2268                                                      
-CONECT 2267 2266                                                                
-CONECT 2268 2266                                                                
-CONECT 2269 2261 2270 2271                                                      
-CONECT 2270 2269                                                                
-CONECT 2271 2269 2272 2276                                                      
+CONECT 2266 2265 2267                                                           
+CONECT 2267 2266 2268                                                           
+CONECT 2268 2267 2269 2270                                                      
+CONECT 2269 2268                                                                
+CONECT 2270 2268                                                                
+CONECT 2271 2262 2272 2276                                                      
 CONECT 2272 2271 2273 2277                                                      
 CONECT 2273 2272 2274                                                           
 CONECT 2274 2273 2275                                                           
@@ -3144,5 +3147,5 @@ CONECT 2375 2243
 CONECT 2401 2242                                                                
 CONECT 2415 2243                                                                
 CONECT 2418 2243                                                                
-MASTER      471    0    7    4   14    0   12    6 2439    3   82   24          
+MASTER      484    0    4    4   14    0   13    6 2439    3   82   24          
 END                                                                             

--- a/integrationtest/src/test/resources/1a4w.pdb
+++ b/integrationtest/src/test/resources/1a4w.pdb
@@ -1,6 +1,6 @@
-HEADER    HYDROLASE/HYDROLASE INHIBITOR           06-FEB-98   1A4W              
-TITLE     CRYSTAL STRUCTURES OF THROMBIN WITH THIAZOLE-CONTAINING INHIBITORS:   
-TITLE    2 PROBES OF THE S1' BINDING SITE                                       
+HEADER    COMPLEX (SERINE PROTEASE/INHIBITORS)    06-FEB-98   1A4W              
+TITLE     CRYSTAL STRUCTURES OF THROMBIN WITH THIAZOLE-CONTAINING               
+TITLE    2 INHIBITORS: PROBES OF THE S1' BINDING SITE                           
 COMPND    MOL_ID: 1;                                                            
 COMPND   2 MOLECULE: ALPHA-THROMBIN (SMALL SUBUNIT);                            
 COMPND   3 CHAIN: L;                                                            
@@ -26,26 +26,26 @@ SOURCE  10 ORGANISM_TAXID: 9606;
 SOURCE  11 ORGAN: BLOOD;                                                        
 SOURCE  12 TISSUE: BLOOD;                                                       
 SOURCE  13 MOL_ID: 3                                                            
-KEYWDS    SERINE PROTEASE-INHIBITOR, BLOOD COAGULATION, HYDROLASE-HYDROLASE     
-KEYWDS   2 INHIBITOR COMPLEX                                                    
+KEYWDS    COMPLEX (SERINE PROTEASE/INHIBITORS), BLOOD COAGULATION               
 EXPDTA    X-RAY DIFFRACTION                                                     
-AUTHOR    J.H.MATTHEWS,R.KRISHNAN,M.J.COSTANZO,B.E.MARYANOFF,A.TULINSKY         
-REVDAT   3   13-JUL-11 1A4W    1       VERSN                                    
+AUTHOR    J.H.MATTHEWS,R.KRISHNAN,M.J.COSTANZO,B.E.MARYANOFF,                   
+AUTHOR   2 A.TULINSKY                                                           
 REVDAT   2   24-FEB-09 1A4W    1       VERSN                                    
 REVDAT   1   29-APR-98 1A4W    0                                                
 JRNL        AUTH   J.H.MATTHEWS,R.KRISHNAN,M.J.COSTANZO,B.E.MARYANOFF,          
 JRNL        AUTH 2 A.TULINSKY                                                   
-JRNL        TITL   CRYSTAL STRUCTURES OF THROMBIN WITH THIAZOLE-CONTAINING      
-JRNL        TITL 2 INHIBITORS: PROBES OF THE S1' BINDING SITE.                  
+JRNL        TITL   CRYSTAL STRUCTURES OF THROMBIN WITH                          
+JRNL        TITL 2 THIAZOLE-CONTAINING INHIBITORS: PROBES OF THE S1'            
+JRNL        TITL 3 BINDING SITE.                                                
 JRNL        REF    BIOPHYS.J.                    V.  71  2830 1996              
 JRNL        REFN                   ISSN 0006-3495                               
 JRNL        PMID   8913620                                                      
 REMARK   1                                                                      
 REMARK   1 REFERENCE 1                                                          
 REMARK   1  AUTH   J.VIJAYALAKSHMI,K.P.PADMANABHAN,K.G.MANN,A.TULINSKY          
-REMARK   1  TITL   THE ISOMORPHOUS STRUCTURES OF PRETHROMBIN2, HIRUGEN-, AND    
-REMARK   1  TITL 2 PPACK-THROMBIN: CHANGES ACCOMPANYING ACTIVATION AND EXOSITE  
-REMARK   1  TITL 3 BINDING TO THROMBIN                                          
+REMARK   1  TITL   THE ISOMORPHOUS STRUCTURES OF PRETHROMBIN2,                  
+REMARK   1  TITL 2 HIRUGEN-, AND PPACK-THROMBIN: CHANGES ACCOMPANYING           
+REMARK   1  TITL 3 ACTIVATION AND EXOSITE BINDING TO THROMBIN                   
 REMARK   1  REF    PROTEIN SCI.                  V.   3  2254 1994              
 REMARK   1  REFN                   ISSN 0961-8368                               
 REMARK   1 REFERENCE 2                                                          
@@ -55,10 +55,11 @@ REMARK   1  REF    BLOOD COAGULATION             V.   4   305 1993
 REMARK   1  REF  2 FIBRINOLYSIS                                                 
 REMARK   1  REFN                   ISSN 0957-5235                               
 REMARK   1 REFERENCE 3                                                          
-REMARK   1  AUTH   X.QIU,K.P.PADMANABHAN,V.E.CARPEROS,A.TULINSKY,T.KLINE,       
-REMARK   1  AUTH 2 J.M.MARAGANORE,J.W.FENTON II                                 
-REMARK   1  TITL   STRUCTURE OF THE HIRULOG 3-THROMBIN COMPLEX AND NATURE OF    
-REMARK   1  TITL 2 THE S' SUBSITES OF SUBSTRATES AND INHIBITORS                 
+REMARK   1  AUTH   X.QIU,K.P.PADMANABHAN,V.E.CARPEROS,A.TULINSKY,               
+REMARK   1  AUTH 2 T.KLINE,J.M.MARAGANORE,J.W.FENTON II                         
+REMARK   1  TITL   STRUCTURE OF THE HIRULOG 3-THROMBIN COMPLEX AND              
+REMARK   1  TITL 2 NATURE OF THE S' SUBSITES OF SUBSTRATES AND                  
+REMARK   1  TITL 3 INHIBITORS                                                   
 REMARK   1  REF    BIOCHEMISTRY                  V.  31 11689 1992              
 REMARK   1  REFN                   ISSN 0006-2960                               
 REMARK   2                                                                      
@@ -93,9 +94,9 @@ REMARK   3   FREE R VALUE TEST SET COUNT   (NO CUTOFF) : NULL
 REMARK   3   TOTAL NUMBER OF REFLECTIONS   (NO CUTOFF) : NULL                   
 REMARK   3                                                                      
 REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
-REMARK   3   PROTEIN ATOMS            : 2238                                    
+REMARK   3   PROTEIN ATOMS            : 2080                                    
 REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
-REMARK   3   HETEROGEN ATOMS          : 44                                      
+REMARK   3   HETEROGEN ATOMS          : 198                                     
 REMARK   3   SOLVENT ATOMS            : 157                                     
 REMARK   3                                                                      
 REMARK   3  B VALUES.                                                           
@@ -144,7 +145,7 @@ REMARK   3   SIDE-CHAIN ANGLE              (A**2) : 4.100 ; 2.500
 REMARK   3                                                                      
 REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
 REMARK   4                                                                      
-REMARK   4 1A4W COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK   4 1A4W COMPLIES WITH FORMAT V. 3.15, 01-DEC-08                         
 REMARK 100                                                                      
 REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY BNL.                                
 REMARK 200                                                                      
@@ -257,10 +258,13 @@ REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000
 REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
 REMARK 400                                                                      
 REMARK 400 COMPOUND                                                             
+REMARK 400                                                                      
 REMARK 400 THROMBIN IS CLEAVED BETWEEN RESIDUES 15 AND 16.  CHAIN               
 REMARK 400 IDENTIFIER *L* IS USED FOR RESIDUES 1H - 15 AND CHAIN                
 REMARK 400 IDENTIFIER *H* IS USED FOR RESIDUES 16 - 247.  CHAIN                 
 REMARK 400 IDENTIFIER *I* IS USED FOR HIRUGEN, THE CARBOXYL.                    
+REMARK 400 RESIDUES DAN R 373, ARG R 350, PIP R 375, AND TZL R 377              
+REMARK 400 CONSTITUTE THE ACTIVE SITE INHIBITOR.                                
 REMARK 465                                                                      
 REMARK 465 MISSING RESIDUES                                                     
 REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
@@ -294,14 +298,14 @@ REMARK 465     GLY I   354
 REMARK 465     LEU I   364                                                      
 REMARK 470                                                                      
 REMARK 470 MISSING ATOM                                                         
-REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS (M=MODEL NUMBER;           
+REMARK 470 THE FOLLOWING RESIDUES HAVE MISSING ATOMS(M=MODEL NUMBER;            
 REMARK 470 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;          
 REMARK 470 I=INSERTION CODE):                                                   
 REMARK 470   M RES CSSEQI  ATOMS                                                
 REMARK 470     LYS L  14A   CG   CD   CE   NZ                                   
 REMARK 470     ARG L  14D   CG   CD   NE   CZ   NH1  NH2                        
 REMARK 470     ILE L  14K   CB   CG1  CG2  CD1                                  
-REMARK 470     ASN H  62    CB   CG   OD1                                       
+REMARK 470     ASN H  62    CB   CG   OD1  ND2                                  
 REMARK 470     ARG H  75    CB   CG   CD   NE   CZ   NH1  NH2                   
 REMARK 470     ARG H  77A   CB   CG   CD   NE   CZ   NH1  NH2                   
 REMARK 470     LYS H 110    CG   CD   CE   NZ                                   
@@ -426,8 +430,8 @@ REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;
 REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
 REMARK 500                                                                      
 REMARK 500  M RES CSSEQI        RMS     TYPE                                    
-REMARK 500    ARG H  73         0.12    SIDE CHAIN                              
-REMARK 500    PHE H 232         0.08    SIDE CHAIN                              
+REMARK 500    ARG H  73         0.12    SIDE_CHAIN                              
+REMARK 500    PHE H 232         0.08    SIDE_CHAIN                              
 REMARK 500                                                                      
 REMARK 500 REMARK: NULL                                                         
 REMARK 500                                                                      
@@ -435,7 +439,7 @@ REMARK 500 GEOMETRY AND STEREOCHEMISTRY
 REMARK 500 SUBTOPIC: MAIN CHAIN PLANARITY                                       
 REMARK 500                                                                      
 REMARK 500 THE FOLLOWING RESIDUES HAVE A PSEUDO PLANARITY                       
-REMARK 500 TORSION ANGLE, C(I) - CA(I) - N(I+1) - O(I), GREATER                 
+REMARK 500 TORSION, C(I) - CA(I) - N(I+1) - O(I), GREATER                       
 REMARK 500 10.0 DEGREES. (M=MODEL NUMBER; RES=RESIDUE NAME;                     
 REMARK 500 C=CHAIN IDENTIFIER; SSEQ=SEQUENCE NUMBER;                            
 REMARK 500 I=INSERTION CODE).                                                   
@@ -445,28 +449,23 @@ REMARK 500    SER H  20         11.04
 REMARK 500    GLN H 151         10.60                                           
 REMARK 500                                                                      
 REMARK 500 REMARK: NULL                                                         
-REMARK 500                                                                      
-REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
-REMARK 500 SUBTOPIC: CHIRAL CENTERS                                             
-REMARK 500                                                                      
-REMARK 500 UNEXPECTED CONFIGURATION OF THE FOLLOWING CHIRAL                     
-REMARK 500 CENTER(S) USING IMPROPER CA--C--CB--N CHIRALITY                      
-REMARK 500 FOR AMINO ACIDS AND C1'--O4'--N1(N9)--C2' FOR                        
-REMARK 500 NUCLEIC ACIDS OR EQUIVALENT ANGLE                                    
-REMARK 500 M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN                            
-REMARK 500 IDENTIFIER; SSEQ=SEQUENCE NUMBER; I=INSERTION CODE                   
-REMARK 500                                                                      
-REMARK 500 STANDARD TABLE:                                                      
-REMARK 500 FORMAT: (10X,I3,1X,A3,1X,A1,I4,A1,6X,F5.1,6X,A1,10X,A1,3X,A16)       
-REMARK 500                                                                      
-REMARK 500  M RES CSSEQI    IMPROPER   EXPECTED   FOUND DETAILS                 
-REMARK 500    SER L  11        24.6      L          L   OUTSIDE RANGE           
-REMARK 500                                                                      
-REMARK 500 REMARK: NULL                                                         
+REMARK 525                                                                      
+REMARK 525 SOLVENT                                                              
+REMARK 525                                                                      
+REMARK 525 THE SOLVENT MOLECULES HAVE CHAIN IDENTIFIERS THAT                    
+REMARK 525 INDICATE THE POLYMER CHAIN WITH WHICH THEY ARE MOST                  
+REMARK 525 CLOSELY ASSOCIATED. THE REMARK LISTS ALL THE SOLVENT                 
+REMARK 525 MOLECULES WHICH ARE MORE THAN 5A AWAY FROM THE                       
+REMARK 525 NEAREST POLYMER CHAIN (M = MODEL NUMBER;                             
+REMARK 525 RES=RESIDUE NAME; C=CHAIN IDENTIFIER; SSEQ=SEQUENCE                  
+REMARK 525 NUMBER; I=INSERTION CODE):                                           
+REMARK 525                                                                      
+REMARK 525  M RES CSSEQI                                                        
+REMARK 525    HOH H 537        DISTANCE =  5.46 ANGSTROMS                       
 REMARK 620                                                                      
 REMARK 620 METAL COORDINATION                                                   
-REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
-REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620  (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;              
+REMARK 620  SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                            
 REMARK 620                                                                      
 REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
 REMARK 620                              NA H 541  NA                            
@@ -489,44 +488,33 @@ REMARK 620 4 HOH H 467   O   171.9  94.2  96.9
 REMARK 620 5 PHE H 204A  O    97.8  93.6  78.7  90.3                            
 REMARK 620 6 HOH H 515   O    74.9  84.0 102.2  97.0 172.5                      
 REMARK 620 N                    1     2     3     4     5                       
-REMARK 630                                                                      
-REMARK 630 MOLECULE TYPE: NULL                                                  
-REMARK 630 MOLECULE NAME: AMINO{[(4S)-4-({[5-(DIMETHYLAMINO)NAPHTHALEN-1-YL]    
-REMARK 630 SULFONYL}AMINO)-5-OXO-5-{(2R)-2-[3-OXO-3-(1,3-THIAZOL-2-YL)PROPYL]   
-REMARK 630 PIPERIDIN-1-YL}PENTYL]AMINO}METHANIMINIUM                            
-REMARK 630 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
-REMARK 630  SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                           
-REMARK 630                                                                      
-REMARK 630   M RES C SSSEQI                                                     
-REMARK 630     QWE H   373                                                      
-REMARK 630 SOURCE: NULL                                                         
-REMARK 630 TAXONOMY: NULL                                                       
-REMARK 630 SUBCOMP:    ANS ARG 5TP                                              
-REMARK 630 DETAILS: NULL                                                        
 REMARK 800                                                                      
 REMARK 800 SITE                                                                 
 REMARK 800 SITE_IDENTIFIER: CAT                                                 
 REMARK 800 EVIDENCE_CODE: UNKNOWN                                               
 REMARK 800 SITE_DESCRIPTION: ACTIVE SITE                                        
-REMARK 800                                                                      
 REMARK 800 SITE_IDENTIFIER: AC1                                                 
 REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
 REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE NA H 541                  
-REMARK 800                                                                      
 REMARK 800 SITE_IDENTIFIER: AC2                                                 
 REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
 REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE NA H 542                  
-REMARK 800                                                                      
 REMARK 800 SITE_IDENTIFIER: AC3                                                 
 REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
-REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE QWE H 373                 
-REMARK 800                                                                      
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ANS H 373                 
 REMARK 800 SITE_IDENTIFIER: AC4                                                 
 REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
-REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR CHAIN I OF HIRUGEN                
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE DAR H 350                 
+REMARK 800 SITE_IDENTIFIER: AC5                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE 2EP H 375                 
+REMARK 800 SITE_IDENTIFIER: AC6                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE KTH H 377                 
 DBREF  1A4W L    1H   14N UNP    P00734   THRB_HUMAN     328    363             
 DBREF  1A4W H   16   247  UNP    P00734   THRB_HUMAN     364    622             
 DBREF  1A4W I  353   364  UNP    P09945   ITH3_HIRME      60     71             
+SEQADV 1A4W TYS I  363  UNP  P09945    TYR    70 CONFLICT                       
 SEQRES   1 L   36  THR PHE GLY SER GLY GLU ALA ASP CYS GLY LEU ARG PRO          
 SEQRES   2 L   36  LEU PHE GLU LYS LYS SER LEU GLU ASP LYS THR GLU ARG          
 SEQRES   3 L   36  GLU LEU LEU GLU SER TYR ILE ASP GLY ARG                      
@@ -555,18 +543,25 @@ MODRES 1A4W TYS I  363  TYR  O-SULFO-L-TYROSINE
 HET    TYS  I 363      16                                                       
 HET     NA  H 541       1                                                       
 HET     NA  H 542       1                                                       
-HET    QWE  H 373      42                                                       
+HET    ANS  H 373      16                                                       
+HET    DAR  H 350      11                                                       
+HET    2EP  H 375       8                                                       
+HET    KTH  H 377       7                                                       
 HETNAM     TYS O-SULFO-L-TYROSINE                                               
 HETNAM      NA SODIUM ION                                                       
-HETNAM     QWE AMINO{[(4S)-4-({[5-(DIMETHYLAMINO)NAPHTHALEN-1-                  
-HETNAM   2 QWE  YL]SULFONYL}AMINO)-5-OXO-5-{(2R)-2-[3-OXO-3-(1,3-               
-HETNAM   3 QWE  THIAZOL-2-YL)PROPYL]PIPERIDIN-1-                                
-HETNAM   4 QWE  YL}PENTYL]AMINO}METHANIMINIUM                                   
-HETSYN     QWE RWJ-50215                                                        
+HETNAM     ANS 5-(DIMETHYLAMINO)-1-NAPHTHALENESULFONIC ACID(DANSYL              
+HETNAM   2 ANS  ACID)                                                           
+HETNAM     DAR D-ARGININE                                                       
+HETNAM     2EP 2-ETHYLPIPERIDINE                                                
+HETNAM     KTH 2-KETOTHIAZOLE                                                   
+HETSYN     ANS DANSYL ACID                                                      
 FORMUL   3  TYS    C9 H11 N O6 S                                                
 FORMUL   4   NA    2(NA 1+)                                                     
-FORMUL   6  QWE    C29 H40 N7 O4 S2 1+                                          
-FORMUL   7  HOH   *157(H2 O)                                                    
+FORMUL   6  ANS    C12 H13 N O3 S                                               
+FORMUL   6  DAR    C6 H15 N4 O2 1+                                              
+FORMUL   6  2EP    C7 H15 N                                                     
+FORMUL   7  KTH    C4 H3 N O S                                                  
+FORMUL   8  HOH   *157(H2 O)                                                    
 HELIX    1  H1 ALA H   55  LEU H   60  1                                   6    
 HELIX    2  H2 GLU H  164  SER H  171  1                                   8    
 HELIX    3  H3 ASP H  125  LEU H  129C 1                                   8    
@@ -590,6 +585,9 @@ SSBOND   2 CYS H   42    CYS H   58                          1555   1555  2.06
 SSBOND   3 CYS H  168    CYS H  182                          1555   1555  2.06  
 SSBOND   4 CYS H  191    CYS H  220                          1555   1555  2.09  
 LINK         N   TYS I 363                 C   GLU I 362     1555   1555  1.33  
+LINK         S   ANS H 373                 N   DAR H 350     1555   1555  1.91  
+LINK         N1  2EP H 375                 C   DAR H 350     1555   1555  1.42  
+LINK         C2' 2EP H 375                 C2' KTH H 377     1555   1555  1.48  
 LINK        NA    NA H 541                 O   LYS H 224     1555   1555  2.32  
 LINK        NA    NA H 542                 O   LYS H 169     1555   1555  2.36  
 LINK        NA    NA H 542                 O   THR H 172     1555   1555  2.33  
@@ -608,14 +606,13 @@ SITE     1 AC1  6 ARG H 221A LYS H 224  HOH H 403  HOH H 460
 SITE     2 AC1  6 HOH H 464  HOH H 497                                          
 SITE     1 AC2  6 LYS H 169  THR H 172  PHE H 204A HOH H 467                    
 SITE     2 AC2  6 HOH H 515  HOH H 518                                          
-SITE     1 AC3 14 HIS H  57  TYR H  60A TRP H  60D LYS H  60F                   
-SITE     2 AC3 14 GLU H  97A LEU H  99  ASP H 189  ALA H 190                    
-SITE     3 AC3 14 TRP H 215  GLY H 216  GLY H 219  HOH H 448                    
-SITE     4 AC3 14 HOH H 471  HOH H 532                                          
-SITE     1 AC4 14 PHE H  34  ARG H  67  ARG H  73  THR H  74                    
-SITE     2 AC4 14 ARG H  75  TYR H  76  LYS H  81  ILE H  82                    
-SITE     3 AC4 14 HOH H 393  HOH H 432  HOH I 419  HOH I 435                    
-SITE     4 AC4 14 HOH I 476  HOH I 504                                          
+SITE     1 AC3  8 TYR H  60A GLU H  97A LEU H  99  TRP H 215                    
+SITE     2 AC3  8 GLY H 216  GLY H 219  DAR H 350  HOH H 448                    
+SITE     1 AC4  8 ASP H 189  ALA H 190  TRP H 215  GLY H 216                    
+SITE     2 AC4  8 GLY H 219  ANS H 373  2EP H 375  HOH H 471                    
+SITE     1 AC5  4 TRP H  60D LEU H  99  DAR H 350  KTH H 377                    
+SITE     1 AC6  5 HIS H  57  TRP H  60D LYS H  60F 2EP H 375                    
+SITE     2 AC6  5 HOH H 532                                                     
 CRYST1   71.470   72.000   73.390  90.00 101.13  90.00 C 1 2 1       4          
 ORIGX1      1.000000  0.000000  0.000000        0.00000                         
 ORIGX2      0.000000  1.000000  0.000000        0.00000                         
@@ -2866,48 +2863,48 @@ HETATM 2240  O   TYS I 363      18.126   0.587  -2.682  1.00 44.82           O
 TER    2241      TYS I 363                                                      
 HETATM 2242 NA    NA H 541       5.845 -14.122  30.560  0.88 23.48          NA  
 HETATM 2243 NA    NA H 542      18.411 -16.475  38.464  0.88 24.77          NA  
-HETATM 2244  C1  QWE H 373      17.735 -17.178  22.612  1.00 26.29           C  
-HETATM 2245  C2  QWE H 373      18.543 -17.350  21.462  1.00 26.22           C  
-HETATM 2246  C3  QWE H 373      19.877 -17.046  21.558  1.00 26.06           C  
-HETATM 2247  C4  QWE H 373      20.401 -16.566  22.766  1.00 26.60           C  
-HETATM 2248  C4A QWE H 373      19.613 -16.358  23.893  1.00 27.46           C  
-HETATM 2249  C5  QWE H 373      20.084 -15.791  25.046  1.00 28.32           C  
-HETATM 2250  C6  QWE H 373      19.241 -15.568  26.114  1.00 27.47           C  
-HETATM 2251  C7  QWE H 373      17.893 -15.971  26.028  1.00 27.79           C  
-HETATM 2252  C8  QWE H 373      17.370 -16.510  24.879  1.00 26.51           C  
-HETATM 2253  C8A QWE H 373      18.205 -16.689  23.809  1.00 26.70           C  
-HETATM 2254  N   QWE H 373      21.383 -15.285  25.104  1.00 29.72           N  
-HETATM 2255  CM1 QWE H 373      21.898 -14.217  24.214  1.00 30.75           C  
-HETATM 2256  CM2 QWE H 373      22.635 -16.213  25.496  1.00 31.28           C  
-HETATM 2257  S   QWE H 373      15.909 -17.581  22.417  1.00 26.82           S  
-HETATM 2258  O1S QWE H 373      15.988 -18.013  21.010  1.00 27.08           O  
-HETATM 2259  O2S QWE H 373      14.998 -18.191  23.402  1.00 25.52           O  
-HETATM 2260  N1  QWE H 373      14.893 -15.970  22.485  1.00 26.45           N  
-HETATM 2261  CA  QWE H 373      15.193 -15.114  21.296  1.00 26.19           C  
-HETATM 2262  C   QWE H 373      16.307 -14.167  21.752  1.00 26.27           C  
-HETATM 2263  O   QWE H 373      16.212 -13.781  22.914  1.00 24.70           O  
-HETATM 2264  CB  QWE H 373      13.942 -14.354  20.879  1.00 23.76           C  
-HETATM 2265  CG  QWE H 373      13.232 -13.686  22.058  1.00 25.01           C  
-HETATM 2266  CD  QWE H 373      11.892 -13.133  21.595  1.00 23.01           C  
-HETATM 2267  NE  QWE H 373      11.218 -12.647  22.780  1.00 21.45           N  
-HETATM 2268  CZ  QWE H 373      11.457 -11.554  23.483  1.00 20.16           C  
-HETATM 2269  NH1 QWE H 373      12.359 -10.674  23.045  1.00 20.04           N  
-HETATM 2270  NH2 QWE H 373      10.723 -11.336  24.566  1.00 20.85           N  
-HETATM 2271  N11 QWE H 373      17.280 -13.692  20.830  1.00 27.91           N  
-HETATM 2272  C21 QWE H 373      17.043 -14.033  19.327  1.00 30.31           C  
-HETATM 2273  C31 QWE H 373      18.421 -14.472  18.809  1.00 29.73           C  
-HETATM 2274  C41 QWE H 373      19.610 -13.417  19.194  1.00 29.33           C  
-HETATM 2275  C51 QWE H 373      19.696 -13.083  20.765  1.00 28.57           C  
-HETATM 2276  C61 QWE H 373      18.351 -12.680  21.310  1.00 28.50           C  
-HETATM 2277  C1' QWE H 373      16.593 -13.014  18.550  1.00 33.08           C  
-HETATM 2278  C2' QWE H 373      15.941 -13.425  17.179  1.00 37.01           C  
-HETATM 2279  S1  QWE H 373      15.783 -14.904  14.458  1.00 43.62           S  
-HETATM 2280  O2  QWE H 373      17.488 -11.922  16.287  1.00 41.38           O  
-HETATM 2281  C52 QWE H 373      17.059 -15.583  13.508  1.00 43.74           C  
-HETATM 2282  C22 QWE H 373      16.864 -13.556  14.739  1.00 42.63           C  
-HETATM 2283 C2'1 QWE H 373      16.825 -12.903  16.107  1.00 40.59           C  
-HETATM 2284  C42 QWE H 373      18.146 -14.734  13.451  1.00 43.96           C  
-HETATM 2285  N3  QWE H 373      18.049 -13.554  14.106  1.00 43.46           N  
+HETATM 2244  C1  ANS H 373      17.735 -17.178  22.612  1.00 26.29           C  
+HETATM 2245  C2  ANS H 373      18.543 -17.350  21.462  1.00 26.22           C  
+HETATM 2246  C3  ANS H 373      19.877 -17.046  21.558  1.00 26.06           C  
+HETATM 2247  C4  ANS H 373      20.401 -16.566  22.766  1.00 26.60           C  
+HETATM 2248  C4A ANS H 373      19.613 -16.358  23.893  1.00 27.46           C  
+HETATM 2249  C5  ANS H 373      20.084 -15.791  25.046  1.00 28.32           C  
+HETATM 2250  C6  ANS H 373      19.241 -15.568  26.114  1.00 27.47           C  
+HETATM 2251  C7  ANS H 373      17.893 -15.971  26.028  1.00 27.79           C  
+HETATM 2252  C8  ANS H 373      17.370 -16.510  24.879  1.00 26.51           C  
+HETATM 2253  C8A ANS H 373      18.205 -16.689  23.809  1.00 26.70           C  
+HETATM 2254  N   ANS H 373      21.383 -15.285  25.104  1.00 29.72           N  
+HETATM 2255  CM1 ANS H 373      21.898 -14.217  24.214  1.00 30.75           C  
+HETATM 2256  CM2 ANS H 373      22.635 -16.213  25.496  1.00 31.28           C  
+HETATM 2257  S   ANS H 373      15.909 -17.581  22.417  1.00 26.82           S  
+HETATM 2258  O1S ANS H 373      15.988 -18.013  21.010  1.00 27.08           O  
+HETATM 2259  O2S ANS H 373      14.998 -18.191  23.402  1.00 25.52           O  
+HETATM 2260  N   DAR H 350      14.893 -15.970  22.485  1.00 26.45           N  
+HETATM 2261  CA  DAR H 350      15.193 -15.114  21.296  1.00 26.19           C  
+HETATM 2262  CB  DAR H 350      13.942 -14.354  20.879  1.00 23.76           C  
+HETATM 2263  CG  DAR H 350      13.232 -13.686  22.058  1.00 25.01           C  
+HETATM 2264  CD  DAR H 350      11.892 -13.133  21.595  1.00 23.01           C  
+HETATM 2265  NE  DAR H 350      11.218 -12.647  22.780  1.00 21.45           N  
+HETATM 2266  CZ  DAR H 350      11.457 -11.554  23.483  1.00 20.16           C  
+HETATM 2267  NH1 DAR H 350      12.359 -10.674  23.045  1.00 20.04           N  
+HETATM 2268  NH2 DAR H 350      10.723 -11.336  24.566  1.00 20.85           N  
+HETATM 2269  C   DAR H 350      16.307 -14.167  21.752  1.00 26.27           C  
+HETATM 2270  O   DAR H 350      16.212 -13.781  22.914  1.00 24.70           O  
+HETATM 2271  N1  2EP H 375      17.280 -13.692  20.830  1.00 27.91           N  
+HETATM 2272  C2  2EP H 375      17.043 -14.033  19.327  1.00 30.31           C  
+HETATM 2273  C3  2EP H 375      18.421 -14.472  18.809  1.00 29.73           C  
+HETATM 2274  C4  2EP H 375      19.610 -13.417  19.194  1.00 29.33           C  
+HETATM 2275  C5  2EP H 375      19.696 -13.083  20.765  1.00 28.57           C  
+HETATM 2276  C6  2EP H 375      18.351 -12.680  21.310  1.00 28.50           C  
+HETATM 2277  C1' 2EP H 375      16.593 -13.014  18.550  1.00 33.08           C  
+HETATM 2278  C2' 2EP H 375      15.941 -13.425  17.179  1.00 37.01           C  
+HETATM 2279  S1  KTH H 377      15.783 -14.904  14.458  1.00 43.62           S  
+HETATM 2280  O2  KTH H 377      17.488 -11.922  16.287  1.00 41.38           O  
+HETATM 2281  C5  KTH H 377      17.059 -15.583  13.508  1.00 43.74           C  
+HETATM 2282  C2  KTH H 377      16.864 -13.556  14.739  1.00 42.63           C  
+HETATM 2283  C2' KTH H 377      16.825 -12.903  16.107  1.00 40.59           C  
+HETATM 2284  C4  KTH H 377      18.146 -14.734  13.451  1.00 43.96           C  
+HETATM 2285  N3  KTH H 377      18.049 -13.554  14.106  1.00 43.46           N  
 HETATM 2286  O   HOH L 382      -2.186  12.007  23.167  0.90 17.26           O  
 HETATM 2287  O   HOH L 391      -6.499   6.251  26.260  0.86 24.38           O  
 HETATM 2288  O   HOH L 408      -2.832   0.680  34.246  0.94 22.88           O  
@@ -3115,17 +3112,17 @@ CONECT 2257 2244 2258 2259 2260
 CONECT 2258 2257                                                                
 CONECT 2259 2257                                                                
 CONECT 2260 2257 2261                                                           
-CONECT 2261 2260 2262 2264                                                      
-CONECT 2262 2261 2263 2271                                                      
-CONECT 2263 2262                                                                
-CONECT 2264 2261 2265                                                           
+CONECT 2261 2260 2262 2269                                                      
+CONECT 2262 2261 2263                                                           
+CONECT 2263 2262 2264                                                           
+CONECT 2264 2263 2265                                                           
 CONECT 2265 2264 2266                                                           
-CONECT 2266 2265 2267                                                           
-CONECT 2267 2266 2268                                                           
-CONECT 2268 2267 2269 2270                                                      
-CONECT 2269 2268                                                                
-CONECT 2270 2268                                                                
-CONECT 2271 2262 2272 2276                                                      
+CONECT 2266 2265 2267 2268                                                      
+CONECT 2267 2266                                                                
+CONECT 2268 2266                                                                
+CONECT 2269 2261 2270 2271                                                      
+CONECT 2270 2269                                                                
+CONECT 2271 2269 2272 2276                                                      
 CONECT 2272 2271 2273 2277                                                      
 CONECT 2273 2272 2274                                                           
 CONECT 2274 2273 2275                                                           
@@ -3147,5 +3144,5 @@ CONECT 2375 2243
 CONECT 2401 2242                                                                
 CONECT 2415 2243                                                                
 CONECT 2418 2243                                                                
-MASTER      484    0    4    4   14    0   13    6 2439    3   82   24          
+MASTER      471    0    7    4   14    0   12    6 2439    3   82   24          
 END                                                                             


### PR DESCRIPTION
Provides many changes to `AtomPositionMap` and `ResidueRangeAndLength`.

* Replaces calcLength methods with getLength methods, which return the full length rather than length-1.
* Better inference for full-chain ranges
* Limited support for scop-style "_" wildcard chain names
* Better testing