### PR TITLE
Change AbstractFeature Qualifiers to a key:Array from key:value

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ProteinSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ProteinSequence.java
@@ -109,7 +109,7 @@ public class ProteinSequence extends AbstractSequence<AminoAcidCompound> {
 
         // cases if a protein has more than 1 parent are not supported yet
         if (CDSFeatures.size() == 1) {
-            Qualifier codedBy = CDSFeatures.get(0).getQualifiers().get("coded_by");
+            Qualifier codedBy = CDSFeatures.get(0).getQualifiers().get("coded_by").get(0);
 
             if (codedBy != null) {
                 String codedBySeq = codedBy.getValue();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/AbstractFeature.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/AbstractFeature.java
@@ -47,7 +47,7 @@ public abstract class AbstractFeature<S extends AbstractSequence<C>, C extends C
     private String description = "";
     private String shortDescription = "";
     private Object userObject = null;
-	private HashMap<String,Qualifier> Qualifiers = new HashMap<String,Qualifier>();
+	private HashMap<String, ArrayList<Qualifier>> Qualifiers = new HashMap<String, ArrayList<Qualifier>>();
 
     /**
      * A feature has a type and a source
@@ -271,13 +271,13 @@ public abstract class AbstractFeature<S extends AbstractSequence<C>, C extends C
     }
     
 	@Override
-	public HashMap<String, Qualifier> getQualifiers() {
+	public HashMap<String, ArrayList<Qualifier>> getQualifiers() {
 		// TODO Auto-generated method stub
 		return Qualifiers;
 	}
 
 	@Override
-	public void setQualifiers(HashMap<String, Qualifier> qualifiers) {
+	public void setQualifiers(HashMap<String, ArrayList<Qualifier>> qualifiers) {
 		// TODO Auto-generated method stub
 		Qualifiers = qualifiers;
 		
@@ -285,8 +285,17 @@ public abstract class AbstractFeature<S extends AbstractSequence<C>, C extends C
 
 	@Override
 	public void addQualifier(String key, Qualifier qualifier) {
-		// TODO Auto-generated method stub
-		Qualifiers.put(key, qualifier);
+		// Check for key. Update list of values
+        if (Qualifiers.containsKey(key)){
+            ArrayList<Qualifier> vals = Qualifiers.get(key);
+            vals.add(qualifier);
+            Qualifiers.put(key, vals);
+        } else {
+            ArrayList<Qualifier> vals = new ArrayList<Qualifier>();
+            vals.add(qualifier);
+            Qualifiers.put(key, vals);
+        }
 		
 	}
+
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/FeatureDbReferenceInfo.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/FeatureDbReferenceInfo.java
@@ -49,7 +49,7 @@ public class FeatureDbReferenceInfo<S extends AbstractSequence<C>, C extends Com
     private String description = "";
     private String shortDescription = "";
     private Object userObject;
-    private HashMap<String,Qualifier> qualifiers = new HashMap<String,Qualifier>();
+    private HashMap<String,ArrayList<Qualifier>> qualifiers = new HashMap<String,ArrayList<Qualifier>>();
     
     
     public FeatureDbReferenceInfo(String database, String id) {
@@ -137,22 +137,30 @@ public class FeatureDbReferenceInfo<S extends AbstractSequence<C>, C extends Com
     }
 
     @Override
-    public HashMap<String, Qualifier> getQualifiers() {
+    public HashMap<String, ArrayList<Qualifier>> getQualifiers() {
         return qualifiers;
     }
 
     @Override
-    public void setQualifiers(HashMap<String, Qualifier> qualifiers) {
+    public void setQualifiers(HashMap<String, ArrayList<Qualifier>> qualifiers) {
         this.qualifiers = qualifiers;
     }
 
     @Override
     public void addQualifier(String key, Qualifier qualifier) {
         if (qualifiers == null) {
-            qualifiers = new HashMap<String, Qualifier>();
+            qualifiers = new HashMap<String, ArrayList<Qualifier>>();
         }
-        
-        qualifiers.put(key, qualifier);
+        // Check for key. Update list of values
+        if (qualifiers.containsKey(key)){
+            ArrayList<Qualifier> vals = qualifiers.get(key);
+            vals.add(qualifier);
+            qualifiers.put(key, vals);
+        } else {
+            ArrayList<Qualifier> vals = new ArrayList<Qualifier>();
+            vals.add(qualifier);
+            qualifiers.put(key, vals);
+        }
+
     }
-    
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/FeatureInterface.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/FeatureInterface.java
@@ -29,6 +29,7 @@ import org.biojava.nbio.core.sequence.location.template.AbstractLocation;
 import org.biojava.nbio.core.sequence.template.AbstractSequence;
 import org.biojava.nbio.core.sequence.template.Compound;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
@@ -175,14 +176,14 @@ public interface FeatureInterface<S extends AbstractSequence<C>, C extends Compo
      * @return
      */
 
-    public HashMap<String, Qualifier> getQualifiers();
+    public HashMap<String, ArrayList<Qualifier>> getQualifiers();
 
     /**
      * Set the qualifiers
      * @param qualifiers
      */
 
-    public void setQualifiers(HashMap<String, Qualifier> qualifiers);
+    public void setQualifiers(HashMap<String, ArrayList<Qualifier>> qualifiers);
     /**
      * Add a qualifier
      * @param qualifier

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -121,8 +121,10 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 		formatter.close();
 		
 		//Now the qualifiers...
-		for(Qualifier  q : feature.getQualifiers().values()) {
-			line += _write_feature_qualifier(q.getName(), q.getValue(), q.needsQuotes());
+		for(ArrayList<Qualifier>  qualifiers : feature.getQualifiers().values()) {
+			for(Qualifier q : qualifiers){
+				line += _write_feature_qualifier(q.getName(), q.getValue(), q.needsQuotes());
+			}
 		}
 		return line;
 		/*

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractSequence.java
@@ -129,7 +129,10 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
                 }
             }
             // success of next statement guaranteed because source is a compulsory field
-            DBReferenceInfo dbQualifier = (DBReferenceInfo)ff.get("source").get(0).getQualifiers().get("db_xref");
+            //DBReferenceInfo dbQualifier = (DBReferenceInfo)ff.get("source").get(0).getQualifiers().get("db_xref");
+            ArrayList<DBReferenceInfo> dbQualifiers = (ArrayList)ff.get("source").get(0).getQualifiers().get("db_xref");
+            DBReferenceInfo dbQualifier = dbQualifiers.get(0);
+
             if (dbQualifier != null) this.setTaxonomy(new TaxonomyID(dbQualifier.getDatabase()+":"+dbQualifier.getId(), DataSource.UNKNOWN));
         }
         

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
@@ -30,12 +30,15 @@ import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompoundSet;
 import org.biojava.nbio.core.sequence.compound.DNACompoundSet;
 import org.biojava.nbio.core.sequence.compound.NucleotideCompound;
+import org.biojava.nbio.core.sequence.features.Qualifier;
 import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.LinkedHashMap;
 import org.biojava.nbio.core.sequence.features.FeatureInterface;
 import org.biojava.nbio.core.sequence.template.AbstractSequence;
@@ -105,9 +108,10 @@ public class GenbankReaderTest {
         inStream.close();
     }
 
+
     @Test
     public void CDStest() throws Exception {
-        logger.info("CDS test");
+        logger.info("CDS Test");
 
         InputStream inStream = this.getClass().getResourceAsStream("/BondFeature.gb");
         assertNotNull(inStream);
@@ -121,16 +125,23 @@ public class GenbankReaderTest {
         @SuppressWarnings("unused")
         LinkedHashMap<String, ProteinSequence> proteinSequences = GenbankProtein.process();
         inStream.close();
-        
+
+
         Assert.assertTrue(proteinSequences.size() == 1);
         logger.info("protein sequences: {}", proteinSequences);
         
         ProteinSequence protein = new ArrayList<ProteinSequence>(proteinSequences.values()).get(0);
         
         FeatureInterface<AbstractSequence<AminoAcidCompound>, AminoAcidCompound> cdsFeature = protein.getFeaturesByType("CDS").get(0);
-        String codedBy = cdsFeature.getQualifiers().get("coded_by").getValue();
+        String codedBy = cdsFeature.getQualifiers().get("coded_by").get(0).getValue();
+        HashMap<String, ArrayList<Qualifier>> quals = cdsFeature.getQualifiers();
+        ArrayList<Qualifier> dbrefs = quals.get("db_xref");
+
         Assert.assertNotNull(codedBy);
         Assert.assertTrue(!codedBy.isEmpty());
+        Assert.assertEquals(codedBy, "NM_000266.2:503..904");
+        Assert.assertEquals(5, dbrefs.size());
+
     }
 
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/loader/GenbankProxySequenceReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/loader/GenbankProxySequenceReaderTest.java
@@ -108,14 +108,14 @@ public class GenbankProxySequenceReaderTest {
         Assert.assertNotNull(Integer.decode(seq.getTaxonomy().getID().split(":")[1]));
 
         // test taxonomy name
-        String taxonName = seq.getFeaturesByType("source").get(0).getQualifiers().get("organism").getValue();
+        String taxonName = seq.getFeaturesByType("source").get(0).getQualifiers().get("organism").get(0).getValue();
         logger.info("taxonomy name '{}'", taxonName);
         Assert.assertNotNull(taxonName);
 
         if (seq.getFeaturesByType("CDS").size() > 0) {
             FeatureInterface<AbstractSequence<AminoAcidCompound>, AminoAcidCompound> CDS = seq.getFeaturesByType("CDS").get(0);
             logger.info("CDS: {}", CDS);
-            String codedBy = CDS.getQualifiers().get("coded_by").getValue();
+            String codedBy = CDS.getQualifiers().get("coded_by").get(0).getValue();
             Assert.assertNotNull(codedBy);
             Assert.assertTrue(!codedBy.isEmpty());
             logger.info("\t\tcoded_by: {}", codedBy);
@@ -138,7 +138,8 @@ public class GenbankProxySequenceReaderTest {
 
         if (CDSs != null) {
             if (CDSs.size() == 1) {
-                Qualifier codedBy = (Qualifier) CDSs.get(0).getQualifiers().get("coded_by");
+                ArrayList<Qualifier> qualifiers = (ArrayList)CDSs.get(0).getQualifiers().get("coded_by");
+                Qualifier codedBy = (Qualifier) qualifiers.get(0);
                 if (codedBy != null) {
 
                     AbstractSequence<?> parentSeq = seq.getParentSequence();


### PR DESCRIPTION
This is a pull request for reference #301 

The basic idea is to allow multiple key/values when parsing genbank files. That is the core change. The rest of the changes are to update getting/setting the fields and to modify the various places this code is called to handle the new format. Also add a test. This passes `mvn test`
 on my machine. Happy to modify in response to feedback.

zach cp