### PR TITLE
Patch

### DIFF
--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DisplayAFP.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DisplayAFP.java
@@ -75,16 +75,16 @@ public class DisplayAFP
 
 	private static boolean isAlignedPosition(int i, char c1, char c2, boolean isFatCat,char[]symb)
 	{
-		if ( isFatCat){
+//		if ( isFatCat){
 			char s = symb[i];
 			if ( c1 != '-' && c2 != '-' && s != ' '){
 				return true;
 			}          
-		} else {
-
-			if ( c1 != '-' && c2 != '-')
-				return true;
-		}
+//		} else {
+//
+//			if ( c1 != '-' && c2 != '-')
+//				return true;
+//		}
 
 		return false;
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/AligPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/AligPanel.java
@@ -244,7 +244,8 @@ public void paintComponent(Graphics g){
             else
                isGapped = true;
          } else {
-            if ( c1 !=  '-' && c2 != '-' ){
+        	char s = symb[i];
+            if ( c1 !=  '-' && c2 != '-' && s!= ' '){
                // no gap
                g2D.setFont(eqFont);
             } else {
@@ -276,7 +277,7 @@ public void paintComponent(Graphics g){
                } else  {
                   
                   int colorPos = 0;
-                  if (isFATCAT ) {
+                  if (isFATCAT) {
                      int block = 0;
                      char s = symb[i];
                      try {
@@ -291,11 +292,19 @@ public void paintComponent(Graphics g){
                         colorPos = ColorUtils.colorWheel.length % colorPos ;
                      }
                   } else {
-                     colorPos = AFPAlignmentDisplay.getBlockNrForAlignPos(afpChain, i);
-                     bg  = ColorUtils.getIntermediate(ColorUtils.orange, end1, blockNum, colorPos);
-                     bg2   = ColorUtils.getIntermediate(ColorUtils.cyan, end2, blockNum, colorPos);
-                     //bg = ColorUtils.rotateHue(ColorUtils.orange,  (1.0f  / 24.0f) * colorPos );
-                     //bg2 = ColorUtils.rotateHue(ColorUtils.cyan,  (1.0f  / 16.0f) * colorPos);
+                	  colorPos = AFPAlignmentDisplay.getBlockNrForAlignPos(afpChain, i);
+                	  if (afpChain.getBlockColors()==null){
+                		  bg  = ColorUtils.getIntermediate(ColorUtils.orange, end1, blockNum, colorPos);
+                		  bg2   = ColorUtils.getIntermediate(ColorUtils.cyan, end2, blockNum, colorPos);
+                		  //bg = ColorUtils.rotateHue(ColorUtils.orange,  (1.0f  / 24.0f) * colorPos );
+                		  //bg2 = ColorUtils.rotateHue(ColorUtils.cyan,  (1.0f  / 16.0f) * colorPos);
+                	  }
+                	  else{
+                		  Color[] colors = afpChain.getBlockColors();
+                		  int n = colors.length;
+                		  bg = colors[colorPos%n];
+                		  bg2 = colors[((colorPos+1)%n)%afpChain.getBlockNum()];
+                	  }
                   }
                   
                    

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/StructureAlignmentJmol.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/StructureAlignmentJmol.java
@@ -541,7 +541,7 @@ public void actionPerformed(ActionEvent e) {
 
    }
 
-   public static String getJmolString(AFPChain afpChain, Atom[] ca1, Atom[] ca2){
+   public String getJmolString(AFPChain afpChain, Atom[] ca1, Atom[] ca2){
      
       if ( afpChain.getBlockNum() > 1){
          return getMultiBlockJmolScript( afpChain,  ca1,  ca2);
@@ -616,7 +616,7 @@ public void actionPerformed(ActionEvent e) {
       return j.toString();
    }
    
-   public static String getJmolScript4Block(AFPChain afpChain, Atom[] ca1, Atom[] ca2, int blockNr){
+   public String getJmolScript4Block(AFPChain afpChain, Atom[] ca1, Atom[] ca2, int blockNr){
 	   int blockNum = afpChain.getBlockNum();
 	   
 	   if ( blockNr >= blockNum)
@@ -644,7 +644,7 @@ public void actionPerformed(ActionEvent e) {
    }
    
 
-   private static String getMultiBlockJmolScript(AFPChain afpChain, Atom[] ca1, Atom[] ca2)
+   private String getMultiBlockJmolScript(AFPChain afpChain, Atom[] ca1, Atom[] ca2)
    {
 
       int blockNum = afpChain.getBlockNum();      
@@ -671,22 +671,33 @@ public void actionPerformed(ActionEvent e) {
 
    }
 
-private static void printJmolScript4Block(Atom[] ca1, Atom[] ca2, int blockNum,
+private void printJmolScript4Block(Atom[] ca1, Atom[] ca2, int blockNum,
 		int[] optLen, int[][][] optAln, StringWriter jmol, int bk) {
 	//the block nr determines the color...
 	 int colorPos = bk;
-	 if ( colorPos > ColorUtils.colorWheel.length){
-	    colorPos = ColorUtils.colorWheel.length % colorPos ;
+	 
+	 Color c1;
+	 Color c2;
+	 //If the colors for the block are specified in AFPChain use them, otherwise the default ones are calculated
+	 if (afpChain.getBlockColors()==null){
+		 
+		 if ( colorPos > ColorUtils.colorWheel.length){
+		    colorPos = ColorUtils.colorWheel.length % colorPos ;
+		 }
+		 
+		 Color end1 = ColorUtils.rotateHue(ColorUtils.orange,  (1.0f  / 24.0f) * blockNum  );
+		 Color end2 = ColorUtils.rotateHue(ColorUtils.cyan,    (1.0f  / 24.0f) * (blockNum +1)  ) ;
+		 	 
+		 c1   = ColorUtils.getIntermediate(ColorUtils.orange, end1, blockNum, bk);
+		 c2   = ColorUtils.getIntermediate(ColorUtils.cyan, end2, blockNum, bk);
 	 }
-	 
-	 Color end1 = ColorUtils.rotateHue(ColorUtils.orange,  (1.0f  / 24.0f) * blockNum  );
-	 Color end2 = ColorUtils.rotateHue(ColorUtils.cyan,    (1.0f  / 24.0f) * (blockNum +1)  ) ;
-	 	 
-	 Color c1   = ColorUtils.getIntermediate(ColorUtils.orange, end1, blockNum, bk);
-	 Color c2   = ColorUtils.getIntermediate(ColorUtils.cyan, end2, blockNum, bk);
-	 
-	 
-	 
+	 else{
+		 Color[] colors = afpChain.getBlockColors();
+		 int n = colors.length;
+		 
+		 c1   = colors[colorPos%n];
+		 c2   = colors[(colorPos+1%n)%afpChain.getBlockNum()];
+	 }
 	 
 	 List<String> pdb1 = new ArrayList<String>();
 	 List<String> pdb2 = new ArrayList<String>();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
@@ -1055,6 +1055,7 @@ nBestTrace=nTrace;
 						inner_loop:
 							for(int idep=1; idep<=winSize/2; idep++) {
 
+								// isCopied indicates that bestTrace has changed and needs to be re-copied
 								if(!isCopied)
 									for(jt=0; jt<nBestTrace; jt++) {
 										trace1[jt]=bestTrace1[jt];
@@ -1063,11 +1064,13 @@ nBestTrace=nTrace;
 									}
 								isCopied=false;
 
+								// Move an atom from the previous trace to the current on, or vice versa
 								traceLen[it-1]+=idir;
 								traceLen[it]-=idir;
 								trace1[it]+=idir;
 								trace2[it]+=idir;
 
+								// Copy atoms from the current trace into strBuf
 								is=0;
 								for(jt=0; jt<nBestTrace; jt++) {
 									for(int i=0; i<traceLen[jt]; i++) {
@@ -1078,9 +1081,12 @@ nBestTrace=nTrace;
 									}
 									is+=traceLen[jt];
 								}
+								// Check new RMSD
 								//sup_str(strBuf1, strBuf2, strLen, d_);
 								rmsdNew=calc_rmsd(strBuf1, strBuf2, strLen, true);
 								//System.out.println(String.format("step %d %d %d %.2f old: %.2f", it, idir, idep, rmsdNew, rmsd));
+								
+								// Update best trace if RMSD improved
 								if(rmsdNew<rmsd) {
 
 									for(jt=0; jt<nBestTrace; jt++) {
@@ -1389,12 +1395,12 @@ nBestTrace=nTrace;
 
 				}
 			}
-
-			mat = notifyMatrixListener(mat);
 			
 			if ( params.getScoringStrategy() == CeParameters.ScoringStrategy.SEQUENCE_CONSERVATION){
 				mat = updateMatrixWithSequenceConservation(mat,ca1,ca2, params);
 			}
+			
+			mat = notifyMatrixListener(mat);
 			
 			double gapOpen = params.getGapOpen();
 			double gapExtension = params.getGapExtension();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeUserArgumentProcessor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeUserArgumentProcessor.java
@@ -35,7 +35,7 @@ import org.biojava.nbio.structure.align.ce.CeParameters.ScoringStrategy;
  */
 public class CeUserArgumentProcessor extends AbstractUserArgumentProcessor {
 	
-	protected class CeStartupParams extends StartupParameters {
+	protected static class CeStartupParams extends StartupParameters {
 		protected int maxGapSize;
 		protected int winSize;
 		protected ScoringStrategy scoringStrategy;
@@ -202,7 +202,6 @@ public class CeUserArgumentProcessor extends AbstractUserArgumentProcessor {
 		//return legend;
 		
 		return "# name1\tname2\tscore\tz-score\trmsd\tlen1\tlen2\tcov1\tcov2\t%ID\tDescription\t " ;
-		
 		
 	}
 	

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AFPChain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AFPChain.java
@@ -25,6 +25,7 @@ import org.biojava.nbio.structure.align.ce.CeSideChainMain;
 import org.biojava.nbio.structure.align.util.AFPAlignmentDisplay;
 import org.biojava.nbio.structure.jama.Matrix;
 
+import java.awt.Color;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -105,6 +106,7 @@ public class AFPChain implements Serializable, Cloneable
 	int[][][]     blockResList;//the list of AFP for each block
 	Matrix[] blockRotationMatrix;
 	Atom[]   blockShiftVector;
+	Color[] blockColors;    //An array of colors for each block, size = blockNum.
 
 	int     focusResn;      //the size of the set
 	int[]     focusRes1;     //the residues from protein 1
@@ -1281,6 +1283,16 @@ public class AFPChain implements Serializable, Cloneable
 	public void setBlockShiftVector(Atom[] blockShiftVector)
 	{
 		this.blockShiftVector = blockShiftVector;
+	}
+	
+	public Color[] getBlockColors()
+	{
+		return blockColors;
+	}
+	
+	public void setBlockColors(Color[] colors)
+	{
+		this.blockColors = colors;
 	}
 
 	public String getAlgorithmName() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AFPAlignmentDisplay.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AFPAlignmentDisplay.java
@@ -449,13 +449,14 @@ public class AFPAlignmentDisplay
 					}
 				}
 
-				len++;
+				
 				p1b = p1;
 				p2b = p2;
 				if ( len >= aligPos) {
 
 					return i;
 				}
+				len++;
 			}
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AFPAlignmentDisplay.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AFPAlignmentDisplay.java
@@ -462,6 +462,4 @@ public class AFPAlignmentDisplay
 		return blockNum;
 
 	}
-
-
 }


### PR DESCRIPTION
Summary of the changes:

- AlignmentTools: new method to calculate block gaps, extended updateSuperposition to calculate the score and RMSD of each block, method to replace an optimal alignment in an AFPChain.

- DisplayAFP: in the alignment panel non FatCat alignments only considered a gap between two residues if a dash ('-') was present in any of the two sequences, but in the CESymm case, a gap can be also described by a space in the symb variable of the AFPChain (without a dash).

- CECalculator: matrix listener used to maintain the black out regions of the matrix mat during the optimization step of the alignment (only applied to the CeSymm class, the matrix listener was already present in the CECalculator).

- AFPChain: added a new member variable to set the colors of the jmol display, named blockColors. Code in the AligPanel has been extended to color the subunits (blocks) accordingly if the variable is not null.