### PR TITLE
Add CrystalCell method to convert operators to function on the unit cell

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalCell.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalCell.java
@@ -149,7 +149,7 @@ public class CrystalCell implements Serializable {
 	 * <p>For instance, all points in the unit cell at the origin will return (0,0,0);
 	 * Points in the unit cell one unit further along the `a` axis will return (1,0,0),
 	 * etc.
-	 * @param pt Input point
+	 * @param pt Input point (in orthonormal coordinates)
 	 * @return A new point with the three indices of the cell containing pt
 	 */
 	public Point3i getCellIndices(Tuple3d pt) {
@@ -183,7 +183,7 @@ public class CrystalCell implements Serializable {
 	 * This is useful to transform a whole chain at once, allowing some of the
 	 * atoms to be outside the unit cell, but forcing the centroid to be within it.
 	 *
-	 * @param points A set of points to transform
+	 * @param points A set of points to transform (in orthonormal coordinates)
 	 * @param reference The reference point, which is unmodified but which would
 	 *    be in the unit cell were it to have been transformed. It is safe to
 	 *    use a member of the points array here.
@@ -203,6 +203,52 @@ public class CrystalCell implements Serializable {
 			point.z -= z;
 			transfToOrthonormal(point);
 		}
+	}
+	
+	/**
+	 * 
+	 * @param ops Set of operations in orthonormal coordinates
+	 * @param reference Reference point, which should be in the unit cell after
+	 *  each operation (also in orthonormal coordinates)
+	 * @return A set of orthonormal operators with equivalent rotation to the
+	 *  inputs, but with translation such that the reference point would fall
+	 *  within the unit cell
+	 */
+	public Matrix4d[] transfToOriginCell(Matrix4d[] ops, Tuple3d reference) {
+		Matrix4d[] transformed = new Matrix4d[ops.length];
+		
+		// reference in crystal coords
+		Point3d refXtal = new Point3d(reference);
+		transfToCrystal(refXtal);
+		
+		
+		for(int j=0;j<ops.length;j++) {
+			// Convert to crystal coords
+			Matrix4d op = transfToCrystal(ops[j]);
+			
+			// transform the reference point
+			Point3d xXtal = new Point3d(refXtal);
+			op.transform(xXtal);
+
+			// Calculate unit cell of transformed reference
+			int x = (int)Math.floor(xXtal.x);
+			int y = (int)Math.floor(xXtal.y);
+			int z = (int)Math.floor(xXtal.z);
+			
+			Matrix4d translation = new Matrix4d();
+			translation.set(new Vector3d(-x,-y,-z));
+
+			// Compose op with an additional translation operator
+			translation.mul(op);
+
+			Point3d ref2 = new Point3d(refXtal);
+			translation.transform(ref2);
+			
+			// Convert back to orthonormal
+			transformed[j] = transfToOrthonormal(translation);
+		}
+		
+		return transformed;
 	}
 
 	/**

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/xtal/TestCrystalCell.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/xtal/TestCrystalCell.java
@@ -20,14 +20,16 @@
  */
 package org.biojava.nbio.structure.xtal;
 
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
+import javax.vecmath.AxisAngle4d;
+import javax.vecmath.Matrix4d;
 import javax.vecmath.Point3d;
 import javax.vecmath.Point3i;
+import static java.lang.Math.sqrt;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.Before;
+import org.junit.Test;
 
 public class TestCrystalCell {
 
@@ -207,4 +209,41 @@ public class TestCrystalCell {
 		assertTrue("Error transforming to origin. Expected:"+expected+" but was:"+query, expected.epsilonEquals(query, tol));
 	}
 
+	@Test
+	public void testMatrixTransfToOriginCell() {
+		CrystalCell cell = new CrystalCell(100, 100, 100, 90, 90, 45);
+
+		Matrix4d[] operations = new Matrix4d[2];
+		
+		Matrix4d xtalOp;
+		int i = 0;
+		
+		// 90 deg rotation
+		xtalOp = new Matrix4d();
+		xtalOp.set(new AxisAngle4d(0,0,1,Math.PI/2));
+		operations[i++] = cell.transfToOrthonormal(xtalOp);
+		
+		// translate (+2,+1,-1) followed by 90 deg rotation 
+		xtalOp.m03 += 2;
+		xtalOp.m13 += 1;
+		xtalOp.m23 += -1;
+		operations[i++] = cell.transfToOrthonormal(xtalOp);
+		
+		xtalOp.set(new AxisAngle4d(0,0,1,-Math.PI/4));
+		xtalOp.m03 += 1;
+
+		Point3d ref;
+		ref = new Point3d(50-3*25*sqrt(2), -3*25*sqrt(2), 50); // center of cell (.5,-2,0)
+		
+		Matrix4d[] transformed = cell.transfToOriginCell(operations, ref);
+		
+		for(Matrix4d op: transformed) {
+			Point3d x = new Point3d(ref);
+			op.transform(x);
+			
+			Point3i index = cell.getCellIndices(x);
+			assertEquals(new Point3i(0,0,0),index);
+		}
+		
+	}
 }


### PR DESCRIPTION
Adds a translational component to an operator such that a particular point falls within the unit cell.