### PR TITLE
Fix NPE in ChemCompGroupFactory

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
@@ -22,10 +22,14 @@
  */
 package org.biojava.nbio.structure.io.mmcif;
 
-import org.biojava.nbio.structure.*;
+import org.biojava.nbio.core.util.SoftHashMap;
+import org.biojava.nbio.structure.AminoAcid;
+import org.biojava.nbio.structure.AminoAcidImpl;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.HetatomImpl;
+import org.biojava.nbio.structure.NucleotideImpl;
 import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
 import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
-import org.biojava.nbio.core.util.SoftHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +57,8 @@ public class ChemCompGroupFactory {
 		logger.debug("Chem comp "+recordName+" read from provider "+chemCompProvider.getClass().getCanonicalName());
 		cc = chemCompProvider.getChemComp(recordName);
 		
-		if (!cc.getOne_letter_code().equals("?")){
+		// If chemCompProvider fails don't try to cache null & one letter code may be null.
+		if (null != cc && !"?".equals(cc.getOne_letter_code())){
 			cache.put(recordName, cc);
 		}
 		return cc;


### PR DESCRIPTION
This is a small fix from issue #313.  If there was a search for a non-existent chemcomp group, this call causes a NPE that is prevented with a test.