### PR TITLE
Downgrading Log4J to 2.3 for compatibility with Java 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>
 		<maxmem>512M</maxmem>
 		<slf4j.version>1.7.12</slf4j.version>
-		<!-- Log4j 2.3 is the most recent version that works with Java 1.6 -->
-		<log4j.version>2.5</log4j.version>
+		<!-- DO NOT CHANGE. Log4j 2.3 is the most recent version that works with Java 1.6 -->
+		<log4j.version>2.3</log4j.version>
 	</properties>
 	<scm>
 		<connection>scm:git:git://github.com/biojava/biojava.git</connection>


### PR DESCRIPTION
Log4J should be fixed at 2.3, as per #364.