### PR TITLE
Patched to allow tests to be completed on windows. 

### DIFF
--- a/biojava-genome/src/test/java/org/biojava/nbio/genome/GeneFeatureHelperTest.java
+++ b/biojava-genome/src/test/java/org/biojava/nbio/genome/GeneFeatureHelperTest.java
@@ -102,7 +102,7 @@ public class GeneFeatureHelperTest extends TestCase {
         File gffFile = File.createTempFile("volvox_length", "gff3");
         gffFile.deleteOnExit();
         GeneFeatureHelper.outputFastaSequenceLengthGFF3(fastaSequenceFile, gffFile);
-        FileAssert.assertBinaryEquals("volvox_length.gff3 and volvox_length_output.gff3 are not equal", gffFile,
+        FileAssert.assertEquals("volvox_length.gff3 and volvox_length_output.gff3 are not equal", gffFile,
                 new File("src/test/resources/volvox_length_reference.gff3"));
 
     }


### PR DESCRIPTION
It was due to the test resource included that was built on linux and was not binary comparable to the one obtained at runtime in windows.
Discussed on mailing list in thread "Biojava genome test fails" with Jose Manuel Duarte.