### PR TITLE
Misc updates for structure package

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -164,6 +164,13 @@ public class StructureToolsTest extends TestCase {
 		chain = substr.getChain(0);
 		assertEquals("Did not find the expected number of residues in "+range, 5, chain.getAtomLength() );
 
+		// single residue
+		range = "A:3";
+		substr = StructureTools.getSubRanges(structure2, range);
+		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		chain = substr.getChain(0);
+		assertEquals("Did not find the expected number of residues in "+range, 1, chain.getAtomLength() );
+
 		// Special '-' case
 		range = "-";
 		substr = StructureTools.getSubRanges(structure2, range);

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/ecod/EcodInstallationTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/ecod/EcodInstallationTest.java
@@ -18,7 +18,7 @@
  *      http://www.biojava.org/
  */
 
-package org.biojava.nbio.structure.test.domain;
+package org.biojava.nbio.structure.test.ecod;
 
 import static org.junit.Assert.*;
 

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/ecod/EcodParseTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/ecod/EcodParseTest.java
@@ -1,0 +1,169 @@
+package org.biojava.nbio.structure.test.ecod;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.AtomPositionMap;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.ResidueRange;
+import org.biojava.nbio.structure.ResidueRangeAndLength;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureTools;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.ecod.EcodDatabase;
+import org.biojava.nbio.structure.ecod.EcodDomain;
+import org.biojava.nbio.structure.ecod.EcodFactory;
+import org.biojava.nbio.structure.io.LocalPDBDirectory.ObsoleteBehavior;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is not a unit test.
+ * 
+ * It is a long-running parsing test, which sequentially parses all ECOD domains.
+ * 
+ * The most common warning is caused by residue ranges with missing terminal CA atoms,
+ * which cause a warning to print.
+ * 
+ * develop83 and earlier versions also had a number of invalid ranges, which cause
+ * error messages to print.
+ * 
+ * Filtering log4j messages to the 'error' level will filter all but the most
+ * grevious errors.
+ * 
+ * @author blivens
+ *
+ */
+public class EcodParseTest {
+	private static final Logger logger = LoggerFactory.getLogger(EcodParseTest.class);
+
+	public static void main(String[] args) throws IOException {
+		String ecodVersion = "develop83";
+		EcodDatabase ecod = EcodFactory.getEcodDatabase(ecodVersion);
+		AtomCache cache = new AtomCache();
+		cache.setObsoleteBehavior(ObsoleteBehavior.FETCH_OBSOLETE);
+		List<EcodDomain> domains = ecod.getAllDomains();
+//		domains = Arrays.asList(ecod.getDomainsById("e1yfbB2"));
+//		domains = Arrays.asList(ecod.getDomainsById("e1w50A2"));
+		domains = Arrays.asList(ecod.getDomainsById("e2ftlE1"));
+		int errors = 0;
+		for(EcodDomain d : domains) {
+			Atom[] ca1;
+			Structure struct;
+			try {
+				struct = cache.getStructure(d.getPdbId());
+				ca1 = StructureTools.getRepresentativeAtomArray(struct);
+			} catch (IOException e) {
+				logger.error("Error getting structure for "+d.getDomainId(),e);
+				errors++;
+				continue;
+			} catch (StructureException e) {
+				logger.error("Error getting structure for "+d.getDomainId(),e);
+				errors++;
+				continue;
+			}
+			
+			// Test that the ranges can be parsed
+			String rangeStr = d.getRange();
+			AtomPositionMap map = new AtomPositionMap(ca1);
+			List<? extends ResidueRange> ranges;
+			try {
+				// Parses range given in domain
+				ranges = ResidueRange.parseMultiple(rangeStr);
+			} catch(Exception e) {
+				logger.error("Error parsing "+d.getPdbId()+"_"+d.getRange(),e);
+				errors++;
+				continue;
+			}
+			boolean clean = true;
+			for(ResidueRange r : ranges) {
+				if( r == null ) {
+					clean = false;
+				}
+			}
+			if( ! clean ) {
+				logger.error("Empty range for {}_{}",d.getPdbId(),d.getRange());
+				errors++;
+				continue;
+			}
+			
+
+			// Check that the ranges are valid (or at least that they have a group)
+			for(ResidueRange range : ranges) {
+				try {
+					Integer start = map.getPosition(range.getStart());
+					if(start == null) {
+						Group g = struct.getChainByPDB(range.getStart().getChainId()).getGroupByPDB(range.getStart());
+						if(g!=null) {
+							logger.warn("No CA atom for starting residue "+d.getDomainId()+"_"+range);
+							clean = false;
+						} else {
+							logger.error("Start doesn't exist for "+d.getDomainId()+"_"+range.toString());
+							clean = false;
+						}
+					}
+				} catch(Exception e) {
+					logger.error("Start doesn't exist for "+d.getDomainId()+"_"+range.toString(),e);
+					clean = false;
+				}
+				try {
+					Integer end = map.getPosition(range.getEnd());
+					if(end == null) {
+						Group g = null;
+						try {
+							g = struct.getChainByPDB(range.getEnd().getChainId()).getGroupByPDB(range.getEnd());
+						} catch(StructureException e ) {}
+						if(g!=null) {
+							logger.warn("No CA atom for ending residue "+d.getDomainId()+"_"+range);
+							clean = false;
+						} else {
+							logger.error("End doesn't exist for "+d.getDomainId()+"_"+range.toString());
+							clean = false;
+						}
+					}
+				} catch(Exception e) {
+					logger.error("End doesn't exist for "+d.getDomainId()+"_"+range.toString(),e);
+					clean = false;
+				}
+			}
+			
+			// Try to recover from missing residues by trimming them to the residue range
+			try {
+				// Parses more flexibly, giving only a warning for missing residues
+				ranges = ResidueRangeAndLength.parseMultiple(rangeStr,map);
+			} catch(Exception e) {
+				logger.error("Error parsing "+d.getPdbId()+"_"+d.getRange(),e);
+				errors++;
+				continue;
+			}
+			clean = true;
+			for(ResidueRange r : ranges) {
+				if( r == null ) {
+					clean = false;
+				}
+			}
+			if( ! clean ) {
+				logger.error("Empty range for {}_{}",d.getPdbId(),d.getRange());
+				errors++;
+				continue;
+			}
+			
+			// Test whether we can use it to get a structure
+			String pdbRangeStr = String.format("%s.%s",d.getPdbId(),d.getRange());
+			try {
+				cache.getStructure(pdbRangeStr);
+			} catch(Exception e) {
+				logger.error("Can't get range "+pdbRangeStr,e);
+				errors++;
+				continue;
+			}
+
+			//All test passed
+			logger.info("OK "+d.getDomainId());
+		}
+		logger.info("Done. {} errors.",errors);
+	}
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomPositionMap.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomPositionMap.java
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 
 import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
 import org.biojava.nbio.structure.io.mmcif.chem.ResidueType;
+import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,8 +77,24 @@ public class AtomPositionMap {
 	public static final GroupMatcher AMINO_ACID_MATCHER = new GroupMatcher() {
 		@Override
 		public boolean matches(Group group) {
-			ResidueType type = group.getChemComp().getResidueType();
-			return PolymerType.PROTEIN_ONLY.contains(type.getPolymerType())
+			if( group == null )
+				return false;
+			ChemComp chem = group.getChemComp();
+			if(chem == null)
+				return false;
+			// Get polymer type
+			PolymerType polyType = chem.getPolymerType();
+			if( polyType == null) {
+				ResidueType type = chem.getResidueType();
+				if(type != null ) {
+					polyType = type.getPolymerType();
+				}
+			}
+			if( polyType == null ) {
+				return false;
+			}
+
+			return PolymerType.PROTEIN_ONLY.contains(polyType)
 					&& group.hasAtom(StructureTools.CA_ATOM_NAME);
 		}
 	};

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomPositionMap.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomPositionMap.java
@@ -23,10 +23,18 @@
 
 package org.biojava.nbio.structure;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
 import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
 import org.biojava.nbio.structure.io.mmcif.chem.ResidueType;
-
-import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A map from {@link ResidueNumber ResidueNumbers} to ATOM record positions in a PDB file.
@@ -49,6 +57,8 @@ import java.util.*;
  */
 public class AtomPositionMap {
 
+	private static final Logger logger = LoggerFactory.getLogger(AtomPositionMap.class);
+	
 	private HashMap<ResidueNumber, Integer> hashMap;
 	private TreeMap<ResidueNumber, Integer> treeMap;
 
@@ -320,4 +330,76 @@ public class AtomPositionMap {
 		return ranges;
 	}
 
+	/**
+	 * Trims a residue range so that both endpoints are contained in this map.
+	 * @param rr
+	 * @param map
+	 * @return
+	 */
+	public ResidueRangeAndLength trimToValidResidues(ResidueRange rr) {
+		ResidueNumber start = rr.getStart();
+		ResidueNumber end = rr.getEnd();
+		String chain = rr.getChainId();
+		// Add chainId
+		if(start.getChainId() == null) {
+			start = new ResidueNumber(chain,start.getSeqNum(),start.getInsCode());
+		}
+		if(end.getChainId() == null) {
+			end = new ResidueNumber(chain,end.getSeqNum(),end.getInsCode());
+		}
+		// Check that start and end are present in the map.
+		// If not, try to find the next valid residue
+		// (terminal residues sometimes lack CA atoms, so they don't appear)
+		Integer startIndex = getPosition(start);
+		if( startIndex == null) {
+			// Assume that the residue numbers are sequential
+			// Find startIndex such that the SeqNum is bigger than start's seqNum
+			for(ResidueNumber key :  treeMap.keySet()) {
+				if( !key.getChainId().equals(chain) )
+					continue;
+				if( start.getSeqNum() <= key.getSeqNum() ) {
+					start = key;
+					startIndex = getPosition(key);
+					break;
+				}
+			}
+			if( startIndex == null ) {
+				logger.error("Unable to find Residue {} in AtomPositionMap, and no plausible substitute.",start);
+				return null;
+			} else {
+				logger.warn("Unable to find Residue {}, so substituting {}.",rr.getStart(),start);
+			}
+		}
+		Integer endIndex = getPosition(end);
+		if( endIndex == null) {
+			// Assume that the residue numbers are sequential
+			// Find startIndex such that the SeqNum is bigger than start's seqNum
+			for(ResidueNumber key :  treeMap.descendingKeySet()) {
+				if( !key.getChainId().equals(chain) )
+					continue;
+				Integer value = getPosition(key);
+				if( value < startIndex ) {
+					// start is before the end!
+					break;
+				}
+				if( end.getSeqNum() >= key.getSeqNum() ) {
+					end = key;
+					endIndex = value;
+					break;
+				}
+			}
+			if( endIndex == null ) {
+				logger.error("Unable to find Residue {} in AtomPositionMap, and no plausible substitute.",end);
+				return null;
+			} else {
+				logger.warn("Unable to find Residue {}, so substituting {}.",rr.getEnd(),end);
+			}
+		}
+		
+		// now use those to calculate the length
+		// if start or end is null, will throw NPE
+		int length = getLength(startIndex, endIndex,chain);
+
+		return new ResidueRangeAndLength(chain, start, end, length);
+	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueNumber.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueNumber.java
@@ -42,6 +42,12 @@ public class ResidueNumber implements Serializable, Comparable<ResidueNumber>
 
 	public ResidueNumber() {
 	}
+	
+	public ResidueNumber(ResidueNumber o) {
+		this.chainId = o.chainId;
+		this.insCode = o.insCode;
+		this.seqNum = o.seqNum;
+	}
 
 	public ResidueNumber(String chainId, Integer residueNumber, Character insCode) {
 		this.chainId = chainId;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRange.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRange.java
@@ -47,8 +47,10 @@ public class ResidueRange {
 				"(?::|_|:$|_$|$)" + //colon or underscore, could be at the end of a line, another non-capt. group.
 				"(?:"+ // another non capturing group for the residue range
 					"([-+]?[0-9]+[A-Za-z]?)" + // first residue
-					"\\s*-\\s*" + // -
-					"([-+]?[0-9]+[A-Za-z]?)" + // second residue
+					"(?:" +
+						"\\s*-\\s*" + // -
+						"([-+]?[0-9]+[A-Za-z]?)" + // second residue
+					")?+"+
 				")?+"+
 			")?" + //end range
 			"\\s*");

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1151,6 +1151,11 @@ public class StructureTools {
 
 			String pdbresnumStart = matcher.group(2);
 			String pdbresnumEnd   = matcher.group(3);
+			
+			if(pdbresnumEnd == null ) {
+				// Single residue range
+				pdbresnumEnd = pdbresnumStart;
+			}
 
 
 			if ( ! firstRange){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1168,7 +1168,15 @@ public class StructureTools {
 
 				ResidueNumber pdbresnum1 = ResidueNumber.fromString(pdbresnumStart);
 				ResidueNumber pdbresnum2 = ResidueNumber.fromString(pdbresnumEnd);
-
+				
+				// Trim extra residues off the range
+				Atom[] allAtoms = StructureTools.getRepresentativeAtomArray(struc);
+				AtomPositionMap map = new AtomPositionMap(allAtoms);
+				ResidueRange trimmed = map.trimToValidResidues(new ResidueRange(chain.getChainID(),pdbresnum1,pdbresnum2));
+				if(trimmed != null) {
+					pdbresnum1 = trimmed.getStart();
+					pdbresnum2 = trimmed.getEnd();
+				}
 				groups = chain.getGroupsByPDB(pdbresnum1, pdbresnum2);
 
 				name.append(chainId).append(AtomCache.UNDERSCORE).append(pdbresnumStart).append("-").append(pdbresnumEnd);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -139,7 +139,7 @@ public class StructureTools {
 	/**
 	 * The atom used as representative for nucleotides, equivalent to {@link #CA_ATOM_NAME} for proteins
 	 */
-	public static final String NUCLEOTIDE_REPRESENTATIVE = C4_ATOM_NAME;
+	public static final String NUCLEOTIDE_REPRESENTATIVE = P_ATOM_NAME;
 	
 	/**
 	 * The character to use for unknown compounds in sequence strings
@@ -807,7 +807,7 @@ public class StructureTools {
 					}
 					break;
 				case NUCLEOTIDE:
-					if (g.hasAtom(NUCLEOTIDE_REPRESENTATIVE) && g.getAtom(NUCLEOTIDE_REPRESENTATIVE).getElement()==Element.C) {
+					if (g.hasAtom(NUCLEOTIDE_REPRESENTATIVE) ) {
 						atoms.add(g.getAtom(NUCLEOTIDE_REPRESENTATIVE));
 					}
 					break;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodFactory.java
@@ -82,6 +82,7 @@ public class EcodFactory {
 				versionedEcodDBs.put(version.toLowerCase(), new SoftReference<EcodDatabase>(ecod));
 
 				// If the parsed version differed from that requested, add that too
+				// Note that getVersion() may trigger file parsing
 				try {
 					if( ! versionedEcodDBs.containsKey(ecod.getVersion().toLowerCase()) ) {
 						versionedEcodDBs.put(ecod.getVersion().toLowerCase(),new SoftReference<EcodDatabase>(ecod));
@@ -96,6 +97,9 @@ public class EcodFactory {
 		}
 	}
 	
+	/**
+	 * removes SoftReferences which have already been garbage collected
+	 */
 	private static void releaseReferences() {
 		synchronized(versionedEcodDBs) {
 			Iterator<Entry<String, SoftReference<EcodDatabase>>> it = versionedEcodDBs.entrySet().iterator();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/chem/PolymerType.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/chem/PolymerType.java
@@ -80,6 +80,16 @@ public enum PolymerType implements Serializable
    otherPolymer("other"),
 
    /**
+    * cyclic peptides
+    */
+   cyclicPeptide("cyclic-pseudo-peptide"),
+   
+   /**
+    * Peptide nucleic acids
+    */
+   peptideNucleicAcid("peptide nucleic acid"),
+   
+   /**
     * if all else fails...
     */
    unknown(null);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/chem/ResidueType.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/chem/ResidueType.java
@@ -25,7 +25,7 @@ import java.io.Serializable;
 
 
 /**
- * Enumerates the possible classifications of residues.
+ * Enumerates the possible classifications of residues. These are generally more specific than PolymerTypes
  * This information is derived from the mmcif dictionary.
  * @author mulvaney
  * @author Andreas Prlic
@@ -36,6 +36,7 @@ import java.io.Serializable;
 public enum ResidueType implements Serializable {
 
    atomn(null, "null"), // present in db for _chem_comp.id_ = 'CFL' but not enumerated in dictionary
+   // Peptides
    dPeptideLinking(PolymerType.dpeptide, "D-peptide linking"),
    lPeptideLinking(PolymerType.peptide, "L-peptide linking"),
    glycine(PolymerType.peptide,"PEPTIDE LINKING"),
@@ -44,12 +45,14 @@ public enum ResidueType implements Serializable {
    lPeptideAminoTerminus(PolymerType.peptide, "L-peptide NH3 amino terminus"),
    dPeptideCarboxyTerminus(PolymerType.dpeptide, "D-peptide COOH carboxy terminus"),
    lPeptideCarboxyTerminus(PolymerType.peptide, "L-peptide COOH carboxy terminus"),
+   // Nucleotides
    dnaLinking(PolymerType.dna, "DNA linking"),
    rnaLinking(PolymerType.rna, "RNA linking"),
    dna3PrimeTerminus(PolymerType.dna, "DNA OH 3 prime terminus"),
    rna3PrimeTerminus(PolymerType.rna, "RNA OH 3 prime terminus"),
    dna5PrimeTerminus(PolymerType.dna, "DNA OH 5 prime terminus"),
    rna5PrimeTerminus(PolymerType.rna, "RNA OH 5 prime terminus"),
+   // Sugars
    dSaccharide(PolymerType.polysaccharide, "D-saccharide"),
    dSaccharide14and14linking(PolymerType.polysaccharide, "D-saccharide 1,4 and 1,4 linking"),
    dSaccharide14and16linking(PolymerType.polysaccharide, "D-saccharide 1,4 and 1,6 linking"),
@@ -57,6 +60,15 @@ public enum ResidueType implements Serializable {
    lSaccharide14and14linking(PolymerType.lpolysaccharide, "L-saccharide 1,4 and 1,4 linking"),
    lSaccharide14and16linking(PolymerType.lpolysaccharide, "L-saccharide 1,4 and 1,6 linking"),
    saccharide(PolymerType.polysaccharide, "saccharide"),
+   // Iso-peptides
+   dBetaPeptideCGammaLinking(PolymerType.dpeptide,"D-beta-peptide, C-gamma linking"),
+   dGammaPeptideCDeltaLinking(PolymerType.dpeptide,"D-gamma-peptide, C-delta linking"),
+   lBetaPeptideCGammaLinking(PolymerType.peptide,"L-beta-peptide, C-gamma linking"),
+   lGammaPeptideCDeltaLinking(PolymerType.peptide,"L-gamma-peptide, C-delta linking"),
+   // L nucleotides. As of 2015-04, these are only found in D-DNA hybrids, so they don't have their own PolymerType
+   lDNALinking(PolymerType.dna,"L-DNA linking"),
+   lRNALinking(PolymerType.dna,"L-RNA linking"),
+   // Other
    nonPolymer(null, "non-polymer"),
    otherChemComp(null, "other");
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/ResidueRangeTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/ResidueRangeTest.java
@@ -327,10 +327,8 @@ public class ResidueRangeTest {
 		// Valid ranges
 		String[] yes = new String[] { "A_", "A:", "ABC:", "abc:", "A_5-100",
 				"A_5-100S", "A_5S-100", "A_5S-100S", "A_-5-100", "A_-5--100",
-				"A_-5S--100S", "ABC:-5--200S", "A", "ABCD", "A1", // valid
-				// multi-char
-				// chain
-				// name
+				"A_-5S--100S", "ABC:-5--200S", "A", "ABCD", "A_1", 
+				"A1", // valid multi-char chain name
 				"3A:1-100", // Weird chain name
 				"_", "_:1-10", "__-2--1", "__"// catch-all chain
 		};
@@ -339,7 +337,7 @@ public class ResidueRangeTest {
 					ResidueRange.RANGE_REGEX.matcher(s).matches());
 		}
 		// invalid ranges
-		String[] no = new String[] { "A_1", "A_1-", "A_1S-", "A_1-100-",
+		String[] no = new String[] { "A_1-", "A_1S-", "A_1-100-",
 				"A_-10-1000_", "", "-", "___", "__:" };
 		for (String s : no) {
 			assertFalse(s + " was considered a valid range format",


### PR DESCRIPTION
- Use phosphate atom as DNA representative atom
- Update PolymerType to for recent mmCIF values
- Handle imprecise residue ranges gracefully (finds overlap with valid residues, assuming
  sequential numbering)
- Allow single-residue ranges (used by ECOD)