### PR TITLE
Output MultipleAlignment objects as an I-TASSER restraint file

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymm.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymm.java
@@ -2,6 +2,7 @@ package org.biojava.nbio.structure.symmetry.internal;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.vecmath.Matrix4d;
 
 import org.biojava.nbio.structure.Atom;
@@ -15,6 +16,7 @@ import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.multiple.MultipleAlignment;
 import org.biojava.nbio.structure.align.multiple.MultipleAlignmentEnsemble;
 import org.biojava.nbio.structure.align.multiple.MultipleAlignmentEnsembleImpl;
+import org.biojava.nbio.structure.align.multiple.util.CoreSuperimposer;
 import org.biojava.nbio.structure.align.multiple.util.MultipleAlignmentScorer;
 import org.biojava.nbio.structure.align.util.AFPChainScorer;
 import org.biojava.nbio.structure.jama.Matrix;
@@ -413,6 +415,8 @@ public class CeSymm {
 
 		if (refined){
 			if (msa == null) msa = SymmetryTools.fromAFP(afpChain, ca1);
+			CoreSuperimposer imposer = new CoreSuperimposer();
+			imposer.superimpose(msa);
 			MultipleAlignmentScorer.calculateScores(msa);
 			msa.putScore("isRefined", 1.0);
 


### PR DESCRIPTION
Add a method to output alignments in I-TASSER's 3D Format, used for specifying an alignment for homology modelling.

The format is similar to PDB's ATOM records. See
http://zhanglab.ccmb.med.umich.edu/I-TASSER/option4.html