### PR TITLE
Fix313 - ChemCompProvider and ChemComp cache consistency

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileParsingParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileParsingParameters.java
@@ -183,9 +183,9 @@ public class FileParsingParameters implements Serializable
 		return loadChemCompInfo;
 	}
 
-	/** 
-	 * Sets if chemical component defintions should be loaded from the web.
-	 * Modifies also the static ChemCompProvider and resets its cache.
+	/** Sets if chemical component defintions should be loaded or not.
+	 * The decision from where the definitions are obtained is
+	 * in the static variable inside {@link ChemCompGroupFactory}. 
 	 * 
 	 * @param loadChemCompInfo flag
 	 */
@@ -193,12 +193,9 @@ public class FileParsingParameters implements Serializable
 
 		if (loadChemCompInfo){
 			System.setProperty(PDBFileReader.LOAD_CHEM_COMP_PROPERTY, "true");
-			ChemCompGroupFactory.setChemCompProvider(new DownloadChemCompProvider());
 		} else {
 			System.setProperty(PDBFileReader.LOAD_CHEM_COMP_PROPERTY, "false");
-			ChemCompGroupFactory.setChemCompProvider(new ReducedChemCompProvider());
 		}
-		
 		this.loadChemCompInfo = loadChemCompInfo;
 
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileParsingParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileParsingParameters.java
@@ -25,6 +25,9 @@
 package org.biojava.nbio.structure.io;
 
 import org.biojava.nbio.structure.AminoAcid;
+import org.biojava.nbio.structure.io.mmcif.ChemCompGroupFactory;
+import org.biojava.nbio.structure.io.mmcif.DownloadChemCompProvider;
+import org.biojava.nbio.structure.io.mmcif.ReducedChemCompProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -134,7 +137,7 @@ public class FileParsingParameters implements Serializable
 		parseCAOnly = false;
 
 		// don't download ChemComp dictionary by default.
-		loadChemCompInfo = false;
+		setLoadChemCompInfo(false);
 		headerOnly = false;
 
 		storeEmptySeqRes = false;
@@ -180,17 +183,22 @@ public class FileParsingParameters implements Serializable
 		return loadChemCompInfo;
 	}
 
-	/**  Sets if chemical component defintions should be loaded from the web
+	/** 
+	 * Sets if chemical component defintions should be loaded from the web.
+	 * Modifies also the static ChemCompProvider and resets its cache.
 	 * 
 	 * @param loadChemCompInfo flag
 	 */
-	public void setLoadChemCompInfo(boolean loadChemCompInfo)
-	{
+	public void setLoadChemCompInfo(boolean loadChemCompInfo) {
 
-		if ( loadChemCompInfo)
+		if (loadChemCompInfo){
 			System.setProperty(PDBFileReader.LOAD_CHEM_COMP_PROPERTY, "true");
-		else
+			ChemCompGroupFactory.setChemCompProvider(new DownloadChemCompProvider());
+		} else {
 			System.setProperty(PDBFileReader.LOAD_CHEM_COMP_PROPERTY, "false");
+			ChemCompGroupFactory.setChemCompProvider(new ReducedChemCompProvider());
+		}
+		
 		this.loadChemCompInfo = loadChemCompInfo;
 
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileParsingParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileParsingParameters.java
@@ -26,8 +26,6 @@ package org.biojava.nbio.structure.io;
 
 import org.biojava.nbio.structure.AminoAcid;
 import org.biojava.nbio.structure.io.mmcif.ChemCompGroupFactory;
-import org.biojava.nbio.structure.io.mmcif.DownloadChemCompProvider;
-import org.biojava.nbio.structure.io.mmcif.ReducedChemCompProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -3544,10 +3544,6 @@ COLUMNS   DATA TYPE         FIELD          DEFINITION
 		load_max_atoms = params.getMaxAtoms();
 		my_ATOM_CA_THRESHOLD = params.getAtomCaThreshold();
 
-		if ( !params.isLoadChemCompInfo()) {
-			ChemCompGroupFactory.setChemCompProvider(new ReducedChemCompProvider());
-		}
-
 	}
 
 	public FileParsingParameters getFileParsingParameters(){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileReader.java
@@ -238,15 +238,6 @@ public class PDBFileReader extends LocalPDBDirectory {
 		downloadStructure(pdbId);
 	}
 
-	@Override
-	public void setFileParsingParameters(FileParsingParameters params){
-		super.setFileParsingParameters(params);
-		if ( ! params.isLoadChemCompInfo()) {
-			ChemCompGroupFactory.setChemCompProvider(new ReducedChemCompProvider());
-		}
-	}
-
-
 	/**
 	 * <b>N.B.</b> This feature won't work unless the structure wasn't found & autoFetch is set to <code>true</code>.
 	 * @param fetchFileEvenIfObsolete the fetchFileEvenIfObsolete to set

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
@@ -53,14 +53,14 @@ public class ChemCompGroupFactory {
 		logger.debug("Chem comp "+recordName+" read from provider "+chemCompProvider.getClass().getCanonicalName());
 		cc = chemCompProvider.getChemComp(recordName);
 		
-		cache.put(recordName, cc);
+		if (!cc.getOne_letter_code().equals("?")){
+			cache.put(recordName, cc);
+		}
 		return cc;
 	}
 
 	public static void setChemCompProvider(ChemCompProvider provider) {
 		logger.debug("Setting new chem comp provider to "+provider.getClass().getCanonicalName());
-		logger.debug("Chem comp provider cache reset after change of provider ");
-		cache = new SoftHashMap<String, ChemComp>(0);
 		chemCompProvider = provider;
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
@@ -34,7 +34,7 @@ public class ChemCompGroupFactory {
 	
 	private static final Logger logger = LoggerFactory.getLogger(ChemCompGroupFactory.class);
 
-	private static ChemCompProvider chemCompProvider = new DownloadChemCompProvider();
+	private static ChemCompProvider chemCompProvider = new ReducedChemCompProvider();
 
 	private static SoftHashMap<String, ChemComp> cache = new SoftHashMap<String, ChemComp>(0);
 
@@ -59,6 +59,18 @@ public class ChemCompGroupFactory {
 		return cc;
 	}
 
+	/**
+	 * The new ChemCompProvider will be set in the static variable, 
+	 * so this provider will be used from now on until it is changed 
+	 * again. Note that this change can have unexpected behavior of
+	 * code executed afterwards.
+	 * <p>
+	 * Changing the provider does not reset the cache, so Chemical
+	 * Component definitions already downloaded from previous providers
+	 * will be used. To reset the cache see {@link #getCache()).
+	 * 
+	 * @param provider
+	 */
 	public static void setChemCompProvider(ChemCompProvider provider) {
 		logger.debug("Setting new chem comp provider to "+provider.getClass().getCanonicalName());
 		chemCompProvider = provider;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
@@ -137,7 +137,9 @@ public class ChemCompGroupFactory {
 		return oneLetter;
 	}
 
-
+	public static SoftHashMap<String, ChemComp> getCache() {
+		return cache;
+	}
 
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/analysis/ScanSymmetry.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/analysis/ScanSymmetry.java
@@ -257,5 +257,6 @@ public class ScanSymmetry implements Runnable {
 //		BioUnitDataProviderFactory.setBioUnitDataProvider(mmcifProvider.getClass().getCanonicalName());	
 		params.setLoadChemCompInfo(true);
 		ChemCompGroupFactory.setChemCompProvider(new AllChemCompProvider());
+//		ChemCompGroupFactory.setChemCompProvider(new DownloadChemCompProvider());
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/analysis/ScanSymmetry.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/analysis/ScanSymmetry.java
@@ -257,6 +257,5 @@ public class ScanSymmetry implements Runnable {
 //		BioUnitDataProviderFactory.setBioUnitDataProvider(mmcifProvider.getClass().getCanonicalName());	
 		params.setLoadChemCompInfo(true);
 		ChemCompGroupFactory.setChemCompProvider(new AllChemCompProvider());
-//		ChemCompGroupFactory.setChemCompProvider(new DownloadChemCompProvider());
 	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/ChemCompTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/ChemCompTest.java
@@ -129,10 +129,6 @@ public class ChemCompTest {
 
         assertTrue(" is not mea" , cc.getId().equals(chemID));
 
-        // an empty description is returned as expected
-        assertNull(cc.getThree_letter_code());
-
-
         // now we change to download chem comp provider
 
         ChemCompGroupFactory.setChemCompProvider(new DownloadChemCompProvider());

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/ChemCompTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/ChemCompTest.java
@@ -20,6 +20,7 @@
  */
 package org.biojava.nbio.structure;
 
+import org.biojava.nbio.core.util.SoftHashMap;
 import org.biojava.nbio.structure.io.mmcif.ChemCompGroupFactory;
 import org.biojava.nbio.structure.io.mmcif.ChemCompProvider;
 import org.biojava.nbio.structure.io.mmcif.DownloadChemCompProvider;
@@ -116,6 +117,10 @@ public class ChemCompTest {
 	@Test
     public void testChangingProviders(){
 
+		//reset the cache
+		SoftHashMap<String, ChemComp> cache = ChemCompGroupFactory.getCache();
+		cache.clear();
+		
 		// test for issue #145
 
         String chemID = "MEA";
@@ -128,6 +133,8 @@ public class ChemCompTest {
         assertNotNull(cc);
 
         assertTrue(" is not mea" , cc.getId().equals(chemID));
+        
+        assertNull(cc.getThree_letter_code());
 
         // now we change to download chem comp provider
 
@@ -144,7 +151,7 @@ public class ChemCompTest {
         
         
         // now testing in opposite order
-        
+        cache.clear();
 
         // first we test with download chem comp provider
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/ChemCompTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/ChemCompTest.java
@@ -171,8 +171,8 @@ public class ChemCompTest {
 
         assertTrue(" is not mea" , cc.getId().equals(chemID));
 
-        // an empty description is returned as expected
-        assertNull(cc.getThree_letter_code());
+        //the cached description contains all information even with the ReducedProvider
+        assertNotNull(cc.getThree_letter_code());
 
         
     }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/PdbFileFormat30Test.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/PdbFileFormat30Test.java
@@ -25,6 +25,8 @@ package org.biojava.nbio.structure;
 
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.PDBFileParser;
+import org.biojava.nbio.structure.io.mmcif.ChemCompGroupFactory;
+import org.biojava.nbio.structure.io.mmcif.ReducedChemCompProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -95,6 +97,7 @@ public class PdbFileFormat30Test {
 		InputStream inStream = this.getClass().getResourceAsStream(fileName);
 		assertNotNull(inStream);
 		
+		ChemCompGroupFactory.setChemCompProvider(new ReducedChemCompProvider());
 		PDBFileParser pdbpars = new PDBFileParser();
 		FileParsingParameters params = new FileParsingParameters();
 		params.setAlignSeqRes(false);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestChemCompProvider.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestChemCompProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  *                    BioJava development code
  *
  * This code may be freely distributed and modified under the
@@ -82,6 +82,7 @@ public class TestChemCompProvider {
 		ChemCompProvider prov3 = ChemCompGroupFactory.getChemCompProvider();
 		String name3 = prov3.getClass().getName();
 		
-		assertEquals( "org.biojava.nbio.structure.io.mmcif.ReducedChemCompProvider",name3);
+		//changing the load to false does not change the provider
+		assertEquals("The ChemCompProvider got modified from " + name1 + " to " + name3, name1, name3);
 	}
 }


### PR DESCRIPTION
See issue #313.

This pull request solves issue 313 by forcing the user to specify which *ChemCompProvider* is used when parsing a PDB or MMCiff file. The cache is kept and increased while the JVM is running, so *ChemComp* downloaded and cached by the *DownloadChemCompProvider* can also be user later by the *ReducedChemCompProvider*. The cache is never reset in the same JVM.