### PR TITLE
created tool for fetching a list of uniprotKb entries in multiple formats

### DIFF
--- a/biojava-ws/pom.xml
+++ b/biojava-ws/pom.xml
@@ -16,6 +16,11 @@
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
+		  <groupId>org.apache.httpcomponents</groupId>
+		  <artifactId>httpclient</artifactId>
+		  <version>4.5</version>
+		</dependency>		
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>

--- a/biojava-ws/src/main/java/demo/UniprotKbBatchRetrievalDemo.java
+++ b/biojava-ws/src/main/java/demo/UniprotKbBatchRetrievalDemo.java
@@ -1,0 +1,99 @@
+package demo;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Scanner;
+
+import org.biojava.nbio.ws.uniprot.BatchRetrieve;
+import org.biojava.nbio.ws.uniprot.BatchRetrieve.BatchRetrievalFormat;
+import org.biojava.nbio.ws.uniprot.ResponseConsumer;
+import org.biojava.nbio.ws.uniprot.UniprotUtilities;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An example of how to use batch retrieval utility in uniprot
+ * @author pbansal
+ *
+ */
+public class UniprotKbBatchRetrievalDemo {
+
+	private final static Logger logger = LoggerFactory.getLogger(UniprotKbBatchRetrievalDemo.class);
+	
+	public static void main(String[] args) {
+		
+		Iterable<String> itr = readFile(args[0]);
+		BatchRetrieve batchRetrieveUniprotEntries = UniprotUtilities.getBatchUtility();
+		
+		try {
+			batchRetrieveUniprotEntries.retrieve(itr, BatchRetrievalFormat.list, new ResponseConsumer() {
+				private Reader reader = null;
+				@Override
+				public void setReader(Reader reader) {
+					this.reader = reader;
+				}
+				
+				@Override
+				public void onSucess() {
+					try {
+						BufferedReader buf = new BufferedReader(reader);
+						String line = buf.readLine();
+						while(line != null) {
+							logger.debug(line);
+							line = buf.readLine();
+						}
+						buf.close();
+					} catch(Exception e) {
+						logger.error("Error while reading the input file.", e.getMessage());
+					}
+				}
+				
+				@Override
+				public void onFail(int httpStatusCode) {
+					logger.error("HttpStatus received " + httpStatusCode);
+				}
+			});
+		} catch (IOException e) {
+			logger.error("Error while retrieving entries", e.getMessage());
+		}
+	}
+	
+	static Iterable<String> readFile(final String fileName) {
+		return new Iterable<String>() {
+			@Override
+			public Iterator<String> iterator() {
+				File fl = new File(fileName);
+				if (!fl.exists()) {
+					throw new IllegalArgumentException("File doesn't exist: " + fileName);
+				}
+				try {
+					final Scanner scanner = new Scanner(fl);
+					return new Iterator<String>() {
+						boolean pastEnd = false;
+						@Override
+						public boolean hasNext() {
+							if (pastEnd) return !pastEnd;
+							boolean hasNext = scanner.hasNextLine();
+							if (!hasNext) {
+								scanner.close();
+								pastEnd = true;
+							}
+							return hasNext;
+						}
+						public String next() {
+							return scanner.nextLine();
+						}
+					};
+				} catch (FileNotFoundException e) {
+					logger.error("Error while reading the input file.", e.getMessage());
+				}
+				return Collections.emptyIterator();
+			}
+		};
+	}
+}

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/BatchRetrieve.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/BatchRetrieve.java
@@ -1,0 +1,45 @@
+package org.biojava.nbio.ws.uniprot;
+
+import java.io.IOException;
+
+public interface BatchRetrieve {
+	
+	/**
+	 * List of formats in which uniprot entry set can be 
+	 * fetched.
+	 * TODO provide tab delimited option too. Once list of columns are listed 
+	 * @author pbansal
+	 *
+	 */
+	public enum BatchRetrievalFormat {
+		xml("xml"),
+		rdf("rdf"),
+		list("list"),
+		text("text"),
+		fastaCannonical("fasta"),
+		fastaWithIsoforms("fasta"),
+		excel("xls");
+		
+		private String extension = null;
+		private BatchRetrievalFormat(String ext) {
+			this.extension = ext;
+		}
+		/**
+		 * @return
+		 */
+		public String getExtenstion() {
+			return extension;
+		}
+	}
+	
+	public static final String INVALID_JOB_ID = "invalidJob";
+	
+	/**
+	 * Given uniprotkb accessions, retrieves the ids from 
+	 * www.uniprot.org in the said format and consume it using the NetworkResponseConsumer
+	 * @param ids
+	 * @throws IOException
+	 */
+	public void retrieve(Iterable<String> ids, BatchRetrievalFormat format, ResponseConsumer out) throws IOException;
+
+} // BatchRetrieve

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/BatchRetrieveUniprotEntries.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/BatchRetrieveUniprotEntries.java
@@ -1,0 +1,149 @@
+package org.biojava.nbio.ws.uniprot;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static org.biojava.nbio.ws.uniprot.UniprotConstants.*;
+
+class BatchRetrieveUniprotEntries implements BatchRetrieve {
+	
+	private final static Logger logger = LoggerFactory.getLogger(BatchRetrieveUniprotEntries.class);
+	
+	@Override
+	public void retrieve(Iterable<String> ids, BatchRetrievalFormat format, ResponseConsumer out) throws IOException {
+		JobIdConsumer consumer = new JobIdConsumer(out);
+		String jobId = createJob(ids, consumer).getJobId();
+		if (!INVALID_JOB_ID.equals(jobId))
+			retrieve(jobId, format, out);
+	}
+
+	private JobIdConsumer createJob(Iterable<String> ids, JobIdConsumer out) throws IOException {
+		makeNetworkRequest(prepareHttpPost(ids), out);
+		return out;
+	}
+	
+	private void makeNetworkRequest(HttpRequestBase base, ResponseConsumer out) throws IOException{
+		CloseableHttpClient httpclient = HttpClients.createDefault();
+		CloseableHttpResponse response = httpclient.execute(base);
+		try {
+			int status = response.getStatusLine().getStatusCode();
+			HttpEntity entity = response.getEntity();
+			out.setReader(new InputStreamReader(response.getEntity().getContent()));
+			if (HttpStatus.SC_OK == status) {
+				out.onSucess();
+			} else {
+				out.onFail(status);
+			}
+		    EntityUtils.consume(entity);
+		} finally {
+		    response.close();
+		}
+	}
+	
+	private void retrieve(String jobId, BatchRetrievalFormat format, ResponseConsumer out) throws IOException {
+		String queryURL = String.format((BatchRetrievalFormat.fastaWithIsoforms == format ? queryUrlWithIsoforms : queryUrl), jobId, format.getExtenstion());
+		makeNetworkRequest(new HttpGet(queryURL), out);
+	}
+
+	private HttpPost prepareHttpPost(Iterable<String> ids) throws UnsupportedEncodingException {
+		HttpPost httpPost = new HttpPost(uploadListURL);
+		List <NameValuePair> nvps = new ArrayList <NameValuePair>();
+		nvps.add(new BasicNameValuePair("format", "job"));
+		nvps.add(new BasicNameValuePair("from", "ACC"));
+		nvps.add(new BasicNameValuePair("to", "ACC"));
+		nvps.add(new BasicNameValuePair("landingPage", "false"));
+		StringBuilder builder = prepareIdString(ids);
+		nvps.add(new BasicNameValuePair("uploadQuery", builder.toString()));
+		httpPost.setEntity(new UrlEncodedFormEntity(nvps));
+		return httpPost;
+	}
+
+	private StringBuilder prepareIdString(Iterable<String> ids) {
+		StringBuilder builder = new StringBuilder();
+		Iterator<String> iterator = ids.iterator();
+		while(iterator.hasNext()) {
+			builder.append(String.format("%s%s", iterator.next(), (iterator.hasNext() ? " " : "")));
+		}
+		return builder;
+	}
+
+	
+	
+	/**
+	 * Utility to cread the stream into a 
+	 * string
+	 * @param reader
+	 * @return the string that is read or an empty string
+	 */
+	public static String readAsString(Reader reader) throws Exception
+	{
+		StringBuffer buffer = new StringBuffer();
+		char[] buf = new char[1024];
+		int numRead = 0;
+		while ((numRead = reader.read(buf)) != -1)
+		{
+			buffer.append(buf, 0, numRead);
+		}
+		return buffer.toString();
+	}
+	
+	
+	/**
+	 * Implementation of NetworkResponseConsumer to consume a job id 
+	 * responded from the server
+	 * @author pbansal
+	 *
+	 */
+	private static class JobIdConsumer implements ResponseConsumer {
+		private String jobId = null;
+		private Reader reader = null;
+		private ResponseConsumer consumer;
+		
+		public JobIdConsumer(ResponseConsumer consumer) {
+			this.consumer = consumer;
+		}
+		
+		@Override
+		public void onSucess() {
+			try {
+				jobId = readAsString(reader);
+			} catch(Exception e) {
+				logger.error("Error while retrieving the jobId ", e.getMessage());
+			}
+		}
+
+		@Override
+		public void onFail(int httpStatusCode) {
+			consumer.onFail(httpStatusCode);
+		}
+
+		@Override
+		public void setReader(Reader reader) {
+			this.reader = reader;
+		}
+		
+		public String getJobId() {
+			return jobId == null ? INVALID_JOB_ID : jobId;
+		}
+	}
+	
+} // BatchRetrieveUniprotEntries

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/ResponseConsumer.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/ResponseConsumer.java
@@ -1,0 +1,15 @@
+package org.biojava.nbio.ws.uniprot;
+
+import java.io.Reader;
+
+/**
+ * A general purpose content holder to wrap the 
+ * network response consumption
+ * @author pbansal
+ *
+ */
+public interface ResponseConsumer {
+	public void onSucess();
+	public void onFail(int httpStatusCode);
+	public void setReader(Reader reader);
+} // ResponseConsumer

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/UniprotConstants.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/UniprotConstants.java
@@ -1,0 +1,13 @@
+package org.biojava.nbio.ws.uniprot;
+
+/**
+ * String constants used by this ws
+ * @author pbansal
+ *
+ */
+public class UniprotConstants {
+	public static final String url = "http://www.uniprot.org";
+	public static final String queryUrl = String.format("%s/uniprot/?query=job:%%s&format=%%s", url);
+	public static final String queryUrlWithIsoforms = String.format("%s/?query=job:%%s&format=%%s&include=yes", url);
+	public static final String uploadListURL = String.format("%s/uploadlists/", url);
+} // UniprotConstants

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/UniprotUtilities.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/uniprot/UniprotUtilities.java
@@ -1,0 +1,12 @@
+package org.biojava.nbio.ws.uniprot;
+
+/**
+ * Just a factory wrapper to prevent users from directly accessing the 
+ * exact implementations object.
+ * @author pbansal
+ */
+public class UniprotUtilities {
+	public static BatchRetrieve getBatchUtility() {
+		return new BatchRetrieveUniprotEntries(); 
+	}
+} // UniprotUtilities


### PR DESCRIPTION
Recently, there has been multiple changes in the programmatic access to uniprotkb website. 2 main among them:
1. Fetching a list of uniprotkb entries across multiple format
2. Mapping a list of external database ids to uniprotkb entries.
There is already a way to fetch a single uniprotkb entry sequence in org.biojava.nbio.core.sequence.loader.UniprotProxySequenceReader but no way to deal with a list of entries. This commit intends to deal with point 1. point 2 will be in an upcoming fix. 