### PR TITLE
New feature: Compound.getAlignedResIndex

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Compound.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Compound.java
@@ -25,13 +25,16 @@
 package org.biojava.nbio.structure;
 
 
+import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -70,6 +73,12 @@ public class Compound implements Serializable {
 	 */
 	private int molId;
 
+	/**
+	 * A map to cache residue number mapping, between ResidueNumbers and index (1-based) in aligned sequences (SEQRES).
+	 * Initialised lazily upon call to {@link #getAlignedResIndex(Group, Chain)}
+	 */
+	private Map<String, Map<ResidueNumber,Integer>> chains2pdbResNums2ResSerials;
+	
 	private String refChainId;
 
 	private String molName = null;
@@ -123,6 +132,7 @@ public class Compound implements Serializable {
 	
 	public Compound () {
 		chains = new ArrayList<Chain>();
+		chains2pdbResNums2ResSerials = new HashMap<String, Map<ResidueNumber,Integer>>();
 		molId = -1;
 	}
 
@@ -134,6 +144,8 @@ public class Compound implements Serializable {
 	public Compound (Compound c) {
 		
 		this.chains = new ArrayList<Chain>();
+		
+		this.chains2pdbResNums2ResSerials = new HashMap<String, Map<ResidueNumber,Integer>>();
 		
 		this.molId = c.molId;
 		
@@ -437,6 +449,50 @@ public class Compound implements Serializable {
 		}
 
 		return new ArrayList<String>(uniqChainIds);
+	}
+	
+	/**
+	 * Given a Group g of Chain c (member of this Compound) return the corresponding position in the 
+	 * alignment of all member sequences (1-based numbering), i.e. this is equivalent 
+	 * to getting the index (1-based) in the SEQRES sequence. 
+	 * If {@link FileParsingParameters#setAlignSeqRes(boolean)} is not used, a mapping will not be available
+	 * and this method will return -1 for all residues of all chains.
+	 * @param g
+	 * @param c
+	 * @return the aligned residue index (1 to n) or -1 if no mapping exists for the given group
+	 * @throws IllegalArgumentException if the given Chain is not a member of this Compound
+	 * @see {@link Chain#getSeqResGroup(int)} 
+	 */
+	public int getAlignedResIndex(Group g, Chain c) {
+		
+		if (!chains.contains(c)) 
+			throw new IllegalArgumentException("Given chain "+c.getChainID()+" is not a member of this Compound (entity): "+getChainIds().toString()); 
+		
+		if (chains2pdbResNums2ResSerials.isEmpty() || !chains2pdbResNums2ResSerials.containsKey(c.getChainID())) {
+			// we do lazy initialisation of the map
+			initResSerialsMap(c);
+		}
+		
+		Integer alignedSerial = chains2pdbResNums2ResSerials.get(c.getChainID()).get(g.getResidueNumber());
+		
+		if (alignedSerial==null) {
+			return -1;
+		}
+		
+		return alignedSerial;
+	}
+	
+	private void initResSerialsMap(Chain c) {
+		if (c.getSeqResGroups().isEmpty()) {
+			logger.warn("No seqres groups found in chain {}, no residue mapping within entity will be available. Make sure you use the ALIGN SEQRES file parsing parameter", c.getChainID());
+		}
+		
+		Map<ResidueNumber,Integer> resNums2ResSerials = new HashMap<ResidueNumber, Integer>();
+		chains2pdbResNums2ResSerials.put(c.getChainID(), resNums2ResSerials);
+		
+		for (int i=0;i<c.getSeqResGroups().size();i++) {
+			resNums2ResSerials.put(c.getSeqResGroup(i).getResidueNumber(), i+1);
+		}
 	}
 
 	/**
@@ -834,7 +890,7 @@ public class Compound implements Serializable {
 	  * @param chain
 	  */
 	public void addChain(Chain chain){
-		this.chains.add(chain);		
+		this.chains.add(chain);
 	}
 
 	/**
@@ -842,6 +898,6 @@ public class Compound implements Serializable {
 	 * @param chains
 	 */
 	public void setChains(List<Chain> chains){
-		this.chains = chains;
+		this.chains = chains;		
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -25,6 +25,7 @@ package org.biojava.nbio.structure;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.contact.AtomContactSet;
 import org.biojava.nbio.structure.contact.Grid;
+import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.PDBFileParser;
 import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
 import org.biojava.nbio.structure.io.mmcif.chem.ResidueType;
@@ -1023,7 +1024,9 @@ public class StructureTools {
 
 	/**
 	 * Returns the set of intra-chain contacts for the given chain for given atom names, i.e. the contact map.
-	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix. 
+	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix.
+	 * The parsing mode {@link FileParsingParameters#setAlignSeqRes(boolean)} needs to be set to true for this 
+	 * to work.  
 	 * @param chain
 	 * @param atomNames the array with atom names to be used. Beware: CA will do both C-alphas an Calciums
 	 * if null all non-H atoms of non-hetatoms will be used
@@ -1047,7 +1050,9 @@ public class StructureTools {
 	
 	/**
 	 * Returns the set of intra-chain contacts for the given chain for all non-H atoms of non-hetatoms, i.e. the contact map.
-	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix. 
+	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix.
+	 * The parsing mode {@link FileParsingParameters#setAlignSeqRes(boolean)} needs to be set to true for this 
+	 * to work.  
 	 * @param chain
 	 * @param cutoff
 	 * @return
@@ -1060,6 +1065,8 @@ public class StructureTools {
 	 * Returns the set of intra-chain contacts for the given chain for C-alpha atoms (including non-standard 
 	 * aminoacids appearing as HETATM groups), i.e. the contact map.
 	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix.  
+	 * The parsing mode {@link FileParsingParameters#setAlignSeqRes(boolean)} needs to be set to true for this 
+	 * to work.
 	 * @param chain
 	 * @param cutoff
 	 * @return
@@ -1076,7 +1083,9 @@ public class StructureTools {
 	
 	/**
 	 * Returns the set of inter-chain contacts between the two given chains for the given atom names.
-	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix. 
+	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix.
+	 * The parsing mode {@link FileParsingParameters#setAlignSeqRes(boolean)} needs to be set to true for this 
+	 * to work.  
 	 * @param chain1
 	 * @param chain2
 	 * @param atomNames the array with atom names to be used. For Calphas use {"CA"}, 
@@ -1103,7 +1112,9 @@ public class StructureTools {
 	
 	/**
 	 * Returns the set of inter-chain contacts between the two given chains for all non-H atoms.
-	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix. 
+	 * Uses a geometric hashing algorithm that speeds up the calculation without need of full distance matrix.
+	 * The parsing mode {@link FileParsingParameters#setAlignSeqRes(boolean)} needs to be set to true for this 
+	 * to work.  
 	 * @param chain1
 	 * @param chain2
 	 * @param cutoff

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GroupContactSet.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GroupContactSet.java
@@ -25,26 +25,22 @@ import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.ResidueNumber;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 
 /**
- * A set of residue-residue contacts 
+ * A set of residue-residue contacts.
+ * Relies on residue indices (based on SEQRES and starting with 1) to store the pairs 
+ * and thus to match contacts.
  * 
  * @author duarte_j
- *
+ * @see ResidueIdentifier
  */
 public class GroupContactSet implements Iterable<GroupContact>{ 
 
-	private HashMap<Pair<ResidueNumber>, GroupContact> contacts;
-	
-	/**
-	 * A cached HashSet to be used only if hasContact(Pair<ResidueIdentifier>) is called
-	 */
-	private HashSet<Pair<ResidueIdentifier>> residueIdContacts;
+	private HashMap<Pair<ResidueIdentifier>, GroupContact> contacts;
 	
 	public GroupContactSet() {
-		contacts = new HashMap<Pair<ResidueNumber>, GroupContact>();
+		contacts = new HashMap<Pair<ResidueIdentifier>, GroupContact>();
 	}
 	
 	/**
@@ -53,7 +49,7 @@ public class GroupContactSet implements Iterable<GroupContact>{
 	 * @param atomContacts
 	 */
 	public GroupContactSet(AtomContactSet atomContacts) {
-		contacts = new HashMap<Pair<ResidueNumber>, GroupContact>();
+		contacts = new HashMap<Pair<ResidueIdentifier>, GroupContact>();
 		atoms2groups(atomContacts);
 	}
 	
@@ -71,7 +67,7 @@ public class GroupContactSet implements Iterable<GroupContact>{
 			if (iResidue.equals(jResidue)) continue;
 			
 			Pair<Group> residuePair = new Pair<Group> (iResidue, jResidue);
-			Pair<ResidueNumber> pair = new Pair<ResidueNumber>(iResidue.getResidueNumber(), jResidue.getResidueNumber());
+			Pair<ResidueIdentifier> pair = new Pair<ResidueIdentifier>(new ResidueIdentifier(iResidue), new ResidueIdentifier(jResidue));
 			
 			if (!contacts.containsKey(pair)) {
 				
@@ -93,7 +89,7 @@ public class GroupContactSet implements Iterable<GroupContact>{
 	}
 
 	public void add(GroupContact groupContact) {
-		contacts.put(getResNumberPairFromContact(groupContact),groupContact);
+		contacts.put(getResIdPairFromContact(groupContact),groupContact);
 	}
 	
 	/**
@@ -128,23 +124,8 @@ public class GroupContactSet implements Iterable<GroupContact>{
 	 * @return
 	 */
 	public boolean hasContact(ResidueIdentifier resId1, ResidueIdentifier resId2) {
-		if (residueIdContacts == null) {
-			initResidueIdContacts();
-		}
-		
-		return residueIdContacts.contains(new Pair<ResidueIdentifier>(resId1, resId2));		
-	}
-	
-	private void initResidueIdContacts() {
-		residueIdContacts = new HashSet<Pair<ResidueIdentifier>>();
-		for (Pair<ResidueNumber> pairResNum:contacts.keySet()) {
-			ResidueNumber resNumFirst = pairResNum.getFirst();
-			ResidueNumber resNumSecond = pairResNum.getSecond();
-			residueIdContacts.add(new Pair<ResidueIdentifier>(
-					new ResidueIdentifier(resNumFirst.getSeqNum(), resNumFirst.getInsCode()),
-					new ResidueIdentifier(resNumSecond.getSeqNum(), resNumSecond.getInsCode())
-					) ); 
-		}
+				
+		return contacts.containsKey(new Pair<ResidueIdentifier>(resId1, resId2));		
 	}
 	
 	/**
@@ -167,8 +148,10 @@ public class GroupContactSet implements Iterable<GroupContact>{
 		return contacts.values().iterator();
 	}
 	
-	private Pair<ResidueNumber> getResNumberPairFromContact(GroupContact groupContact) {
-		return new Pair<ResidueNumber>(groupContact.getPair().getFirst().getResidueNumber(),groupContact.getPair().getSecond().getResidueNumber());
+	private Pair<ResidueIdentifier> getResIdPairFromContact(GroupContact groupContact) {
+		return new Pair<ResidueIdentifier>(
+				new ResidueIdentifier(groupContact.getPair().getFirst()),
+				new ResidueIdentifier(groupContact.getPair().getSecond()) );
 		
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/ResidueIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/ResidueIdentifier.java
@@ -20,45 +20,56 @@
  */
 package org.biojava.nbio.structure.contact;
 
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.Group;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
- * A class used only within the contact package to be able to compare 
- * contacts based on residue numbers and independently from chain identifiers
+ * A bean for identifying groups in GroupContactSets.
+ * Used only within the contact package to be able to compare 
+ * contacts between chains of same entity/compound based on residue numbers 
+ * and independently from chain identifiers.
  * 
  * @author duarte_j
  */
 class ResidueIdentifier {
 
-	private int seqNum;
-	private Character insCode;
+	private static final Logger logger = LoggerFactory.getLogger(ResidueIdentifier.class);
 	
-	public ResidueIdentifier(int seqNum, Character insCode) {
-		this.seqNum = seqNum;
-		this.insCode = insCode;
+	private int seqResIndex;
+	
+	
+	public ResidueIdentifier(Group g) {
+
+		Chain c = g.getChain();
+		if (c==null) {
+			logger.warn("Chain is not available for group {}. Contact comparison will not work for this residue",g.toString());
+			this.seqResIndex = -1;
+		} else {
+			Compound comp = c.getCompound();
+			if (comp==null) {
+				logger.warn("Compound is not available for group {}. Contact comparison will not work for this residue",g.toString());
+				this.seqResIndex = -1;
+			} else {
+				this.seqResIndex = comp.getAlignedResIndex(g, c);
+			}
+
+		}
 	}
 	
-	public int getSeqNum() {
-		return seqNum;
+	public int getSeqResIndex() {
+		return seqResIndex;
 	}
 
-	public void setSeqNum(int seqNum) {
-		this.seqNum = seqNum;
-	}
-
-	public Character getInsCode() {
-		return insCode;
-	}
-
-	public void setInsCode(char insCode) {
-		this.insCode = insCode;
+	public void setSeqResIndex(int seqResIndex) {
+		this.seqResIndex = seqResIndex;
 	}
 
 	@Override
 	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + seqNum;
-		result = prime * result + (insCode==null?0:insCode);
-		return result;
+		return seqResIndex;
 	}
 
 	@Override
@@ -70,24 +81,13 @@ class ResidueIdentifier {
 		if (getClass() != obj.getClass())
 			return false;
 		ResidueIdentifier other = (ResidueIdentifier) obj;
-		if (this.seqNum!=other.seqNum) 
-			return false;
-		if (this.insCode==null && other.insCode!=null)
-			return false;
-		if (this.insCode!=null && other.insCode==null)
-			return false;
-		if (this.insCode==null && other.insCode==null)
-			return true;
-		if (this.insCode!=other.insCode)
-			return false;
-
-		return true;
+		
+		return this.seqResIndex == other.seqResIndex;
 	}
 
 	@Override
 	public String toString() {
-		return ""+ seqNum + (insCode==null?"":insCode);
+		return ""+ seqResIndex;
 	}
 
-	
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
@@ -24,6 +24,7 @@ import org.biojava.nbio.structure.*;
 import org.biojava.nbio.structure.asa.AsaCalculator;
 import org.biojava.nbio.structure.asa.GroupAsa;
 import org.biojava.nbio.structure.io.FileConvert;
+import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
 import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.biojava.nbio.structure.xtal.CrystalTransform;
@@ -538,7 +539,9 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 	 * The two sides of the given StructureInterface need to match this StructureInterface
 	 * in the sense that they must come from the same Compound (Entity), i.e.
 	 * their residue numbers need to align with 100% identity, except for unobserved 
-	 * density residues.
+	 * density residues. The SEQRES indices obtained through {@link Compound#getAlignedResIndex(Group, Chain)} are
+	 * used to match residues, thus if no SEQRES is present or if {@link FileParsingParameters#setAlignSeqRes(boolean)}
+	 * is not used, this calculation is not guaranteed to work properly.
 	 * @param other
 	 * @param invert if false the comparison will be done first-to-first and second-to-second, 
 	 * if true the match will be first-to-second and second-to-first
@@ -586,20 +589,13 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 				ResidueIdentifier second = null;
 
 				if (!invert) {
-					first = new ResidueIdentifier(
-							thisContact.getPair().getFirst().getResidueNumber().getSeqNum(), 
-							thisContact.getPair().getFirst().getResidueNumber().getInsCode());
+					first = new ResidueIdentifier(thisContact.getPair().getFirst());
 					
-					second = new ResidueIdentifier( 
-							thisContact.getPair().getSecond().getResidueNumber().getSeqNum(), 
-							thisContact.getPair().getSecond().getResidueNumber().getInsCode());
+					second = new ResidueIdentifier(thisContact.getPair().getSecond());
 				} else {
-					first = new ResidueIdentifier( 
-							thisContact.getPair().getSecond().getResidueNumber().getSeqNum(), 
-							thisContact.getPair().getSecond().getResidueNumber().getInsCode());
-					second = new ResidueIdentifier(
-							thisContact.getPair().getFirst().getResidueNumber().getSeqNum(), 
-							thisContact.getPair().getFirst().getResidueNumber().getInsCode());
+					first = new ResidueIdentifier(thisContact.getPair().getSecond());
+					
+					second = new ResidueIdentifier(thisContact.getPair().getFirst());
 				}
 
 				if (otherContacts.hasContact(first,second)) {

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundResIndexMapping.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundResIndexMapping.java
@@ -1,0 +1,194 @@
+package org.biojava.nbio.structure;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.biojava.nbio.structure.io.PDBFileParser;
+import org.junit.Test;
+
+public class TestCompoundResIndexMapping {
+
+	private static final String PATH_TO_TEST_FILES = "/org/biojava/nbio/structure/io/";
+	
+	
+	@Test
+	public void test1B8G() throws IOException, StructureException { 
+
+		
+		AtomCache cache = new AtomCache();
+		FileParsingParameters params = new FileParsingParameters();
+		params.setAlignSeqRes(true);
+		cache.setFileParsingParams(params);
+		
+		StructureIO.setAtomCache(cache); 
+
+		cache.setUseMmCif(false);
+		Structure s = StructureIO.getStructure("1B8G");
+		
+		Chain chainA = s.getChainByPDB("A");
+		int i = chainA.getCompound().getAlignedResIndex(chainA.getAtomGroup(0),chainA);
+		assertEquals("First residue in 1b8gA "+chainA.getAtomGroup(0).toString()+" should map to 1 in SEQRES",1,i);
+		
+		checkAllResidues(s);		
+		
+	}
+
+	@Test
+	public void test1SMT() throws IOException, StructureException { 
+
+		
+		AtomCache cache = new AtomCache();
+		FileParsingParameters params = new FileParsingParameters();
+		params.setAlignSeqRes(true);
+		cache.setFileParsingParams(params);
+
+		
+		StructureIO.setAtomCache(cache); 
+
+		cache.setUseMmCif(false);
+		Structure s = StructureIO.getStructure("1SMT");
+		
+		Chain chainA = s.getChainByPDB("A");
+		int i = chainA.getCompound().getAlignedResIndex(chainA.getAtomGroup(0),chainA);
+		assertEquals("First residue in 1smtA "+chainA.getAtomGroup(0).toString()+" should map to 24 in SEQRES",24,i);
+		Chain chainB = s.getChainByPDB("B");
+		i = chainB.getCompound().getAlignedResIndex(chainB.getAtomGroup(0),chainB);
+		assertEquals("First residue in 1smtB "+chainA.getAtomGroup(0).toString()+" should map to 20 in SEQRES",20,i);
+		
+		checkAllResidues(s);
+	}
+	
+	private void checkAllResidues(Structure s) {
+		for (Chain c:s.getChains()) {
+			for (Group g:c.getAtomGroups()) {
+				if (g.getType() != GroupType.AMINOACID) continue;
+				
+				int resIndex = c.getCompound().getAlignedResIndex(g, c);
+				assertNotEquals("Residue "+g.getResidueNumber()+" should not map to -1 in SEQRES",-1, resIndex);
+				assertNotEquals("Residue "+g.getResidueNumber()+" should not map to 0 in SEQRES",0, resIndex);
+				assertTrue(resIndex <= c.getSeqResLength());
+			}
+		}
+	}
+	
+	//@Test
+	public void test3ddoRawNoSeqres() throws IOException, StructureException { 
+		
+		// 3ddo has 6 chains in 1 entity, all of them with different residue numbering (chain A is 1000+, chain B 2000+ ...)
+		Structure s = getStructure("3ddo_raw_noseqres.pdb.gz", true);
+		
+		assertEquals(1,s.getCompounds().size());
+		
+		Chain chainA = s.getChainByPDB("A");
+		Chain chainB = s.getChainByPDB("B");
+		Chain chainC = s.getChainByPDB("C");
+
+		// the last 3 residues of each chain are all the same: they should map to the same index
+		for (int resNum=251;resNum<=253;resNum++) {
+			Group groupInChainA = chainA.getGroupByPDB(new ResidueNumber("A", resNum+1000, null));
+			int indexInChainA = chainA.getCompound().getAlignedResIndex(groupInChainA, chainA);
+			
+			Group groupInChainB = chainB.getGroupByPDB(new ResidueNumber("B", resNum+2000, null));
+			int indexInChainB = chainB.getCompound().getAlignedResIndex(groupInChainB, chainB);
+			
+			Group groupInChainC = chainC.getGroupByPDB(new ResidueNumber("C", resNum+3000, null));
+			int indexInChainC = chainC.getCompound().getAlignedResIndex(groupInChainC, chainC);
+
+			assertNotEquals(-1, indexInChainA);
+			assertNotEquals(-1, indexInChainB);
+			assertNotEquals(-1, indexInChainC);
+			
+			assertEquals(indexInChainA,indexInChainB);
+			assertEquals(indexInChainA,indexInChainC);
+		}
+
+		
+		
+		// this should work either with or without setAlignSeqRes, since the mapping happens in CompoundFinder
+		s = getStructure("3ddo_raw_noseqres.pdb.gz", false);
+		
+		assertEquals(1,s.getCompounds().size());
+		
+		chainA = s.getChainByPDB("A");
+		chainB = s.getChainByPDB("B");
+		chainC = s.getChainByPDB("C");
+
+		// the last 3 residues of each chain are all the same: they should map to the same index
+		for (int resNum=251;resNum<=253;resNum++) {
+			Group groupInChainA = chainA.getGroupByPDB(new ResidueNumber("A", resNum+1000, null));
+			int indexInChainA = chainA.getCompound().getAlignedResIndex(groupInChainA, chainA);
+			
+			Group groupInChainB = chainB.getGroupByPDB(new ResidueNumber("B", resNum+2000, null));
+			int indexInChainB = chainB.getCompound().getAlignedResIndex(groupInChainB, chainB);
+			
+			Group groupInChainC = chainC.getGroupByPDB(new ResidueNumber("C", resNum+3000, null));
+			int indexInChainC = chainC.getCompound().getAlignedResIndex(groupInChainC, chainC);
+
+			assertNotEquals(-1, indexInChainA);
+			assertNotEquals(-1, indexInChainB);
+			assertNotEquals(-1, indexInChainC);
+
+			assertEquals(indexInChainA,indexInChainB);
+			assertEquals(indexInChainA,indexInChainC);
+		}
+
+
+	}
+	
+	@Test
+	public void test3ddoRawSeqres() throws IOException, StructureException { 
+
+		// 3ddo has 6 chains in 1 entity, all of them with different residue numbering (chain A is 1000+, chain B 2000+ ...)
+		Structure s = getStructure("3ddo_raw_trunc_seqres.pdb.gz", true);
+
+		assertEquals(1,s.getCompounds().size());
+
+		Chain chainA = s.getChainByPDB("A");
+		Chain chainB = s.getChainByPDB("B");
+		Chain chainC = s.getChainByPDB("C");
+
+		// the last 3 residues of each chain are all the same: they should map to the same index
+		for (int resNum=28;resNum<=30;resNum++) {
+			Group groupInChainA = chainA.getGroupByPDB(new ResidueNumber("A", resNum+1000, null));
+			int indexInChainA = chainA.getCompound().getAlignedResIndex(groupInChainA, chainA);
+
+			Group groupInChainB = chainB.getGroupByPDB(new ResidueNumber("B", resNum+2000, null));
+			int indexInChainB = chainB.getCompound().getAlignedResIndex(groupInChainB, chainB);
+
+			Group groupInChainC = chainC.getGroupByPDB(new ResidueNumber("C", resNum+3000, null));
+			int indexInChainC = chainC.getCompound().getAlignedResIndex(groupInChainC, chainC);
+
+			assertNotEquals(-1, indexInChainA);
+			assertNotEquals(-1, indexInChainB);
+			assertNotEquals(-1, indexInChainC);
+
+			assertEquals(indexInChainA,indexInChainB);
+			assertEquals(indexInChainA,indexInChainC);
+		}
+
+
+
+		// this will not work without setAlignSeqRes, since the mapping happens in SeqRes2AtomAligner
+		//s = getStructure("3ddo_raw_trunc_seqres.pdb.gz", false);
+		
+
+
+
+	}
+	
+	private Structure getStructure(String fileName, boolean setAlignSeqRes) throws IOException {
+		InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream(PATH_TO_TEST_FILES+fileName));
+		
+		PDBFileParser pdbpars = new PDBFileParser();
+		FileParsingParameters params = new FileParsingParameters();
+		params.setAlignSeqRes(setAlignSeqRes);
+		pdbpars.setFileParsingParameters(params);
+
+		return pdbpars.parsePDBFile(inStream) ;
+	}
+}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundResIndexMapping.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundResIndexMapping.java
@@ -76,6 +76,11 @@ public class TestCompoundResIndexMapping {
 		}
 	}
 	
+	// This doesn't work yet, since for raw files without a SEQRES, the seqres groups are not populated. Instead
+	// in that case Compound.getAlignedResIndex() returns residue numbers as given (without insertion codes) and
+	// thus in general residues will not be correctly aligned between different chains of same entity. This breaks 
+	// cases like 3ddo (with no SEQRES records) where residue numbering is different in every chain of the one entity. 
+	// see https://github.com/eppic-team/eppic/issues/39
 	//@Test
 	public void test3ddoRawNoSeqres() throws IOException, StructureException { 
 		

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/contact/TestContactCalc.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/contact/TestContactCalc.java
@@ -21,6 +21,9 @@
 package org.biojava.nbio.structure.contact;
 
 import org.biojava.nbio.structure.*;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -40,11 +43,20 @@ public class TestContactCalc {
 			"1w0nA",
 			"1wb4A",
 			"1wvfA",
-			"2gpiA",
-			"2h6fB",
-			"3nulA",
-			"7odcA" };
+			"2gpiA"			
+			};
 	
+	@BeforeClass
+	public static void setupBeforeClass() {
+		AtomCache cache = new AtomCache();
+		FileParsingParameters params = new FileParsingParameters();
+		// it is important to set setAlignSeqRes(true), or otherwise contacts won't be stored correctly
+		// since the contacts are stored via using SEQRES as identifiers 
+		params.setAlignSeqRes(true);
+		cache.setFileParsingParams(params);
+		StructureIO.setAtomCache(cache);
+
+	}
 	
 	@Test
 	public void testIntraChainContacts() throws StructureException, IOException { 
@@ -61,7 +73,7 @@ public class TestContactCalc {
 			System.out.print(pdbId+"\t");
 			String pdbCode = pdbId.substring(0,4);
 			String pdbChainCode = pdbId.substring(4,5);
-
+			
 			Structure structure = StructureIO.getStructure(pdbCode);
 			
 			Chain chain = structure.getChainByPDB(pdbChainCode);
@@ -131,6 +143,10 @@ public class TestContactCalc {
 		assertTrue(Math.abs(contacts1.size()-contacts2.size())<10);
 		assertTrue(Math.abs(contacts1.size()-contacts3.size())<10);
 		assertTrue(Math.abs(contacts2.size()-contacts3.size())<10);
+
+		assertTrue(contacts1.size()>1);
+		assertTrue(contacts2.size()>1);
+		assertTrue(contacts3.size()>1);
 
 		assertTrue(contacts1.size()<atomContacts1.size()/10);
 		assertTrue(contacts2.size()<atomContacts2.size()/10);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/xtal/TestInterfaceClustering.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/xtal/TestInterfaceClustering.java
@@ -1,0 +1,161 @@
+package org.biojava.nbio.structure.xtal;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.zip.GZIPInputStream;
+
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.contact.StructureInterfaceCluster;
+import org.biojava.nbio.structure.contact.StructureInterfaceList;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.biojava.nbio.structure.io.PDBFileParser;
+import org.junit.Test;
+
+public class TestInterfaceClustering {
+
+	@Test
+	public void test3DDO() throws IOException, StructureException {
+		
+		// 3DDO is special in that it contains 6 chains in 1 entity, all of them with different residue numbering
+		
+		AtomCache cache = new AtomCache();
+		FileParsingParameters params = new FileParsingParameters();
+		params.setAlignSeqRes(true);
+		cache.setFileParsingParams(params);
+		cache.setUseMmCif(true);
+		
+		StructureIO.setAtomCache(cache); 
+				
+		Structure s = StructureIO.getStructure("3DDO");
+		
+		CrystalBuilder cb = new CrystalBuilder(s);
+		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
+		interfaces.calcAsas(100, 1, 0);
+		interfaces.removeInterfacesBelowArea();
+		
+		List<StructureInterfaceCluster> clusters = interfaces.getClusters();
+		
+		// 22 if below 35A2 interfaces are filtered
+		assertEquals(22,interfaces.size());
+		
+		// we simply want to test that some interfaces cluster together, for this entry 
+		// it is problematic because of different residue numbering between different chains of same entity
+		assertTrue("Expected fewer than 22 interfaces (some interfaces should cluster together)",clusters.size()<22);
+		
+		// first 2 clusters are of size 3
+		assertEquals("Cluster 1 should have 3 members",3,clusters.get(0).getMembers().size());
+		assertEquals("Cluster 2 should have 3 members",3,clusters.get(1).getMembers().size());
+		
+		// detection of isologous test: first 3 interfaces should be isologous
+		
+		assertTrue("Interface 1 should be isologous",interfaces.get(1).isIsologous());
+		assertTrue("Interface 2 should be isologous",interfaces.get(2).isIsologous());
+		assertTrue("Interface 3 should be isologous",interfaces.get(3).isIsologous());
+		
+		
+		
+	}
+
+	
+	@Test
+	public void test3C5FWithSeqresPdb() throws IOException, StructureException {
+		
+		InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream("/org/biojava/nbio/structure/io/3c5f_raw.pdb.gz"));
+		assertNotNull(inStream);
+
+		PDBFileParser pdbpars = new PDBFileParser();
+		FileParsingParameters params = new FileParsingParameters();
+		params.setAlignSeqRes(true);
+		pdbpars.setFileParsingParameters(params);
+
+		Structure s = pdbpars.parsePDBFile(inStream) ;
+
+		assertNotNull(s);
+		
+		assertEquals(8, s.getChains().size());
+		
+		assertEquals(4, s.getCompounds().size());
+
+		CrystalBuilder cb = new CrystalBuilder(s);
+		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
+		interfaces.calcAsas(100, 1, 0);
+		interfaces.removeInterfacesBelowArea();
+
+		List<StructureInterfaceCluster> clusters = interfaces.getClusters();
+
+		// 23 if below 35A2 interfaces are filtered
+		assertEquals(23,interfaces.size());
+
+		// we simply want to test that some interfaces cluster together
+		assertTrue("Expected fewer than 23 interfaces (some interfaces should cluster together)",clusters.size()<23);
+
+		// third cluster (index 2) is of size 2
+		assertEquals("Cluster 3 should have 2 members",2,clusters.get(2).getMembers().size());
+
+		assertTrue("Interface 3 should be isologous",interfaces.get(3).isIsologous());
+		
+		
+	}
+	
+	// This doesn't work yet, since for raw files without a SEQRES, the seqres groups are not populated. Instead
+	// in that case Compound.getAlignedResIndex() returns residue numbers as given (without insertion codes) and
+	// thus in general residues will not be correctly aligned between different chains of same entity. This breaks 
+	// cases like 3ddo (with no SEQRES records) where residue numbering is different in every chain of the one entity. 
+	// Then contact overlap calculation will be wrong and interface clustering won't work.
+	// see https://github.com/eppic-team/eppic/issues/39
+	// See also TestCompoundResIndexMapping
+	//@Test 
+	public void test3DDONoSeqresPdb() throws IOException, StructureException {
+		
+		// 3ddo contains 6 chains in 1 entity, with residue numbering completely different in each of the chains
+		
+		InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream("/org/biojava/nbio/structure/io/3ddo_raw_noseqres.pdb.gz"));
+		assertNotNull(inStream);
+
+		PDBFileParser pdbpars = new PDBFileParser();
+		FileParsingParameters params = new FileParsingParameters();
+		params.setAlignSeqRes(true);
+		pdbpars.setFileParsingParameters(params);
+
+		Structure s = pdbpars.parsePDBFile(inStream) ;
+
+		assertNotNull(s);
+		
+		assertEquals(6, s.getChains().size());
+		
+		assertEquals(1, s.getCompounds().size());
+		
+		CrystalBuilder cb = new CrystalBuilder(s);
+		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
+		interfaces.calcAsas(100, 1, 0);
+		interfaces.removeInterfacesBelowArea();
+
+		List<StructureInterfaceCluster> clusters = interfaces.getClusters();
+
+		// 22 if below 35A2 interfaces are filtered
+		assertEquals(22,interfaces.size());
+
+		// we simply want to test that some interfaces cluster together, for this entry 
+		// it is problematic because of different residue numbering between different chains of same entity
+		assertTrue("Expected fewer than 22 interfaces (some interfaces should cluster together)",clusters.size()<22);
+
+		// first 2 clusters are of size 3
+		assertEquals("Cluster 1 should have 3 members",3,clusters.get(0).getMembers().size());
+		assertEquals("Cluster 2 should have 3 members",3,clusters.get(1).getMembers().size());
+
+		// detection of isologous test: first 3 interfaces should be isologous
+
+		assertTrue("Interface 1 should be isologous",interfaces.get(1).isIsologous());
+		assertTrue("Interface 2 should be isologous",interfaces.get(2).isIsologous());
+		assertTrue("Interface 3 should be isologous",interfaces.get(3).isIsologous());
+
+
+
+	}
+}


### PR DESCRIPTION
This introduces a new minor feature Compound.getAlignedResIndex(), used for mapping residue numbers to the corresponding seqres residue indices. This was already possible via looking up the indices of Chain.getSeqresGroups(), but like this it is more convenient and a lot faster because the mapping is cached (lazily initialised).

This fixes contact overlap calculation for cases like 3ddo where all 6 chains have different residue numbers for the same entity.