### PR TITLE
Improved headerOnly() performance and removing FileParsingParameters.storeEmptySeqRes.

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileParsingParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileParsingParameters.java
@@ -94,8 +94,6 @@ public class FileParsingParameters implements Serializable
 	 */
 	boolean updateRemediatedFiles;
 
-	private boolean storeEmptySeqRes;
-
 	/** 
 	 * The maximum number of atoms that will be parsed before the parser switches to a CA-only
 	 * representation of the PDB file. If this limit is exceeded also the SEQRES groups will be
@@ -138,16 +136,13 @@ public class FileParsingParameters implements Serializable
 	public void setDefault(){
 
 		parseSecStruc = false;
-
-		// by default we now do NOT align Atom and SeqRes records
-		alignSeqRes   = false;
+		// Default is to align / when false the unaligned SEQRES is stored.
+		alignSeqRes   = true; 
 		parseCAOnly = false;
 
 		// don't download ChemComp dictionary by default.
 		setLoadChemCompInfo(false);
 		headerOnly = false;
-
-		storeEmptySeqRes = false;
 
 		updateRemediatedFiles = false;
 		fullAtomNames = null;
@@ -266,23 +261,6 @@ public class FileParsingParameters implements Serializable
 	public void setAlignSeqRes(boolean alignSeqRes) {
 		this.alignSeqRes = alignSeqRes;
 	}
-
-
-	/** 
-	 * A flag to determine if SEQRES should be stored, even if alignSeqRes is disabled.
-	 * This will provide access to the sequence in the SEQRES, without linking it up with the ATOMs.
-	 * 
-	 * @return flag
-	 */
-	public boolean getStoreEmptySeqRes() {
-
-		return storeEmptySeqRes;
-	}
-
-	public void setStoreEmptySeqRes(boolean storeEmptySeqRes){
-		this.storeEmptySeqRes = storeEmptySeqRes;
-	}
-
 
 	/** A flag if local files should be replaced with the latest version of remediated PDB files. Default: false
 	 * 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -21,7 +21,57 @@
  */
 package org.biojava.nbio.structure.io;
 
-import org.biojava.nbio.structure.*;
+import static java.lang.Math.min;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.vecmath.Matrix4d;
+
+import org.biojava.nbio.structure.AminoAcid;
+import org.biojava.nbio.structure.AminoAcidImpl;
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.AtomImpl;
+import org.biojava.nbio.structure.Author;
+import org.biojava.nbio.structure.BondImpl;
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.ChainImpl;
+import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.DBRef;
+import org.biojava.nbio.structure.Element;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.GroupIterator;
+import org.biojava.nbio.structure.GroupType;
+import org.biojava.nbio.structure.HetatomImpl;
+import org.biojava.nbio.structure.JournalArticle;
+import org.biojava.nbio.structure.NucleotideImpl;
+import org.biojava.nbio.structure.PDBCrystallographicInfo;
+import org.biojava.nbio.structure.PDBHeader;
+import org.biojava.nbio.structure.ResidueNumber;
+import org.biojava.nbio.structure.SSBond;
+import org.biojava.nbio.structure.SSBondImpl;
+import org.biojava.nbio.structure.Site;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureImpl;
+import org.biojava.nbio.structure.StructureTools;
 import org.biojava.nbio.structure.io.mmcif.ChemCompGroupFactory;
 import org.biojava.nbio.structure.io.util.PDBTemporaryStorageUtils.LinkRecord;
 import org.biojava.nbio.structure.secstruc.SecStrucInfo;
@@ -31,21 +81,6 @@ import org.biojava.nbio.structure.xtal.SpaceGroup;
 import org.biojava.nbio.structure.xtal.SymoplibParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.vecmath.Matrix4d;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import static java.lang.Math.min;
 
 //import org.biojava.nbio.structure.Calc;
 
@@ -2905,15 +2940,15 @@ COLUMNS   DATA TYPE         FIELD          DEFINITION
 		
 		structure.setDBRefs(dbrefs);
 
-		if ( params.isAlignSeqRes() ){
+		// Only align if requested (default) and not when headerOnly mode with no Atoms.
+		// Otherwise, we store the empty SeqRes Groups unchanged in the right chains.
+		if ( params.isAlignSeqRes() && !params.isHeaderOnly() ){	
 			logger.debug("Parsing mode align_seqres, will parse SEQRES and align to ATOM sequence");
 			SeqRes2AtomAligner aligner = new SeqRes2AtomAligner();
 			aligner.align(structure,seqResChains);
 
-		} else if ( params.getStoreEmptySeqRes() ){
+		} else {
 			logger.debug("Parsing mode unalign_seqres, will parse SEQRES but not align it to ATOM sequence");
-			// user wants to know about the seqres, but not align them
-
 			storeUnAlignedSeqRes(structure, seqResChains);
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/analysis/ScanSymmetry.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/analysis/ScanSymmetry.java
@@ -20,7 +20,18 @@
  */
 package org.biojava.nbio.structure.symmetry.analysis;
 
-import org.biojava.nbio.structure.*;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Set;
+
+import org.biojava.nbio.structure.PDBCrystallographicInfo;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.mmcif.AllChemCompProvider;
@@ -33,14 +44,6 @@ import org.biojava.nbio.structure.symmetry.core.Subunits;
 import org.biojava.nbio.structure.symmetry.misc.ProteinComplexSignature;
 import org.biojava.nbio.structure.symmetry.utils.BlastClustReader;
 import org.biojava.nbio.structure.xtal.SpaceGroup;
-
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.List;
-import java.util.Set;
 
 
 public class ScanSymmetry implements Runnable {
@@ -251,8 +254,6 @@ public class ScanSymmetry implements Runnable {
 		cache = new AtomCache();
 		FileParsingParameters params = cache.getFileParsingParams();
 		cache.setUseMmCif(true);
-		params.setStoreEmptySeqRes(true);
-		params.setAlignSeqRes(true);
 		params.setParseCAOnly(true);
 //		MmCifBiolAssemblyProvider mmcifProvider = new MmCifBiolAssemblyProvider();
 //		BioUnitDataProviderFactory.setBioUnitDataProvider(mmcifProvider.getClass().getCanonicalName());	

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/Test2JA5.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/Test2JA5.java
@@ -20,6 +20,7 @@
  */
 package org.biojava.nbio.structure;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -38,7 +39,38 @@ public class Test2JA5 {
     public void test2JA5() throws IOException, StructureException {
 
         FileParsingParameters fileParsingParameters = new FileParsingParameters();
-        fileParsingParameters.setAlignSeqRes(false);
+        fileParsingParameters.setAlignSeqRes(true); // Need to align seqres to match chains.
+        fileParsingParameters.setLoadChemCompInfo(true);
+        fileParsingParameters.setHeaderOnly(false); // Need header only off to have chains to match.
+
+        AtomCache cache = new AtomCache();
+        cache.setUseMmCif(false);
+        cache.setFileParsingParams(fileParsingParameters);
+
+        StructureIO.setAtomCache(cache);
+
+
+        Structure s1 = StructureIO.getStructure("2ja5");
+
+        // This is not applicable anymore, we need to parse atoms to have chains to match.
+        // assertTrue(StructureTools.getNrAtoms(s1) == 0);
+
+        // SeqRes contains 15 chains, but since we cannot align Chain N to AtomGroups => 14.
+        assertTrue(s1.getChains().size() == 14);
+
+        Chain nChain = null;
+        try {
+        	nChain = s1.getChainByPDB("N");
+        } catch (StructureException e){
+        	// this is expected here, since there is no chain N
+        }
+        assertNull(nChain);
+    }
+    
+    @Test
+    public void test2JA5noHeader() throws IOException, StructureException {
+
+        FileParsingParameters fileParsingParameters = new FileParsingParameters();
         fileParsingParameters.setLoadChemCompInfo(true);
         fileParsingParameters.setHeaderOnly(true);
 
@@ -51,9 +83,11 @@ public class Test2JA5 {
 
         Structure s1 = StructureIO.getStructure("2ja5");
 
+        // This is not applicable anymore, we need to parse atoms to have chains to match.
         assertTrue(StructureTools.getNrAtoms(s1) == 0);
 
-        assertTrue(s1.getChains().size() == 14);
+        // All 15 seqres chains will be store.
+        assertTrue(s1.getChains().size() == 15);
 
         Chain nChain = null;
         try {
@@ -61,10 +95,6 @@ public class Test2JA5 {
         } catch (StructureException e){
         	// this is expected here, since there is no chain N
         }
-        assertNull(nChain);
-
-
-
-        
+        assertNotNull(nChain);
     }
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/Test2JA5.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/Test2JA5.java
@@ -20,14 +20,14 @@
  */
 package org.biojava.nbio.structure;
 
-import org.biojava.nbio.structure.align.util.AtomCache;
-import org.biojava.nbio.structure.io.FileParsingParameters;
-
-import org.junit.Test;
-
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.junit.Test;
 
 /**
  * Created by andreas on 9/16/15.
@@ -38,7 +38,7 @@ public class Test2JA5 {
     public void test2JA5() throws IOException, StructureException {
 
         FileParsingParameters fileParsingParameters = new FileParsingParameters();
-        fileParsingParameters.setStoreEmptySeqRes(true);
+        fileParsingParameters.setAlignSeqRes(false);
         fileParsingParameters.setLoadChemCompInfo(true);
         fileParsingParameters.setHeaderOnly(true);
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
@@ -20,12 +20,13 @@
  */
 package org.biojava.nbio.structure;
 
-import junit.framework.TestCase;
+import java.io.IOException;
+
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.junit.Before;
 
-import java.io.IOException;
+import junit.framework.TestCase;
 
 public class TestBond extends TestCase {
 	private Structure s;
@@ -39,8 +40,7 @@ public class TestBond extends TestCase {
 
 		FileParsingParameters params = cache.getFileParsingParams();
 
-		params.setStoreEmptySeqRes(true);
-		params.setAlignSeqRes(true);
+		params.setAlignSeqRes(false);
 		params.setLoadChemCompInfo(true);
 		params.setCreateAtomBonds(true);
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
@@ -39,8 +39,8 @@ public class TestBond extends TestCase {
 		cache.setUseMmCif(false);
 
 		FileParsingParameters params = cache.getFileParsingParams();
-
-		params.setAlignSeqRes(false);
+		
+		params.setAlignSeqRes(true);
 		params.setLoadChemCompInfo(true);
 		params.setCreateAtomBonds(true);
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestHeaderOnly.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestHeaderOnly.java
@@ -1,0 +1,180 @@
+package org.biojava.nbio.structure.io;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestHeaderOnly {
+
+	final String pdbID = "1REP";
+	
+	/**
+	 * All groups are expected to be empty.
+	 * 
+	 * @throws StructureException
+	 * @throws IOException
+	 */
+	@Test
+	public void testHeaderOnly() throws StructureException, IOException {
+		// Get either PDB or mmCIF with a headerOnly = true.
+		
+		// Test 1: with PDB
+		AtomCache cache = new AtomCache();
+		cache.setUseMmCif(false);
+		
+		FileParsingParameters params = new FileParsingParameters();
+		params.setHeaderOnly(true);
+		// params.setAlignSeqRes(true);  // Now this is default.
+		cache.setFileParsingParams(params);
+		
+		StructureIO.setAtomCache(cache); 
+		
+		Structure sPDB = StructureIO.getStructure(pdbID);
+		
+		Assert.assertEquals(false, doSeqResHaveAtoms(sPDB));
+		
+		for (Chain c : sPDB.getChains()) {
+			System.out.println(c.getChainID() + ":" + getSequenceString(c.getSeqResGroups()));
+		}
+		
+		// Test 2: with mmCIF
+		cache.setUseMmCif(true);
+		
+		Structure sCIF = StructureIO.getStructure(pdbID);
+		Assert.assertEquals(false, doSeqResHaveAtoms(sCIF));
+		
+		for (Chain c : sCIF.getChains()) {
+			System.out.println(c.getChainID() + ":" + getSequenceString(c.getSeqResGroups()));
+		}
+	}
+	
+	/**
+	 * Test that with alignSeqRes, expected Group(s) have Atoms, while others
+	 * are present with correct sequence but empty.
+	 * 
+	 * @throws StructureException
+	 * @throws IOException
+	 */
+	@Test
+	public void testAlignSeqres() throws StructureException, IOException {
+		// Get either PDB or mmCIF with a headerOnly = false.
+		
+		// Test 1: with PDB
+		AtomCache cache = new AtomCache();
+		cache.setUseMmCif(false);
+		
+		FileParsingParameters params = new FileParsingParameters();
+		params.setHeaderOnly(false);
+		// params.setAlignSeqRes(true);  // Now this is default.
+		cache.setFileParsingParams(params);
+		
+		StructureIO.setAtomCache(cache); 
+		
+		Structure sPDB = StructureIO.getStructure(pdbID);
+		Assert.assertEquals(true, doSeqResHaveAtoms(sPDB));
+		check1REPChainC(sPDB); // Check particular residues to be aligned.
+		
+		// Test 2: with mmCIF
+		cache.setUseMmCif(true);
+		
+		Structure sCIF = StructureIO.getStructure(pdbID);
+		Assert.assertEquals(true, doSeqResHaveAtoms(sCIF));
+		check1REPChainC(sCIF); // Check particular residues to be aligned.
+	}
+	
+	/**
+	 * Scan through SeqResGroups, returns true if any have Atoms.
+	 * @param s
+	 * @return
+	 */
+	public boolean doSeqResHaveAtoms(Structure s) {
+		for (int i = 0; i < s.nrModels(); i++) {
+			for (Chain c : s.getChains(i)) {
+				for (Group g : c.getSeqResGroups()) {
+					if (hasAtoms(g)) return true; // Found some Atoms in a Seqres group.
+				}
+			}
+		}
+		
+		return false;
+	}
+	
+	/**
+	 * Does a group have any Atom(s)?
+	 * 
+	 * @param g : a group
+	 * @return true if has any Atom(s)
+	 */
+	public boolean hasAtoms(Group g) {
+		if (g.getAtoms().size() > 0) return true;
+		return false;
+	}
+	
+	/**
+	 * Check that the gapped residues have no atoms, but that ungapped residues
+	 * have atoms.  
+	 * 
+	 * @param s: Structure to test.
+	 */
+	public void check1REPChainC(Structure s) throws StructureException {
+		String sequence = "MAETAVINHKKRKNSPRIVQSNDLTEAAYSLSRDQKRMLYLFVDQIRK" + 
+				"SDGTLQEHDGICEIHVAKYAEIFGLTSAEASKDIRQALKSFAGKEVVFYRPEEDAGDE" + 
+				"KGYESFPWFIKPAHSPSRGLYSVHINPYLIPFFIGLQNRFTQFRLSETKEITNPYAMR" +
+				"LYESLCQYRKPDGSGIVSLKIDWIIERYQLPQSYQRMPDFRRRFLQVCVNEINSRTPM" +
+				"RLSYIEKKKGRQTTHIVFSFRDITSMTTG";
+		
+		boolean [] shouldMatch = new boolean[sequence.length()];
+		for (int i = 0; i < sequence.length(); i++) shouldMatch[i] = true;
+		
+		// 1-14 is gap
+		for (int i = 0; i < 14; i++) shouldMatch[i] = false;
+		
+		// 50-55 is gap
+		for (int i = 49; i < 55; i++) shouldMatch[i] = false;
+		
+		// 98-109 is gap
+		for (int i = 97; i < 109; i++) shouldMatch[i] = false;
+		
+		// 247-251 is gap
+		for (int i = 246; i < 251; i++) shouldMatch[i] = false;
+		
+		Chain c = s.findChain("C");
+		
+		List<Group> seqres = c.getSeqResGroups();
+		
+		// Check lengths
+		Assert.assertEquals(sequence.length(), seqres.size());
+		
+		// Check sequences.
+		Assert.assertEquals(sequence, c.getSeqResSequence());
+		
+		for (int i = 0; i < sequence.length(); i++) {
+			Assert.assertEquals(shouldMatch[i], hasAtoms(seqres.get(i)));
+		}
+	}
+	
+	/**
+	 * 
+	 * @param seqres : a list of Group(s)
+	 * @return a String representing these Groups
+	 */
+	public String getSequenceString(List<Group> seqres) {
+		StringBuilder sb = new StringBuilder();
+		
+		for (Group g : seqres) {
+			ChemComp c = g.getChemComp();
+			sb.append(c.getOne_letter_code());
+		}
+		
+		return sb.toString();
+	}
+}


### PR DESCRIPTION
These changes are to close out issue #353 (originally mmCIF parsing of SEQRES..).  Based on the design Steve Darnell suggested, these changes do the following:

Simplify the options:
* FileParsingParameters.storeEmptySeqRes option is dropped.
* FileParsingParameters.alignSeqRes is true by default.  When false, parsing will store seqres without aligning to AtomGroups.
* FileParsingParameters.headerOnly == true indicates that parsing should only take in header information and skip sections like Atoms, Sites, and Conects.  

Parsers:  
PDBFileParser and SimpleMMcifConsumer were updated for matching behaviors to the options.
  When in headerOnly mode, parsing non-header sections return immediately to speed the parsing.

Tests:
Existing unit tests were updated for this change in the FileParsingParameters intent.  Added a new unit test to specifically test the setHeaderOnly() option and parsing of SEQRES.

Performance:
The headerOnly parsing is now greatly faster than default mode.  Prior to these changes, a 10% speed difference was found for mmCIF or PDB parsing in headerOnly mode.  After these changes with headerOnly mode for the PDB:4HHB, PDB parsing is 95% faster and mmCIF parsing is 45% faster. This can greatly speed up bulk-parsing of PDB/mmCIF files for data mining and scanning of a large PDB/mmCIF library.  (see org.biojava.nbio.structure.io.TestHeaderOnly#testSpeed2 using local files).