### PR TITLE
Improving mmCIF support

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRangeAndLength.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRangeAndLength.java
@@ -23,7 +23,6 @@ package org.biojava.nbio.structure;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NavigableMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
@@ -486,13 +486,19 @@ public interface Structure extends Cloneable, StructureIdentifier {
 
 
     /** 
-     * Create a String that contains the contents of a PDB file .
+     * Create a String that contains this Structure's contents in PDB file format.
      *
      * @return a String that looks like a PDB file
      * @see FileConvert
      */
     public String toPDB();
 
+    /**
+     * Create a String that contains this Structure's contents in MMCIF file format.
+     * @return
+     */
+    public String toMMCIF();
+    
     /** 
      * Set the Compounds
      *

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -599,16 +599,17 @@ public class StructureImpl implements Structure, Serializable {
 	}
 
 
-	/** create a String that contains the contents of a PDB file.
-	 *
-	 * @return a String that represents the structure as a PDB file.
-	 */
 	@Override
 	public String toPDB() {
 		FileConvert f = new FileConvert(this) ;
 		return f.toPDB();
 	}
 
+	@Override
+	public String toMMCIF() {
+		FileConvert f = new FileConvert(this);
+		return f.toMMCIF();
+	}
 
 	@Override
 	public boolean hasChain(String chainId) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -22,6 +22,7 @@
 package org.biojava.nbio.structure.io;
 
 import org.biojava.nbio.structure.*;
+import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.biojava.nbio.core.util.XMLWriter;
 
 import java.io.IOException;
@@ -34,8 +35,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-//import org.slf4j.Logger;
-//import org.slf4j.LoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /** Methods to convert a structure object into different file formats.
@@ -44,7 +45,12 @@ import java.util.Map;
  */
 public class FileConvert {
 	
-	//private static final Logger logger = LoggerFactory.getLogger(FileConvert.class);
+	private static final Logger logger = LoggerFactory.getLogger(FileConvert.class);
+	
+	/**
+	 * The character to be printed out in cases where a value is not assigned in mmCIF files
+	 */
+	public static final String MMCIF_MISSING_VALUE = "?";
 	
 	private Structure structure ;
 
@@ -336,7 +342,8 @@ public class FileConvert {
 	}
 	
 	
-	/** Convert a Chain object to PDB representation
+	/** 
+	 * Convert a Chain object to PDB representation
 	 * 
 	 * @param chain
 	 * @return
@@ -358,7 +365,8 @@ public class FileConvert {
 		return w.toString();
 	}
 	
-	/** Convert a Group object to PDB representation
+	/** 
+	 * Convert a Group object to PDB representation
 	 * 
 	 * @param g
 	 * @return
@@ -370,7 +378,7 @@ public class FileConvert {
 	}
 
 	/**
-	 * print ATOM record in the following syntax
+	 * Print ATOM record in the following syntax
 	<pre>
     ATOM      1  N   ASP A  15     110.964  24.941  59.191  1.00 83.44           N
 *
@@ -489,7 +497,8 @@ Angstroms.
 	}
 
 
-	/** convert a protein Structure to a DAS Structure XML response .
+	/** 
+	 * Convert a protein Structure to a DAS Structure XML response .
 	 * @param xw  a XMLWriter object
 	 * @throws IOException ...
 	 *
@@ -676,4 +685,208 @@ Angstroms.
 
 		return fullName;
 	}
+	
+	
+	public String toMmCif() {
+		StringBuilder str = new StringBuilder();
+		
+		try {
+			String header = MMCIFFileTools.toLoopMmCifHeaderString("_atom_site", AtomSite.class.getName());
+			str.append(header);
+		} catch (ClassNotFoundException e) {
+			logger.error("Class not found, will not have a header for this MMCIF category: "+e.getMessage());
+		}
+		
+		
+		
+		int nrModels = structure.nrModels();
+		
+		for (int m = 0 ; m < nrModels ; m++) {
+			List<Chain> model = structure.getModel(m);
+
+
+			int nrChains = model.size();
+			for ( int c =0; c<nrChains;c++) {
+				Chain  chain   = model.get(c);
+				
+				if (chain.getCompound()==null) {
+					logger.warn("No Compound (entity) found for chain {}: entity_id will be set to 0, label_seq_id will be the same as auth_seq_id", chain.getChainID());
+				}
+				
+				int nrGroups = chain.getAtomLength();
+				
+				for ( int h=0; h<nrGroups;h++){
+
+					Group g= chain.getAtomGroup(h);
+
+					toMmCif(g,str,m+1);
+					
+				}
+				
+			}
+
+
+		}
+		
+		return str.toString();
+	}
+	
+	public static String toMmCif(Chain chain, String chainId, String internalChainId) {
+		StringBuilder str = new StringBuilder();
+		
+		try {
+			String header = MMCIFFileTools.toLoopMmCifHeaderString("_atom_site", AtomSite.class.getName());
+			str.append(header);
+		} catch (ClassNotFoundException e) {
+			logger.error("Class not found, will not have a header for this MMCIF category: "+e.getMessage());
+		}
+		
+		if (chain.getCompound()==null) {
+			logger.warn("No Compound (entity) found for chain {}: entity_id will be set to 0, label_seq_id will be the same as auth_seq_id", chain.getChainID());
+		}
+
+		
+		int nrGroups = chain.getAtomLength();
+		
+		for ( int h=0; h<nrGroups;h++){
+
+			Group g= chain.getAtomGroup(h);
+
+			toMmCif(g,str, 1, chainId, internalChainId);			
+			
+		}
+		
+		return str.toString();
+	}
+	
+	public static String toMmCif(Chain chain) {
+		StringBuilder str = new StringBuilder();
+		
+		try {
+			String header = MMCIFFileTools.toLoopMmCifHeaderString("_atom_site", AtomSite.class.getName());
+			str.append(header);
+		} catch (ClassNotFoundException e) {
+			logger.error("Class not found, will not have a header for this MMCIF category: "+e.getMessage());
+		}
+		
+		int nrGroups = chain.getAtomLength();
+		
+		for ( int h=0; h<nrGroups;h++){
+
+			Group g= chain.getAtomGroup(h);
+
+			toMmCif(g, str, 1);			
+			
+		}
+		
+		return str.toString();		
+	}
+	
+	public static void toMmCif(Group g, StringBuilder str, int model) {
+		toMmCif(g, str, model, g.getChainId(), g.getChain().getInternalChainID());
+	}
+	
+	public static void toMmCif(Group g, StringBuilder str, int model, String chainId, String internalChainId) {
+		int groupsize  = g.size();
+
+		for ( int atompos = 0 ; atompos < groupsize; atompos++) {
+			Atom a = null ;
+			
+			a = g.getAtom(atompos);
+			if ( a == null)
+				continue ;
+
+			toMmCif(a, str, model, chainId, internalChainId);
+			
+		}
+		if ( g.hasAltLoc()){
+			for (Group alt : g.getAltLocs() ) {
+				toMmCif(alt,str,model,chainId,internalChainId);
+			}
+		}
+	}
+	
+	/**
+	 * Write the atom as a mmCIF atom_site record.
+	 * @param a
+	 * @param str
+	 * @param chainId
+	 * @param internalChainId
+	 */
+	private static void toMmCif(Atom a, StringBuilder str, int model, String chainId, String internalChainId) {
+		
+		/*
+		ATOM 7    C CD  . GLU A 1 24  ? -10.109 15.374 38.853 1.00 50.05 ? ? ? ? ? ? 24  GLU A CD  1 
+		ATOM 8    O OE1 . GLU A 1 24  ? -9.659  14.764 37.849 1.00 49.80 ? ? ? ? ? ? 24  GLU A OE1 1 
+		ATOM 9    O OE2 . GLU A 1 24  ? -11.259 15.171 39.310 1.00 50.51 ? ? ? ? ? ? 24  GLU A OE2 1 
+		ATOM 10   N N   . LEU A 1 25  ? -5.907  18.743 37.412 1.00 41.55 ? ? ? ? ? ? 25  LEU A N   1 
+		ATOM 11   C CA  . LEU A 1 25  ? -5.168  19.939 37.026 1.00 37.55 ? ? ? ? ? ? 25  LEU A CA  1 		
+		*/
+		
+		Group g = a.getGroup();
+
+		String record ;
+		if ( g.getType().equals(GroupType.HETATM) ) {
+			record = "HETATM";
+		} else {
+			record = "ATOM";
+		}
+
+		String entityId = "0";
+		String labelSeqId = Integer.toString(g.getResidueNumber().getSeqNum());
+		if (g.getChain()!=null && g.getChain().getCompound()!=null) {
+			entityId = Integer.toString(g.getChain().getCompound().getMolId());
+			labelSeqId = Integer.toString(g.getChain().getCompound().getAlignedResIndex(g, g.getChain()));
+		}
+		
+		Character  altLoc = a.getAltLoc()           ;
+		String altLocStr = altLoc.toString();
+		if (altLoc==null || altLoc == ' ') {
+			altLocStr = ".";
+		}		
+		
+		Element e = a.getElement();
+		String eString = e.toString().toUpperCase();
+		if ( e.equals(Element.R)) {
+			eString = "X";
+		}
+		
+		String insCode = MMCIF_MISSING_VALUE;
+		if (g.getResidueNumber().getInsCode()!=null ) {
+			insCode = Integer.toString(g.getResidueNumber().getInsCode());
+		}
+		
+		AtomSite atomSite = new AtomSite();
+		atomSite.setGroup_PDB(record);
+		atomSite.setId(Integer.toString(a.getPDBserial()));
+		atomSite.setType_symbol(eString);
+		atomSite.setLabel_atom_id(a.getName());
+		atomSite.setLabel_alt_id(altLocStr);
+		atomSite.setLabel_comp_id(g.getPDBName());
+		atomSite.setLabel_asym_id(internalChainId);
+		atomSite.setLabel_entity_id(entityId);
+		atomSite.setLabel_seq_id(labelSeqId);
+		atomSite.setPdbx_PDB_ins_code(insCode);
+		atomSite.setCartn_x(d3.format(a.getX()));
+		atomSite.setCartn_y(d3.format(a.getY()));
+		atomSite.setCartn_z(d3.format(a.getZ()));
+		atomSite.setOccupancy(d2.format(a.getOccupancy()));
+		atomSite.setB_iso_or_equiv(d2.format(a.getTempFactor()));
+		atomSite.setCartn_x_esd(MMCIF_MISSING_VALUE);
+		atomSite.setCartn_y_esd(MMCIF_MISSING_VALUE);
+		atomSite.setCartn_z_esd(MMCIF_MISSING_VALUE);
+		atomSite.setOccupancy_esd(MMCIF_MISSING_VALUE);
+		atomSite.setB_iso_or_equiv_esd(MMCIF_MISSING_VALUE);
+		atomSite.setPdbx_formal_charge(MMCIF_MISSING_VALUE);
+		atomSite.setAuth_seq_id(Integer.toString(g.getResidueNumber().getSeqNum()));
+		atomSite.setAuth_comp_id(g.getPDBName());
+		atomSite.setAuth_asym_id(chainId);
+		atomSite.setAuth_atom_id(a.getName());
+		atomSite.setPdbx_PDB_model_num(Integer.toString(model));
+		
+		str.append(MMCIFFileTools.toSingleLineMmCifString(atomSite));
+		
+	}
+	
+	
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -22,6 +22,7 @@
 package org.biojava.nbio.structure.io;
 
 import org.biojava.nbio.structure.*;
+import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
 import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.biojava.nbio.core.util.XMLWriter;
 
@@ -688,7 +689,7 @@ Angstroms.
 		
 		StringBuilder str = new StringBuilder();
 		
-		str.append(MMCIFFileTools.MMCIF_TOP_HEADER+"BioJava_mmCIF_file"+newline);
+		str.append(SimpleMMcifParser.MMCIF_TOP_HEADER+"BioJava_mmCIF_file"+newline);
 		
 		str.append(getAtomSiteHeader());
 		

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -691,11 +691,23 @@ Angstroms.
 		
 		str.append(SimpleMMcifParser.MMCIF_TOP_HEADER+"BioJava_mmCIF_file"+newline);
 		
+		if (structure.getPDBHeader()!=null & structure.getPDBHeader().getCrystallographicInfo()!=null &&
+				structure.getPDBHeader().getCrystallographicInfo().getSpaceGroup()!=null &&
+				structure.getPDBHeader().getCrystallographicInfo().getCrystalCell()!=null) {
+			
+			str.append(MMCIFFileTools.toMMCIF("_cell", 
+					MMCIFFileTools.convertCrystalCellToCell(structure.getPDBHeader().getCrystallographicInfo().getCrystalCell()))); 
+			str.append(MMCIFFileTools.toMMCIF("_symmetry", 
+					MMCIFFileTools.convertSpaceGroupToSymmetry(structure.getPDBHeader().getCrystallographicInfo().getSpaceGroup())));
+			
+		}
+			
+		
 		str.append(getAtomSiteHeader());
 		
 		@SuppressWarnings("unchecked")
 		List<Object> list = 
-		(List<Object>) (List<?>) MMCIFFileTools.structureToAtomSites(structure);
+		(List<Object>) (List<?>) MMCIFFileTools.convertStructureToAtomSites(structure);
 
 
 		str.append(MMCIFFileTools.toMMCIF(list));		
@@ -711,7 +723,7 @@ Angstroms.
 		
 		@SuppressWarnings("unchecked")
 		List<Object> list = 
-		(List<Object>) (List<?>) MMCIFFileTools.chainToAtomSites(chain, 1, chainId, internalChainId);
+		(List<Object>) (List<?>) MMCIFFileTools.convertChainToAtomSites(chain, 1, chainId, internalChainId);
 		
 		str.append(MMCIFFileTools.toMMCIF(list));
 		return str.toString();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
@@ -79,7 +79,7 @@ public class MMCIFFileTools {
 			sb.append(toSingleLineMmCifString(o, sizes));
 		}
 		
-		sb.append(SimpleMMcifParser.LOOP_END+newline);
+		sb.append(SimpleMMcifParser.COMMENT_CHAR+newline);
 		
 		return sb.toString();
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
@@ -11,10 +11,20 @@ import org.biojava.nbio.structure.Element;
 import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.GroupType;
 import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
 import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Some tools for mmCIF file writing.
+ * 
+ * See http://www.iucr.org/__data/assets/pdf_file/0019/22618/cifguide.pdf
+ * 
+ * 
+ * @author duarte_j
+ *
+ */
 public class MMCIFFileTools {
 
 	private static final Logger logger = LoggerFactory.getLogger(MMCIFFileTools.class);
@@ -32,7 +42,7 @@ public class MMCIFFileTools {
 	public static final String MMCIF_DEFAULT_VALUE = ".";
 	
 	/**
-	 * The header appearing at the beginning of a mmCIF file
+	 * The header appearing at the beginning of a mmCIF file. A "block code" can be added to it of no more than 32 chars.
 	 */
 	public static final String MMCIF_TOP_HEADER = "data_";
 	
@@ -47,7 +57,7 @@ public class MMCIFFileTools {
 	public static String toLoopMmCifHeaderString(String categoryName, String className) throws ClassNotFoundException {
 		StringBuilder str = new StringBuilder();
 		
-		str.append("loop_"+newline);
+		str.append(SimpleMMcifParser.LOOP_START+newline);
 		
 		Class<?> c = Class.forName(className);
 		
@@ -72,6 +82,8 @@ public class MMCIFFileTools {
 		for (Object o:list) {
 			sb.append(toSingleLineMmCifString(o, sizes));
 		}
+		
+		sb.append(SimpleMMcifParser.LOOP_END+newline);
 		
 		return sb.toString();
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
@@ -41,10 +41,6 @@ public class MMCIFFileTools {
 	 */
 	public static final String MMCIF_DEFAULT_VALUE = ".";
 	
-	/**
-	 * The header appearing at the beginning of a mmCIF file. A "block code" can be added to it of no more than 32 chars.
-	 */
-	public static final String MMCIF_TOP_HEADER = "data_";
 	
 	/**
 	 * Produces a mmCIF loop header string for the given categoryName and className.

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
@@ -1,0 +1,120 @@
+package org.biojava.nbio.structure.io;
+
+import java.lang.reflect.Field;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MMCIFFileTools {
+
+	private static final Logger logger = LoggerFactory.getLogger(MMCIFFileTools.class);
+	
+	private static final String newline = System.getProperty("line.separator");
+	
+	public static String toLoopMmCifHeaderString(String categoryName, String className) throws ClassNotFoundException {
+		StringBuilder str = new StringBuilder();
+		
+		str.append("loop_"+newline);
+		
+		Class<?> c = Class.forName(className);
+		
+		for (Field f : c.getDeclaredFields()) {
+			str.append(categoryName+"."+f.getName()+newline);
+		}
+		
+		return str.toString();
+	}
+	
+	public static String toSingleLineMmCifString(Object a) {
+		
+		StringBuilder str = new StringBuilder();
+		
+		Class<?> c = a.getClass();
+		
+		for (Field f : c.getDeclaredFields()) {
+			f.setAccessible(true);
+
+			try {
+				Object obj = f.get(a);
+				if (obj==null) {
+					logger.info("Field {} is null, will not write it out",f.getName()); 
+					continue;
+				}
+				String val = (String) obj;
+				
+				str.append(String.format("%-9s", addMmCifQuoting(val)));
+								
+				
+			} catch (IllegalAccessException e) {
+				logger.warn("Field {} is inaccessible", f.getName());
+				continue;
+			} catch (ClassCastException e) {
+				logger.warn("Could not cast value to String for field {}",f.getName());
+				continue;
+			}
+		}
+		
+		str.append(newline);
+		
+		return str.toString();
+		
+		//return 
+		//	String.format(
+		//		"%-6s %-7s %-2s %-4s %-1s"+newline, 
+		//		a.getGroup_PDB(), a.getId(), a.getType_symbol(), a.getLabel_atom_id(), a.getLabel_alt_id());
+		
+	}
+	
+	private static String addMmCifQuoting(String val) {
+		String newval;
+		
+		if (val.contains("'")) {
+			// double quoting for strings containing single quotes
+			newval = "\""+val+"\"";
+		} else if (val.contains(" ")) {
+			// single quoting for stings containing spaces
+			newval = "'"+val+"'";
+		} else {
+			if (val.contains(" ") && val.contains("'")) {
+				// TODO deal with this case
+				logger.warn("Value contains both spaces and single quotes, won't format it: {}",val);
+			}
+			newval = val;
+		}
+		return newval;
+	}
+	
+//	private static void addMmCifAtomSiteHeader(StringBuilder str) {
+//	str.append("loop_"+newline);
+//	
+//	String atomSiteCategory = "_atom_site";
+//	
+//	str.append(atomSiteCategory+".group_PDB"+newline);
+//	str.append(atomSiteCategory+".id"+newline);
+//
+//	str.append(atomSiteCategory+".type_symbol"+newline);
+//
+//	str.append(atomSiteCategory+".label_atom_id+"+newline);
+//	str.append(atomSiteCategory+".label_alt_id"+newline);
+//	str.append(atomSiteCategory+".label_comp_id"+newline);
+//
+//	str.append(atomSiteCategory+".label_asym_id"+newline);
+//	str.append(atomSiteCategory+".label_entity_id"+newline);
+//	str.append(atomSiteCategory+".label_seq_id"+newline);
+//
+//	str.append(atomSiteCategory+".pdbx_PDB_ins_code"+newline);
+//	str.append(atomSiteCategory+".Cartn_x"+newline);
+//	str.append(atomSiteCategory+".Cartn_y"+newline);
+//	str.append(atomSiteCategory+".Cartn_z"+newline);
+//	str.append(atomSiteCategory+".occupancy"+newline);
+//	str.append(atomSiteCategory+".B_iso_or_equiv"+newline);
+//
+//	str.append(atomSiteCategory+".pdbx_formal_charge"+newline);
+//
+//	str.append(atomSiteCategory+".auth_seq_id"+newline);
+//	str.append(atomSiteCategory+".auth_asym_id"+newline);
+//
+//	str.append(atomSiteCategory+".pdbx_PDB_model_num"+newline);
+//	
+//}
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileTools.java
@@ -1,7 +1,17 @@
 package org.biojava.nbio.structure.io;
 
-import java.lang.reflect.Field;
 
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.Element;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.GroupType;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +21,29 @@ public class MMCIFFileTools {
 	
 	private static final String newline = System.getProperty("line.separator");
 	
+	/**
+	 * The character to be printed out in cases where a value is not assigned in mmCIF files
+	 */
+	public static final String MMCIF_MISSING_VALUE = "?";
+	
+	/**
+	 * The character to be printed out as a default value in mmCIF files, e.g. for the default alt_locs
+	 */
+	public static final String MMCIF_DEFAULT_VALUE = ".";
+	
+	/**
+	 * The header appearing at the beginning of a mmCIF file
+	 */
+	public static final String MMCIF_TOP_HEADER = "data_";
+	
+	/**
+	 * Produces a mmCIF loop header string for the given categoryName and className.
+	 * className must be one of the beans in the {@link org.biojava.nbio.structure.io.mmcif.model} package
+	 * @param categoryName
+	 * @param className
+	 * @return
+	 * @throws ClassNotFoundException if the given className can not be found
+	 */
 	public static String toLoopMmCifHeaderString(String categoryName, String className) throws ClassNotFoundException {
 		StringBuilder str = new StringBuilder();
 		
@@ -25,24 +58,55 @@ public class MMCIFFileTools {
 		return str.toString();
 	}
 	
-	public static String toSingleLineMmCifString(Object a) {
+	/**
+	 * Converts a list of mmCIF beans (see {@link org.biojava.nbio.structure.io.mmcif.model} to
+	 * a String representing them in mmCIF loop format with one record per line.
+	 * @param list
+	 * @return
+	 */
+	public static String toMMCIF(List<Object> list) {
+		int[] sizes = getFieldSizes(list);
+		
+		StringBuilder sb = new StringBuilder();
+		
+		for (Object o:list) {
+			sb.append(toSingleLineMmCifString(o, sizes));
+		}
+		
+		return sb.toString();
+	}
+	
+	/**
+	 * Given a mmCIF bean produces a String representing it in mmCIF loop format as a single record line
+	 * @param a
+	 * @param sizes the size of each of the fields
+	 * @return
+	 */
+	public static String toSingleLineMmCifString(Object a, int[] sizes) {
 		
 		StringBuilder str = new StringBuilder();
 		
 		Class<?> c = a.getClass();
 		
+		if (sizes.length!=c.getDeclaredFields().length) 
+			throw new IllegalArgumentException("The given sizes of fields differ from the number of declared fields");
+		
+		int i = -1;
 		for (Field f : c.getDeclaredFields()) {
+			i++;
 			f.setAccessible(true);
 
 			try {
 				Object obj = f.get(a);
+				String val;
 				if (obj==null) {
-					logger.info("Field {} is null, will not write it out",f.getName()); 
-					continue;
+					logger.debug("Field {} is null, will write it out as {}",f.getName(),MMCIF_MISSING_VALUE);
+					val = MMCIF_MISSING_VALUE;
+				} else {
+					val = (String) obj;
 				}
-				String val = (String) obj;
 				
-				str.append(String.format("%-9s", addMmCifQuoting(val)));
+				str.append(String.format("%-"+sizes[i]+"s ", addMmCifQuoting(val)));
 								
 				
 			} catch (IllegalAccessException e) {
@@ -58,13 +122,13 @@ public class MMCIFFileTools {
 		
 		return str.toString();
 		
-		//return 
-		//	String.format(
-		//		"%-6s %-7s %-2s %-4s %-1s"+newline, 
-		//		a.getGroup_PDB(), a.getId(), a.getType_symbol(), a.getLabel_atom_id(), a.getLabel_alt_id());
-		
 	}
 	
+	/**
+	 * Adds quoting to a String according to the STAR format (mmCIF) rules
+	 * @param val
+	 * @return
+	 */
 	private static String addMmCifQuoting(String val) {
 		String newval;
 		
@@ -81,40 +145,206 @@ public class MMCIFFileTools {
 			}
 			newval = val;
 		}
+		// TODO deal with all the other cases: e.g. multi-line quoting
+		
 		return newval;
 	}
 	
-//	private static void addMmCifAtomSiteHeader(StringBuilder str) {
-//	str.append("loop_"+newline);
-//	
-//	String atomSiteCategory = "_atom_site";
-//	
-//	str.append(atomSiteCategory+".group_PDB"+newline);
-//	str.append(atomSiteCategory+".id"+newline);
-//
-//	str.append(atomSiteCategory+".type_symbol"+newline);
-//
-//	str.append(atomSiteCategory+".label_atom_id+"+newline);
-//	str.append(atomSiteCategory+".label_alt_id"+newline);
-//	str.append(atomSiteCategory+".label_comp_id"+newline);
-//
-//	str.append(atomSiteCategory+".label_asym_id"+newline);
-//	str.append(atomSiteCategory+".label_entity_id"+newline);
-//	str.append(atomSiteCategory+".label_seq_id"+newline);
-//
-//	str.append(atomSiteCategory+".pdbx_PDB_ins_code"+newline);
-//	str.append(atomSiteCategory+".Cartn_x"+newline);
-//	str.append(atomSiteCategory+".Cartn_y"+newline);
-//	str.append(atomSiteCategory+".Cartn_z"+newline);
-//	str.append(atomSiteCategory+".occupancy"+newline);
-//	str.append(atomSiteCategory+".B_iso_or_equiv"+newline);
-//
-//	str.append(atomSiteCategory+".pdbx_formal_charge"+newline);
-//
-//	str.append(atomSiteCategory+".auth_seq_id"+newline);
-//	str.append(atomSiteCategory+".auth_asym_id"+newline);
-//
-//	str.append(atomSiteCategory+".pdbx_PDB_model_num"+newline);
-//	
-//}
+	/**
+	 * Converts an Atom object to an {@link AtomSite} object.
+	 * @param a
+	 * @param model
+	 * @param chainId
+	 * @param internalChainId
+	 * @return
+	 */
+	private static AtomSite atomToAtomSite(Atom a, int model, String chainId, String internalChainId) {
+		
+		/*
+		ATOM 7    C CD  . GLU A 1 24  ? -10.109 15.374 38.853 1.00 50.05 ? ? ? ? ? ? 24  GLU A CD  1 
+		ATOM 8    O OE1 . GLU A 1 24  ? -9.659  14.764 37.849 1.00 49.80 ? ? ? ? ? ? 24  GLU A OE1 1 
+		ATOM 9    O OE2 . GLU A 1 24  ? -11.259 15.171 39.310 1.00 50.51 ? ? ? ? ? ? 24  GLU A OE2 1 
+		ATOM 10   N N   . LEU A 1 25  ? -5.907  18.743 37.412 1.00 41.55 ? ? ? ? ? ? 25  LEU A N   1 
+		ATOM 11   C CA  . LEU A 1 25  ? -5.168  19.939 37.026 1.00 37.55 ? ? ? ? ? ? 25  LEU A CA  1 		
+		*/
+		
+		Group g = a.getGroup();
+
+		String record ;
+		if ( g.getType().equals(GroupType.HETATM) ) {
+			record = "HETATM";
+		} else {
+			record = "ATOM";
+		}
+
+		String entityId = "0";
+		String labelSeqId = Integer.toString(g.getResidueNumber().getSeqNum());
+		if (g.getChain()!=null && g.getChain().getCompound()!=null) {
+			entityId = Integer.toString(g.getChain().getCompound().getMolId());
+			labelSeqId = Integer.toString(g.getChain().getCompound().getAlignedResIndex(g, g.getChain()));
+		}
+		
+		Character  altLoc = a.getAltLoc()           ;
+		String altLocStr = altLoc.toString();
+		if (altLoc==null || altLoc == ' ') {
+			altLocStr = MMCIF_DEFAULT_VALUE;
+		}		
+		
+		Element e = a.getElement();
+		String eString = e.toString().toUpperCase();
+		if ( e.equals(Element.R)) {
+			eString = "X";
+		}
+		
+		String insCode = MMCIF_MISSING_VALUE;
+		if (g.getResidueNumber().getInsCode()!=null ) {
+			insCode = Integer.toString(g.getResidueNumber().getInsCode());
+		}
+		
+		AtomSite atomSite = new AtomSite();
+		atomSite.setGroup_PDB(record);
+		atomSite.setId(Integer.toString(a.getPDBserial()));
+		atomSite.setType_symbol(eString);
+		atomSite.setLabel_atom_id(a.getName());
+		atomSite.setLabel_alt_id(altLocStr);
+		atomSite.setLabel_comp_id(g.getPDBName());
+		atomSite.setLabel_asym_id(internalChainId);
+		atomSite.setLabel_entity_id(entityId);
+		atomSite.setLabel_seq_id(labelSeqId);
+		atomSite.setPdbx_PDB_ins_code(insCode);
+		atomSite.setCartn_x(FileConvert.d3.format(a.getX()));
+		atomSite.setCartn_y(FileConvert.d3.format(a.getY()));
+		atomSite.setCartn_z(FileConvert.d3.format(a.getZ()));
+		atomSite.setOccupancy(FileConvert.d2.format(a.getOccupancy()));
+		atomSite.setB_iso_or_equiv(FileConvert.d2.format(a.getTempFactor()));
+		atomSite.setAuth_seq_id(Integer.toString(g.getResidueNumber().getSeqNum()));
+		atomSite.setAuth_comp_id(g.getPDBName());
+		atomSite.setAuth_asym_id(chainId);
+		atomSite.setAuth_atom_id(a.getName());
+		atomSite.setPdbx_PDB_model_num(Integer.toString(model));
+		
+		return atomSite;
+	}
+	
+	/**
+	 * Converts a Group into a List of {@link AtomSite} objects
+	 * @param g
+	 * @param model
+	 * @param chainId
+	 * @param internalChainId
+	 * @return
+	 */
+	private static List<AtomSite> groupToAtomSites(Group g, int model, String chainId, String internalChainId) {
+		
+		List<AtomSite> list = new ArrayList<AtomSite>();
+		
+		int groupsize  = g.size();
+
+		for ( int atompos = 0 ; atompos < groupsize; atompos++) {
+			Atom a = null ;
+			
+			a = g.getAtom(atompos);
+			if ( a == null)
+				continue ;
+
+			list.add(atomToAtomSite(a, model, chainId, internalChainId));
+			
+		}
+		if ( g.hasAltLoc()){
+			for (Group alt : g.getAltLocs() ) {
+				list.addAll(groupToAtomSites(alt, model, chainId, internalChainId));
+			}
+		}
+		return list;
+	}
+	
+	/**
+	 * Converts a Chain into a List of {@link AtomSite} objects
+	 * @param c
+	 * @param model
+	 * @param chainId
+	 * @param internalChainId
+	 * @return
+	 */
+	public static List<AtomSite> chainToAtomSites(Chain c, int model, String chainId, String internalChainId) {
+		
+		List<AtomSite> list = new ArrayList<AtomSite>();
+		
+		if (c.getCompound()==null) {
+			logger.warn("No Compound (entity) found for chain {}: entity_id will be set to 0, label_seq_id will be the same as auth_seq_id", c.getChainID());
+		}
+	
+		for ( int h=0; h<c.getAtomLength();h++){
+
+			Group g= c.getAtomGroup(h);
+
+			list.addAll(groupToAtomSites(g, model, chainId, internalChainId));			
+			
+		}
+		
+		return list;
+	}
+	
+	/**
+	 * Converts a Structure into a List of {@link AtomSite} objects
+	 * @param s
+	 * @return
+	 */
+	public static List<AtomSite> structureToAtomSites(Structure s) {
+		List<AtomSite> list = new ArrayList<AtomSite>();
+		
+		for (int m=0;m<s.nrModels();m++) {
+			for (Chain c:s.getChains()) {
+				list.addAll(chainToAtomSites(c, m+1, c.getChainID(), c.getInternalChainID()));
+			}
+		}
+		return list;
+	}
+	
+	/**
+	 * Finds the max length of each of the String values contained in each of the fields of the given list of beans.
+	 * Useful for producing mmCIF loop data that is aligned for all columns.
+	 * @param a
+	 * @return
+	 * @see #toMMCIF(List)
+	 */
+	private static int[] getFieldSizes(List<Object> list) {
+		
+		if (list.isEmpty()) throw new IllegalArgumentException("List of beans is empty!");
+		
+		int[] sizes = new int [list.get(0).getClass().getDeclaredFields().length];
+		
+		
+		for (Object a:list) {
+			Class<?> c = a.getClass();
+
+			int i = -1;
+			for (Field f : c.getDeclaredFields()) {
+				i++;
+
+				f.setAccessible(true);
+
+				try {
+					Object obj = f.get(a);
+					int length;
+					if (obj==null) {
+						length = MMCIF_MISSING_VALUE.length();
+					} else {
+						String val = (String) obj;
+						length = addMmCifQuoting(val).length();
+					}
+					
+					if (length>sizes[i]) sizes[i] = length; 			
+
+				} catch (IllegalAccessException e) {
+					logger.warn("Field {} is inaccessible", f.getName());
+					continue;
+				} catch (ClassCastException e) {
+					logger.warn("Could not cast value to String for field {}",f.getName());
+					continue;
+				}
+			}
+		}
+		return sizes;
+	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -619,6 +619,10 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 			addCompounds(asym);
 			
 		}
+		
+		if (structAsyms.isEmpty()) {
+			logger.warn("No _struct_asym category in file, no SEQRES groups will be added."); 
+		}
 
 		if ( params.isAlignSeqRes() ){		
 			alignSeqRes();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
@@ -308,9 +308,9 @@ public class SimpleMMcifParser implements MMcifParser {
 			if ( line.startsWith(STRING_LIMIT))
 				return data;
 		}
-		boolean inString = false;
-		boolean inS1     = false;
-		boolean inS2     = false;
+		boolean inString = false; // semicolon (;) quoting
+		boolean inS1     = false; // single quote (') quoting
+		boolean inS2     = false; // double quote (") quoting
 		String word 	 = "";
 
 		for (int i=0; i< line.length(); i++ ){
@@ -321,9 +321,9 @@ public class SimpleMMcifParser implements MMcifParser {
 			if (i < line.length() - 1)
 				nextC = line.charAt(i+1);
 			
-			//Character lastC = null;
-			//if (i>0) 
-			//	lastC = line.charAt(i-1);
+			Character lastC = null;
+			if (i>0) 
+				lastC = line.charAt(i-1);
 			
 			if  (c == ' ') {
 
@@ -364,10 +364,12 @@ public class SimpleMMcifParser implements MMcifParser {
 						word += c;
 					}
 
-				} else {
+				} else if (lastC==null || lastC==' ') {
 					// the beginning of a new string
 					inString = true;
 					inS1     = true;
+				} else {
+					word += c;
 				}
 			} else if ( c == S2 ){
 				if ( inString){
@@ -394,10 +396,12 @@ public class SimpleMMcifParser implements MMcifParser {
 					} else {
 						word += c;
 					}
-				} else {
+				}  else if (lastC==null || lastC==' ') {
 					// the beginning of a new string
 					inString = true;
 					inS2     = true;
+				} else {
+					word += c;
 				}
 			} else {
 				word += c;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
@@ -814,8 +814,7 @@ public class SimpleMMcifParser implements MMcifParser {
 
 	}
 	
-	@SuppressWarnings("rawtypes")
-	private void setArray(Class c, Object o, String key, String val){
+	private void setArray(Class<?> c, Object o, String key, String val){
 
 
 		// TODO: not implemented yet!
@@ -834,12 +833,11 @@ public class SimpleMMcifParser implements MMcifParser {
 
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private Object buildObject(String className, List<String> loopFields, List<String> lineData, Set<String> warnings) {
 		Object o = null;
 		try {
 			// build up the Entity object from the line data...
-			Class c = Class.forName(className);
+			Class<?> c = Class.forName(className);
 
 			o = c.newInstance();
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
@@ -315,7 +315,7 @@ public class SimpleMMcifParser implements MMcifParser {
 					}
 					
 					if (category!=null && !key.substring(0,pos).equals(category)) {
-						// we've changed category: need to flush the last one
+						// we've changed category: need to flush the previous one
 						endLineChecks(category, loopFields, lineData, loopWarnings);
 						resetBuffers(loopFields, lineData, loopWarnings);
 					}
@@ -333,7 +333,7 @@ public class SimpleMMcifParser implements MMcifParser {
 		}
 		
 		if (category!=null && lineData.size()>0 && lineData.size()==loopFields.size()) {
-			// the last category in the file will still be missing
+			// the last category in the file will still be missing, we add it now
 			endLineChecks(category, loopFields, lineData, loopWarnings);
 			resetBuffers(loopFields, lineData, loopWarnings);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
@@ -23,6 +23,7 @@ package org.biojava.nbio.structure.io.mmcif;
 
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.io.MMCIFFileReader;
+import org.biojava.nbio.structure.io.MMCIFFileTools;
 import org.biojava.nbio.structure.io.StructureIOFile;
 import org.biojava.nbio.structure.io.mmcif.model.*;
 import org.biojava.nbio.structure.jama.Matrix;
@@ -30,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.vecmath.Matrix4d;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -238,8 +240,8 @@ public class SimpleMMcifParser implements MMcifParser {
 					if ( pos < 0 ) {
 						// looks like a chem_comp file
 						// line should start with data, otherwise something is wrong!
-						if (! line.startsWith("data_")){
-							logger.warn("this does not look like a valid MMcif file! The first line should be data_1XYZ, but is " + line);
+						if (! line.startsWith(MMCIFFileTools.MMCIF_TOP_HEADER)){
+							logger.warn("This does not look like a valid MMcif file! The first line should start with 'data_', but is '" + line+"'");
 							triggerDocumentEnd();
 							return;
 						}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
@@ -377,9 +377,9 @@ public class SimpleMMcifParser implements MMcifParser {
 			if (i < line.length() - 1)
 				nextC = line.charAt(i+1);
 			
-			Character lastC = null;
+			Character prevC = null;
 			if (i>0) 
-				lastC = line.charAt(i-1);
+				prevC = line.charAt(i-1);
 			
 			if  (c == ' ') {
 
@@ -398,12 +398,9 @@ public class SimpleMMcifParser implements MMcifParser {
 
 					boolean wordEnd = false;
 					if (! inS2) {
-						if (nextC != null){
-							//System.out.println("nextC: >"+nextC+"<");
-							if ( Character.isWhitespace(nextC)){
-								i++;
-								wordEnd = true;
-							}
+						if (nextC==null || Character.isWhitespace(nextC)){
+							i++;
+							wordEnd = true;
 						}
 					}
 
@@ -420,7 +417,7 @@ public class SimpleMMcifParser implements MMcifParser {
 						word += c;
 					}
 
-				} else if (lastC==null || lastC==' ') {
+				} else if (prevC==null || prevC==' ') {
 					// the beginning of a new string
 					inString = true;
 					inS1     = true;
@@ -432,12 +429,9 @@ public class SimpleMMcifParser implements MMcifParser {
 
 					boolean wordEnd = false;
 					if (! inS1) {
-						if (nextC != null){
-							//System.out.println("nextC: >"+nextC+"<");
-							if ( Character.isWhitespace(nextC)){
-								i++;
-								wordEnd = true;
-							}
+						if (nextC==null || Character.isWhitespace(nextC)){
+							i++;
+							wordEnd = true;
 						}
 					}
 
@@ -452,7 +446,7 @@ public class SimpleMMcifParser implements MMcifParser {
 					} else {
 						word += c;
 					}
-				}  else if (lastC==null || lastC==' ') {
+				}  else if (prevC==null || prevC==' ') {
 					// the beginning of a new string
 					inString = true;
 					inS2     = true;

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestDifficultMmCIFFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestDifficultMmCIFFiles.java
@@ -22,11 +22,17 @@ package org.biojava.nbio.structure.io;
 
 import org.biojava.nbio.structure.*;
 import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.mmcif.MMcifParser;
+import org.biojava.nbio.structure.io.mmcif.SimpleMMcifConsumer;
+import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
 import org.biojava.nbio.structure.quaternary.BioAssemblyInfo;
 import org.junit.Test;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
@@ -156,5 +162,36 @@ public class TestDifficultMmCIFFiles {
 		Chain chain2 = s.getChainByPDB("ABCD");
 		assertNotNull(chain2);
 		assertEquals(chain2, chain);
+	}
+	
+	/**
+	 * This is to test the issue discussed here:
+	 * http://www.globalphasing.com/startools/
+	 * Essentially single quote characters (') are valid not only for quoting, but also as parts of
+	 * data values as long as some rules of the STAR format are followed.
+	 * For instance Phenix produces mmCIF files with non-quoted strings containing single quote characters 
+	 * @throws IOException
+	 */
+	//@Test
+	public void testQuotingCornerCase () throws IOException {
+		InputStream inStream = this.getClass().getResourceAsStream("/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif");
+		MMcifParser parser = new SimpleMMcifParser();
+
+		SimpleMMcifConsumer consumer = new SimpleMMcifConsumer();
+
+		FileParsingParameters fileParsingParams = new FileParsingParameters();
+		fileParsingParams.setAlignSeqRes(true);
+
+		consumer.setFileParsingParameters(fileParsingParams);
+
+		parser.addMMcifConsumer(consumer);
+
+		parser.parse(new BufferedReader(new InputStreamReader(inStream))); 
+
+		Structure s = consumer.getStructure();
+		
+		assertNotNull(s);
+		
+		
 	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestDifficultMmCIFFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestDifficultMmCIFFiles.java
@@ -194,4 +194,37 @@ public class TestDifficultMmCIFFiles {
 		
 		
 	}
+	
+	/**
+	 * The last category in 2KLI mmCIF file is _pdbx_struct_oper_list, which is needed for 
+	 * the biounit annotation.
+	 * This tests makes sure that the last category in a mmCIF file is not missed because 
+	 * of its position as last one in file.
+	 * @throws IOException
+	 * @throws StructureException
+	 */
+	@Test
+	public void test2KLI() throws IOException, StructureException { 
+
+		AtomCache cache = new AtomCache();
+
+		StructureIO.setAtomCache(cache); 
+
+		FileParsingParameters params = cache.getFileParsingParams();
+		params.setParseBioAssembly(true);
+		StructureIO.setAtomCache(cache);
+
+
+		cache.setUseMmCif(true);
+		Structure sCif = StructureIO.getStructure("2KLI");
+
+		assertNotNull(sCif);
+
+		assertNotNull(sCif.getPDBHeader().getBioAssemblies());
+
+		Map<Integer,BioAssemblyInfo> mapCif = sCif.getPDBHeader().getBioAssemblies();
+		
+		assertNotNull(mapCif);
+
+	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestDifficultMmCIFFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestDifficultMmCIFFiles.java
@@ -172,7 +172,7 @@ public class TestDifficultMmCIFFiles {
 	 * For instance Phenix produces mmCIF files with non-quoted strings containing single quote characters 
 	 * @throws IOException
 	 */
-	//@Test
+	@Test
 	public void testQuotingCornerCase () throws IOException {
 		InputStream inStream = this.getClass().getResourceAsStream("/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif");
 		MMcifParser parser = new SimpleMMcifParser();

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -8,6 +8,7 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
@@ -54,11 +55,25 @@ public class TestMMCIFWriting {
 
 		parser.addMMcifConsumer(consumer);
 
-		parser.parse(new BufferedReader(new FileReader(outputFile))); 
-
+		//parser.parse(new BufferedReader(new FileReader(new File("/home/duarte_j/test.cif")))); 
+		parser.parse(new BufferedReader(new FileReader(outputFile)));
+		
 		Structure readStruct = consumer.getStructure();
 		
+		assertNotNull(readStruct); 
+		
 		assertEquals(originalStruct.getChains().size(), readStruct.getChains().size());
+		
+		for (int i=0;i<originalStruct.getChains().size();i++) {
+			assertEquals(originalStruct.getChains().get(i).getAtomGroups().size(),
+							readStruct.getChains().get(i).getAtomGroups().size());
+			
+			Chain origChain = originalStruct.getChains().get(i);
+			Chain readChain = readStruct.getChains().get(i);
+			
+			assertEquals(origChain.getAtomGroups().size(), readChain.getAtomGroups().size());
+			//assertEquals(origChain.getSeqResGroups().size(), readChain.getSeqResGroups().size());
+		}
 		
 	}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -1,0 +1,41 @@
+package org.biojava.nbio.structure.io;
+
+import static org.junit.Assert.*;
+
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.junit.Test;
+
+public class TestMMCIFWriting {
+
+	@Test
+	public void test1SMT() throws IOException, StructureException {
+		AtomCache cache = new AtomCache();
+		
+		StructureIO.setAtomCache(cache); 
+
+		cache.setUseMmCif(true);
+		
+		FileParsingParameters params = new FileParsingParameters();
+		params.setAlignSeqRes(true);
+		cache.setFileParsingParams(params);
+		
+		Structure sCif = StructureIO.getStructure("1SMT");
+		
+		assertNotNull(sCif);
+		
+
+		FileConvert fc = new FileConvert(sCif);
+		
+		FileWriter fw = new FileWriter("/home/duarte_j/test.cif");
+		//System.out.println(fc.toMmCif());
+		fw.write(fc.toMmCif());
+		fw.close();
+	}
+
+}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -37,10 +37,8 @@ public class TestMMCIFWriting {
 		File outputFile = File.createTempFile("biojava_testing_", ".cif");
 		
 		
-		FileConvert fc = new FileConvert(originalStruct);
-		
 		FileWriter fw = new FileWriter(outputFile);
-		fw.write(fc.toMMCIF());
+		fw.write(originalStruct.toMMCIF());
 		fw.close();
 		
 		

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -2,6 +2,9 @@ package org.biojava.nbio.structure.io;
 
 import static org.junit.Assert.*;
 
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 
@@ -9,6 +12,9 @@ import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
 import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.mmcif.MMcifParser;
+import org.biojava.nbio.structure.io.mmcif.SimpleMMcifConsumer;
+import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
 import org.junit.Test;
 
 public class TestMMCIFWriting {
@@ -25,17 +31,35 @@ public class TestMMCIFWriting {
 		params.setAlignSeqRes(true);
 		cache.setFileParsingParams(params);
 		
-		Structure sCif = StructureIO.getStructure("1SMT");
+		Structure originalStruct = StructureIO.getStructure("1SMT");
+				
+		File outputFile = File.createTempFile("biojava_testing_", ".cif");
 		
-		assertNotNull(sCif);
 		
-
-		FileConvert fc = new FileConvert(sCif);
+		FileConvert fc = new FileConvert(originalStruct);
 		
-		FileWriter fw = new FileWriter("/home/jose/test.cif");
-		//System.out.println(fc.toMmCif());
+		FileWriter fw = new FileWriter(outputFile);
 		fw.write(fc.toMMCIF());
 		fw.close();
+		
+		
+		MMcifParser parser = new SimpleMMcifParser();
+
+		SimpleMMcifConsumer consumer = new SimpleMMcifConsumer();
+
+		FileParsingParameters fileParsingParams = new FileParsingParameters();
+		fileParsingParams.setAlignSeqRes(true);
+
+		consumer.setFileParsingParameters(fileParsingParams);
+
+		parser.addMMcifConsumer(consumer);
+
+		parser.parse(new BufferedReader(new FileReader(outputFile))); 
+
+		Structure readStruct = consumer.getStructure();
+		
+		assertEquals(originalStruct.getChains().size(), readStruct.getChains().size());
+		
 	}
 
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -32,9 +32,9 @@ public class TestMMCIFWriting {
 
 		FileConvert fc = new FileConvert(sCif);
 		
-		FileWriter fw = new FileWriter("/home/duarte_j/test.cif");
+		FileWriter fw = new FileWriter("/home/jose/test.cif");
 		//System.out.println(fc.toMmCif());
-		fw.write(fc.toMmCif());
+		fw.write(fc.toMMCIF());
 		fw.close();
 	}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -194,7 +194,7 @@ public class TestNonDepositedFiles {
 	 * See github issue #234
 	 * @throws IOException
 	 */
-	//@Test
+	@Test
 	public void testPhenixFile() throws IOException {
 		InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream("/org/biojava/nbio/structure/io/4lup_phenix_output.cif.gz"));
 		MMcifParser parser = new SimpleMMcifParser();

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -29,7 +29,6 @@ import org.biojava.nbio.structure.io.mmcif.MMcifParser;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifConsumer;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
 import org.biojava.nbio.structure.xtal.CrystalCell;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -192,10 +191,10 @@ public class TestNonDepositedFiles {
 	/**
 	 * A test for reading a phenix-produced (ver 1.9_1692) mmCIF file.
 	 * This is the file submitted to the PDB for deposition of entry 4lup
+	 * See github issue #234
 	 * @throws IOException
 	 */
-	@Ignore // remove once issue #234 is fixed
-	@Test
+	//@Test
 	public void testPhenixFile() throws IOException {
 		InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream("/org/biojava/nbio/structure/io/4lup_phenix_output.cif.gz"));
 		MMcifParser parser = new SimpleMMcifParser();

--- a/biojava-structure/src/test/resources/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif
+++ b/biojava-structure/src/test/resources/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif
@@ -8,6 +8,7 @@ _atom_site.label_alt_id
 _atom_site.label_comp_id 
 _atom_site.label_asym_id 
 _atom_site.label_entity_id 
+# a comment line
 _atom_site.label_seq_id 
 _atom_site.pdbx_PDB_ins_code 
 _atom_site.Cartn_x 
@@ -22,6 +23,7 @@ _atom_site.auth_atom_id
 _atom_site.pdbx_PDB_model_num 
 ATOM   1728 O OP1  . DT  C 2 1  ? 7.732   19.982  88.407  0.00 20.42 107 DT  B OP1  1  
 ATOM   1730 O O5'  . DT  C 2 1  ? 7.464   18.547  86.371  0.00 21.57 107 DT  B O5'  1 
+# a comment line
 ATOM   1738 C H2"  . DT  C 2 1  ? 8.111   19.111  84.111  0.00 29.00 107 DT  B H2"  1
 ATOM   1730 O "O3'"  . DT  C 2 1  ? 7.111   18.111  86.111  0.00 21.00 107 DT  B "O3'"  1
 # 
@@ -32,6 +34,17 @@ _audit_author.pdbx_ordinal
 'Welsh, L.C.'    2 
 "Marvin, D.A."   3
 # 
+_exptl_crystal.id                    1 
+_exptl_crystal.density_meas          ? 
+_exptl_crystal.density_Matthews      ? 
+# a comment line
+_exptl_crystal.density_percent_sol   ? 
+_exptl_crystal.description           
+;THE DATA IS DERIVED FROM CONTINUOUS TRANSFORM DATA AND THEREFORE THE NUMBER OF UNIQUE REFLECTIONS IS A MEANINGLESS NUMBER. THE STRUCTURE WAS REFINED AGAI THE SAME STRUCTURE FACTORS AS PDB ENTRY 1HGV, USIN
+G DIFFERENT REFINEMENT PROTOCOL. THEREFORE, THE STRUCT FACTORS FOR 1HHO, CAN BE TAKEN FROM R1HGVSF
+;
+# 
+# a comment line
 loop_
 _pdbx_database_related.db_name 
 _pdbx_database_related.db_id 
@@ -42,7 +55,7 @@ PDB 1QL1 unspecified 'INOVIRUS (FILAMENTOUS BACTERIOPHAGE) STRAIN PF1 MAJOR COAT
 # 
 loop_
 _citation.id 
-_citation.title 
+_citation.title
 _citation.journal_abbrev 
 _citation.journal_volume 
 _citation.page_first 
@@ -69,4 +82,5 @@ _citation_author.ordinal
 primary 'Pederson, D.M.'   1  
 primary "Welsh, L.C."      2  
 primary 'Marvin, D.A.'     3  
-#
+
+

--- a/biojava-structure/src/test/resources/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif
+++ b/biojava-structure/src/test/resources/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif
@@ -1,0 +1,40 @@
+data_4LUP_subset_no_quotes
+loop_
+_atom_site.group_PDB 
+_atom_site.id 
+_atom_site.type_symbol 
+_atom_site.label_atom_id 
+_atom_site.label_alt_id 
+_atom_site.label_comp_id 
+_atom_site.label_asym_id 
+_atom_site.label_entity_id 
+_atom_site.label_seq_id 
+_atom_site.pdbx_PDB_ins_code 
+_atom_site.Cartn_x 
+_atom_site.Cartn_y 
+_atom_site.Cartn_z 
+_atom_site.occupancy 
+_atom_site.B_iso_or_equiv 
+_atom_site.Cartn_x_esd 
+_atom_site.Cartn_y_esd 
+_atom_site.Cartn_z_esd 
+_atom_site.occupancy_esd 
+_atom_site.B_iso_or_equiv_esd 
+_atom_site.pdbx_formal_charge 
+_atom_site.auth_seq_id 
+_atom_site.auth_comp_id 
+_atom_site.auth_asym_id 
+_atom_site.auth_atom_id 
+_atom_site.pdbx_PDB_model_num 
+ATOM   1727 P P      . DT  C 2 1  ? 7.887   18.595  87.913  0.00 20.67 ? ? ? ? ? ? 107 DT  B P      1 
+ATOM   1728 O OP1    . DT  C 2 1  ? 7.732   19.982  88.407  0.00 20.42 ? ? ? ? ? ? 107 DT  B OP1    1 
+ATOM   1729 O OP2    . DT  C 2 1  ? 7.210   17.480  88.610  0.00 20.42 ? ? ? ? ? ? 107 DT  B OP2    1 
+ATOM   1730 O O5'  . DT  C 2 1  ? 7.464   18.547  86.371  0.00 21.57 ? ? ? ? ? ? 107 DT  B O5'  1 
+ATOM   1731 C C5'  . DT  C 2 1  ? 6.642   19.572  85.828  0.00 23.49 ? ? ? ? ? ? 107 DT  B C5'  1 
+ATOM   1732 C C4'  . DT  C 2 1  ? 6.943   19.784  84.356  0.00 27.33 ? ? ? ? ? ? 107 DT  B C4'  1 
+ATOM   1733 O O4'  . DT  C 2 1  ? 8.382   19.831  84.159  0.00 28.38 ? ? ? ? ? ? 107 DT  B O4'  1 
+ATOM   1734 C C3'  . DT  C 2 1  ? 6.438   18.687  83.425  1.00 31.54 ? ? ? ? ? ? 107 DT  B C3'  1 
+ATOM   1735 O O3'  . DT  C 2 1  ? 6.115   19.248  82.157  1.00 34.97 ? ? ? ? ? ? 107 DT  B O3'  1 
+ATOM   1736 C C2'  . DT  C 2 1  ? 7.641   17.758  83.333  1.00 31.47 ? ? ? ? ? ? 107 DT  B C2'  1 
+ATOM   1737 C C1'  . DT  C 2 1  ? 8.790   18.756  83.333  1.00 31.55 ? ? ? ? ? ? 107 DT  B C1'  1 
+#

--- a/biojava-structure/src/test/resources/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif
+++ b/biojava-structure/src/test/resources/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif
@@ -74,6 +74,11 @@ J.Mol.Biol.                309 401 ? 2001 JMOBAK UK 0022-2836 0070 ? 11371161 10
 'Acta Crystallogr.,Sect.D' 56  137 ? 2000 ABCRE6 DK 0907-4449 0766 ? 10666593 10.1107/S0907444999015334      
 2       'Structure of the Capsid of Pf3 Filamentous Phage Determined from X-Ray Fibre Diffraction Data at 3.1 A Resolution'                                 
 J.Mol.Biol.                283 155 ? 1998 JMOBAK UK 0022-2836 0070 ? 9761681  10.1006/JMBI.1998.2081         
+#
+_space_group.name_H-M_alt         'P 1 21 1'
+_space_group.name_Hall            " P 2yb"
+_space_group.IT_number            4
+_space_group.crystal_system       monoclinic
 # 
 loop_
 _citation_author.citation_id 
@@ -82,5 +87,4 @@ _citation_author.ordinal
 primary 'Pederson, D.M.'   1  
 primary "Welsh, L.C."      2  
 primary 'Marvin, D.A.'     3  
-
 

--- a/biojava-structure/src/test/resources/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif
+++ b/biojava-structure/src/test/resources/org/biojava/nbio/structure/io/difficult_mmcif_quoting.cif
@@ -1,4 +1,4 @@
-data_4LUP_subset_no_quotes
+data_
 loop_
 _atom_site.group_PDB 
 _atom_site.id 
@@ -14,27 +14,59 @@ _atom_site.Cartn_x
 _atom_site.Cartn_y 
 _atom_site.Cartn_z 
 _atom_site.occupancy 
-_atom_site.B_iso_or_equiv 
-_atom_site.Cartn_x_esd 
-_atom_site.Cartn_y_esd 
-_atom_site.Cartn_z_esd 
-_atom_site.occupancy_esd 
-_atom_site.B_iso_or_equiv_esd 
-_atom_site.pdbx_formal_charge 
+_atom_site.B_iso_or_equiv  
 _atom_site.auth_seq_id 
-_atom_site.auth_comp_id 
+_atom_site.auth_comp_id
 _atom_site.auth_asym_id 
 _atom_site.auth_atom_id 
 _atom_site.pdbx_PDB_model_num 
-ATOM   1727 P P      . DT  C 2 1  ? 7.887   18.595  87.913  0.00 20.67 ? ? ? ? ? ? 107 DT  B P      1 
-ATOM   1728 O OP1    . DT  C 2 1  ? 7.732   19.982  88.407  0.00 20.42 ? ? ? ? ? ? 107 DT  B OP1    1 
-ATOM   1729 O OP2    . DT  C 2 1  ? 7.210   17.480  88.610  0.00 20.42 ? ? ? ? ? ? 107 DT  B OP2    1 
-ATOM   1730 O O5'  . DT  C 2 1  ? 7.464   18.547  86.371  0.00 21.57 ? ? ? ? ? ? 107 DT  B O5'  1 
-ATOM   1731 C C5'  . DT  C 2 1  ? 6.642   19.572  85.828  0.00 23.49 ? ? ? ? ? ? 107 DT  B C5'  1 
-ATOM   1732 C C4'  . DT  C 2 1  ? 6.943   19.784  84.356  0.00 27.33 ? ? ? ? ? ? 107 DT  B C4'  1 
-ATOM   1733 O O4'  . DT  C 2 1  ? 8.382   19.831  84.159  0.00 28.38 ? ? ? ? ? ? 107 DT  B O4'  1 
-ATOM   1734 C C3'  . DT  C 2 1  ? 6.438   18.687  83.425  1.00 31.54 ? ? ? ? ? ? 107 DT  B C3'  1 
-ATOM   1735 O O3'  . DT  C 2 1  ? 6.115   19.248  82.157  1.00 34.97 ? ? ? ? ? ? 107 DT  B O3'  1 
-ATOM   1736 C C2'  . DT  C 2 1  ? 7.641   17.758  83.333  1.00 31.47 ? ? ? ? ? ? 107 DT  B C2'  1 
-ATOM   1737 C C1'  . DT  C 2 1  ? 8.790   18.756  83.333  1.00 31.55 ? ? ? ? ? ? 107 DT  B C1'  1 
+ATOM   1728 O OP1  . DT  C 2 1  ? 7.732   19.982  88.407  0.00 20.42 107 DT  B OP1  1  
+ATOM   1730 O O5'  . DT  C 2 1  ? 7.464   18.547  86.371  0.00 21.57 107 DT  B O5'  1 
+ATOM   1738 C H2"  . DT  C 2 1  ? 8.111   19.111  84.111  0.00 29.00 107 DT  B H2"  1
+ATOM   1730 O "O3'"  . DT  C 2 1  ? 7.111   18.111  86.111  0.00 21.00 107 DT  B "O3'"  1
+# 
+loop_
+_audit_author.name 
+_audit_author.pdbx_ordinal 
+'Pederson, D.M.' 1 
+'Welsh, L.C.'    2 
+"Marvin, D.A."   3
+# 
+loop_
+_pdbx_database_related.db_name 
+_pdbx_database_related.db_id 
+_pdbx_database_related.content_type 
+_pdbx_database_related.details 
+PDB 1IFP unspecified 'INOVIRUS (FILAMENTOUS BACTERIOPHAGE) STRAIN PF3 MAJOR COATPROTEIN ASSEMBLY'                                           
+PDB 1QL1 unspecified 'INOVIRUS (FILAMENTOUS BACTERIOPHAGE) STRAIN PF1 MAJOR COAT PROTEIN ASSEMBLY' 
+# 
+loop_
+_citation.id 
+_citation.title 
+_citation.journal_abbrev 
+_citation.journal_volume 
+_citation.page_first 
+_citation.page_last 
+_citation.year 
+_citation.journal_id_ASTM 
+_citation.country 
+_citation.journal_id_ISSN 
+_citation.journal_id_CSD 
+_citation.book_publisher 
+_citation.pdbx_database_id_PubMed 
+_citation.pdbx_database_id_DOI 
+primary 'The Protein Capsid of Filamentous Bacteriophage Ph75 from Thermus Thermophilus'                                                                    
+J.Mol.Biol.                309 401 ? 2001 JMOBAK UK 0022-2836 0070 ? 11371161 10.1006/JMBI.2001.4685         
+1       'The Molecular Structure and Structural Transition of the Alpha-Helical Capsid in Filamentous Bacteriophage Pf1'                                    
+'Acta Crystallogr.,Sect.D' 56  137 ? 2000 ABCRE6 DK 0907-4449 0766 ? 10666593 10.1107/S0907444999015334      
+2       'Structure of the Capsid of Pf3 Filamentous Phage Determined from X-Ray Fibre Diffraction Data at 3.1 A Resolution'                                 
+J.Mol.Biol.                283 155 ? 1998 JMOBAK UK 0022-2836 0070 ? 9761681  10.1006/JMBI.1998.2081         
+# 
+loop_
+_citation_author.citation_id 
+_citation_author.name 
+_citation_author.ordinal 
+primary 'Pederson, D.M.'   1  
+primary "Welsh, L.C."      2  
+primary 'Marvin, D.A.'     3  
 #


### PR DESCRIPTION
This should solve issues #188 and #234 
- basic mmcif writing: coordinates and crystallographic info
- any data in one of the beans in package `org.biojava.nbio.structure.io.mmcif.model` can be written to mmcif format using `org.biojava.nbio.structure.io.MMCIFFileTools.toMMCIF()`, which uses java reflection
- many fixes to the parser so that it can parse a broader set of files (including phenix-produced ones and biojava-produced ones!)
- all biojava-structure tests pass. The long parsing test in biojava-integrationtest also passes