### PR TITLE
Adding ZipChemCompProvider. 

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ZipAppendUtil.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ZipAppendUtil.java
@@ -1,0 +1,184 @@
+/*
+ *                    BioJava development code
+ *
+ * This code may be freely distributed and modified under the
+ * terms of the GNU Lesser General Public Licence.  This should
+ * be distributed with the code.  If you do not have a copy,
+ * see:
+ *
+ *      http://www.gnu.org/copyleft/lesser.html
+ *
+ * Copyright for this code is held jointly by the individual
+ * authors.  These should be listed in @author doc comments.
+ *
+ * For more information on the BioJava project and its aims,
+ * or to join the biojava-l mailing list, visit the home page
+ * at:
+ *
+ *      http://www.biojava.org/
+ *
+ */
+package org.biojava.nbio.structure.io.mmcif;
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.logging.Logger;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+/**
+* Singleton helper class to add entries to zip archives.
+* @since Feb 8, 2013
+* @author edlunde
+* 
+*/
+public class ZipAppendUtil {
+	private static final Logger s_logger = Logger.getLogger( ZipAppendUtil.class.getPackage().getName() );
+	private boolean busy;
+	private static ZipAppendUtil s_instance;
+	
+	/**
+	 * Get a singleton instance.
+	 * @return
+	 */
+	public static ZipAppendUtil getInstance() {
+
+		if (s_instance == null) {
+			s_instance = new ZipAppendUtil();
+		}
+		return s_instance;
+
+	}
+	
+	/**
+	 * Extract contents of sourceArchive to a temporary file, append files to pathWithinArchive, and rezip.
+	 * @param sourceArchive
+	 * @param files
+	 * @param pathWithinArchive
+	 * @return
+	 */
+	public boolean addToZipArchive(File sourceArchive, File[] files, String pathWithinArchive){
+		if (busy) return false;
+		
+		busy = true;
+		if (files == null) return false;
+		if(files.length >0){
+			try{
+
+				File tmpZip = File.createTempFile(sourceArchive.getName(), null);
+				tmpZip.delete();
+				if(!sourceArchive.renameTo(tmpZip)){
+					s_logger.info("\nDictionary archive is occupied. Reading from a temporary copy instead.");
+					copyFile(sourceArchive, tmpZip); //Since the chemcomp.zip file cannot be renamed while in use (Win only), copy it to tmpZip
+				}
+				byte[] buffer = new byte[1024];
+				ZipInputStream zin = new ZipInputStream(new FileInputStream(tmpZip));
+				ZipOutputStream out = new ZipOutputStream(new FileOutputStream(sourceArchive));
+				for(int i = 0; i < files.length; i++){
+					InputStream in = new FileInputStream(files[i]);
+					ZipEntry entry =new ZipEntry(pathWithinArchive + files[i].getName());
+					entry.setSize(files[i].length());
+					entry.setTime(files[i].lastModified());
+					CRC32 crc32 = new CRC32();
+					out.putNextEntry(entry);
+					for(int read = in.read(buffer); read > -1; read = in.read(buffer)){
+						out.write(buffer, 0, read);
+						crc32.update(buffer,0,read);
+					}
+					entry.setCrc(crc32.getValue());
+					out.closeEntry();
+					in.close();
+				}
+				for(ZipEntry ze = zin.getNextEntry(); ze != null; ze = zin.getNextEntry()){
+					if(!zipEntryMatch(ze.getName(), files, pathWithinArchive)){
+						ZipEntry destEntry = new ZipEntry(ze.getName());
+						CRC32 crc32 = new CRC32();
+						out.putNextEntry(destEntry);
+						for(int read = zin.read(buffer); read > -1; read = zin.read(buffer)){
+							out.write(buffer, 0, read);
+							crc32.update(buffer,0,read);
+						}
+
+						destEntry.setCrc(crc32.getValue());
+						out.closeEntry();
+					}
+				}
+				out.close();
+				zin.close();
+				/*
+				if(tmpZip.delete()) {
+					s_logger.info("Successfully deleted temp zip file");
+				}	
+				s_logger.info("Wrote downloaded file(s) to "+sourceArchive.getAbsolutePath());
+				*/
+				busy = false;
+				return true;
+			}catch(Exception e){
+				busy = false;
+				s_logger.info(e.getMessage());
+				return false;
+			}
+		}
+		busy = false;
+		return false;
+	}
+	
+	/**
+	 * Check for an entry.
+	 * @param zeName
+	 * @param files
+	 * @param path
+	 * @return
+	 */
+	private boolean zipEntryMatch(String zeName, File[] files, String path){
+		for(int i = 0; i < files.length; i++){
+			if((path + files[i].getName()).equals(zeName)){
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Create a copy for a file.
+	 * @param src
+	 * @param dst
+	 * @throws IOException
+	 */
+	public void copyFile(File src, File dst) throws IOException {
+	    InputStream is = null;
+	    OutputStream os = null;
+	    try {
+	        is = new FileInputStream(src);
+	        os = new FileOutputStream(dst);
+	        byte[] buffer = new byte[1024];
+	        int length;
+	        while ((length = is.read(buffer)) > 0) {
+	            os.write(buffer, 0, length);
+	        }
+	    } finally {
+	        is.close();
+	        os.close();
+	    }
+	}
+	
+	/**
+	 * Check if the zip archive is being modified or referenced.
+	 * @return
+	 */
+	public boolean isBusy() {
+		return this.busy;
+	}
+	
+	/* Prevent direct access to the constructor*/
+	private ZipAppendUtil() {
+		super();
+	}
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ZipChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ZipChemCompProvider.java
@@ -1,0 +1,296 @@
+/*
+ *                    BioJava development code
+ *
+ * This code may be freely distributed and modified under the
+ * terms of the GNU Lesser General Public Licence.  This should
+ * be distributed with the code.  If you do not have a copy,
+ * see:
+ *
+ *      http://www.gnu.org/copyleft/lesser.html
+ *
+ * Copyright for this code is held jointly by the individual
+ * authors.  These should be listed in @author doc comments.
+ *
+ * For more information on the BioJava project and its aims,
+ * or to join the biojava-l mailing list, visit the home page
+ * at:
+ *
+ *      http://www.biojava.org/
+ *
+ */
+package org.biojava.nbio.structure.io.mmcif;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
+import org.biojava.nbio.structure.io.mmcif.chem.ResidueType;
+import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
+
+/** This chemical component provider retrieves and caches chemical component definition files from a zip archive specified in its construction.
+ * 	If the archive does not contain the record, an attempt is made to download it using DownloadChemCompProvider. The downloaded file is then added to the archive.
+ *	It is up to the calling function to handle exceptions raised by constructing with a non-existent archive. 
+ *
+ * @author edlunde
+ * @author larsonm
+ * @since 12/05/12
+ * 
+ */
+public class ZipChemCompProvider implements ChemCompProvider{
+
+	private static final String FILE_SEPARATOR = System.getProperty("file.separator");
+	private static ZipChemCompProvider s_provider = null;
+	private String tempdir = "";  // Base path where $zipRootDir/ will be downloaded to.
+	private String zipRootDir = "chemcomp/"; 
+	private ZipFile zipDictionary;
+	private String zipFile;
+	private static final Logger s_logger = Logger.getLogger( ZipChemCompProvider.class.getPackage().getName() );
+	private DownloadChemCompProvider dlProvider;
+	
+	// Missing IDs from library that cannot be download added here to prevent delays.
+	private Set<String> unavailable = new HashSet<String>();
+
+	/**
+	 * 
+	 * @param chemicalComponentDictionaryFile : zip filename
+	 * @param tempDir : directory of the zip filename
+	 * @throws IOException
+	 */
+	public ZipChemCompProvider(String chemicalComponentDictionaryFile, String tempDir) throws IOException{
+		this.zipFile = chemicalComponentDictionaryFile;
+		this.tempdir = tempDir;
+		
+		init();
+	}
+	
+	// Create the zip file and setup a fallback DownloadChemCompProvider.
+	private void init() throws IOException {
+		try{
+			s_logger.info("Using chemical component dictionary: " + zipFile.toString());
+			
+			// Check if file exists, if not create.
+			File zipFile = new File(this.zipFile);
+			if (!zipFile.exists()) {
+				createNewZip(zipFile);
+			}
+			
+			this.zipDictionary = new ZipFile(this.zipFile);
+		}catch(ZipException e){
+			s_logger.info(e.getMessage());
+		}
+		
+		// Setup an instance of the download chemcomp provider.
+		dlProvider = new DownloadChemCompProvider(this.tempdir);
+	}
+
+	/**
+	 * Get a singleton instance of the provider.
+	 * @return
+	 */
+	public static ZipChemCompProvider getInstance() throws IOException {
+		ZipChemCompProvider provider = s_provider;
+		if (provider == null){
+			s_provider = provider = new ZipChemCompProvider();
+		}
+
+		return provider;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.biojava.nbio.structure.io.mmcif.ChemCompProvider#getChemComp(java.lang.String)
+	 * 
+	 * @param recordName : three letter PDB name for a residue
+	 * @return ChemComp from .zip or ChemComp from repository.  Will return empty ChemComp when unable to find a residue and will return null if not provided a valid recordName.
+	 */
+	@Override
+	public ChemComp getChemComp(String recordName) {
+		
+		if (null == recordName) return null;
+		
+		// handle non-existent ChemComp codes and do not repeatedly attempt to add these.
+		for (String str : unavailable) {
+			if (recordName.equals(str)) return getEmptyChemComp(recordName);
+		}
+		
+		try {
+			ZipEntry ccEntry = zipDictionary.getEntry(zipRootDir+recordName+".cif.gz");
+			
+			//read single gzipped cif from archive and write to temporary file 
+			InputStream zipStream = zipDictionary.getInputStream(ccEntry);
+			InputStream inputStream = new GZIPInputStream(zipStream);
+			s_logger.fine("reading "+recordName+" from " + zipFile); 
+			MMcifParser parser = new SimpleMMcifParser();
+			ChemCompConsumer consumer = new ChemCompConsumer();
+			parser.addMMcifConsumer(consumer);
+			parser.parse(inputStream);
+			
+			ChemicalComponentDictionary dict = consumer.getDictionary();
+			ChemComp cc = dict.getChemComp(recordName);
+			zipStream.close();
+			if (cc != null){
+				return cc;
+			}
+		}catch(NullPointerException npe){
+			s_logger.info(npe.getMessage()+"\n"+"File "+recordName+" not found in archive. Attempting download from PDB.");
+		}
+		catch (Exception e) {
+			s_logger.info(e.getMessage());
+		}
+		
+		//if file isn't found in archive, download it/add to archive
+		ChemComp cc = downloadAndAdd(recordName);
+		
+		if (cc == null) {
+			// Could not find this ChemComp, add this to a list of unavailable. 
+			unavailable.add(recordName);
+			return getEmptyChemComp(recordName);
+		}
+		
+		return cc;
+
+	}
+	/**	Use DownloadChemCompProvider to grab a gzipped cif record from the PDB. Zip all downloaded cif.gz files into the dictionary. 
+	 * */ 
+	public ChemComp downloadAndAdd(String recordName){
+		ChemComp cc = dlProvider.getChemComp(recordName);
+		
+		if (cc != null && "?".equals(cc.getOne_letter_code())) {
+			// Failed to find this chemical component and defaulted back to reduced chemical component.
+			unavailable.add(recordName);
+			return cc;  // Don't try to add this to the chemcomp.zip.
+		}
+		
+		if(ZipAppendUtil.getInstance().isBusy()) {
+			return cc;
+		}
+		
+		String tmpdir = this.tempdir;
+
+		// Fall-back to java temporary directory if not set.
+		if (tmpdir == null || tmpdir.equals("")) {
+			tmpdir = System.getProperty("java.io.tmpdir");	
+		}
+		if ( !(tmpdir.endsWith(FILE_SEPARATOR) ) ) {
+			tmpdir += FILE_SEPARATOR;
+		}
+		tmpdir+="chemcomp";
+		
+		final File [] files;
+		final File source;
+		try{
+			files = finder(tmpdir, "cif.gz");	//DownloadProvider places files in default temp dir\chemcomp
+			source = new File(zipDictionary.getName());
+		}catch(NullPointerException npe){
+			return cc;
+		}
+
+		// Adding files could run on a separate thread, but more care is needed to prevent race
+		// conditions such as having asssembled a list of files to add/adding files while still writing an individual
+		// file to the temporary directory.  Keeping this on one thread to prevent race conditions.
+		
+		// TODO: assess race conditions and make reassembling the zip a background task.
+		
+		//Thread updateArchiveThread = new Thread(new Runnable(){
+		//	public void run(){
+				
+		if(! ZipAppendUtil.getInstance().isBusy()) {
+			ZipAppendUtil.getInstance().addToZipArchive(source, files, zipRootDir);
+			for (File f : files){
+				f.delete();
+			}
+			try {
+				zipDictionary.close();
+			} catch (IOException e) {
+				s_logger.info(e.getMessage());
+			}
+		}
+		//	}
+		//});
+		//updateArchiveThread.start();
+		
+		return cc;
+	}
+
+	/**
+	 * Cleanup the temporary files that have been created within tmpdir.
+	 */
+	public void purgeAllTempFiles() {
+		File[] ccOutFiles = finder(System.getProperty("java.io.tmpdir"),"cif");
+		for(File f : ccOutFiles) f.delete();
+		File[] chemcompTempFiles = finderPrefix(System.getProperty("java.io.tmpdir"), "chemcomp.zip");
+		for(File f : chemcompTempFiles)f.delete();
+		File chemcompDir = new File(System.getProperty("java.io.tmpdir") + FILE_SEPARATOR +"chemcomp");
+		chemcompDir.delete();
+	}
+
+	/**
+	 * Return an empty ChemComp group for a three-letter resName.
+	 * @param resName
+	 * @return
+	 */
+    private ChemComp getEmptyChemComp(String resName){
+    	String pdbName = "";
+    	if (null != resName && resName.length() >= 3) {
+    		pdbName = resName.substring(0,3);
+    	}
+    	ChemComp comp = new ChemComp();   
+    	comp.setOne_letter_code("?");
+    	comp.setThree_letter_code(pdbName);
+    	comp.setPolymerType(PolymerType.unknown);
+    	comp.setResidueType(ResidueType.atomn);
+    	return comp;
+    }
+    
+	/**
+	 * Return File(s) in dirName that match suffix.
+	 * @param dirName
+	 * @param suffix
+	 * @return
+	 */
+	private File[] finder( String dirName, final String suffix){
+		File dir = new File(dirName);
+		return dir.listFiles(new FilenameFilter() { 
+			public boolean accept(File dir, String filename)
+			{ return filename.endsWith(suffix); }
+		} );
+
+	}
+	
+	/**
+	 * Return File(s) in dirName that match prefix.
+	 * @param dirName
+	 * @param prefix
+	 * @return
+	 */
+	private File[] finderPrefix( String dirName, final String prefix){
+		File dir = new File(dirName);
+		return dir.listFiles(new FilenameFilter() { 
+			public boolean accept(File dir, String filename)
+			{ return filename.startsWith(prefix); }
+		} );
+	}
+	
+	/**
+	 * Construct a provider for a singleton instance.
+	 */
+	private ZipChemCompProvider() throws IOException {
+		this.tempdir = System.getProperty("java.io.tmpdir");	
+		init();
+	}
+	
+	private void createNewZip(File f) throws IOException {
+	      final ZipOutputStream out = new ZipOutputStream(new FileOutputStream(f));
+	      out.close();
+	}
+}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestChemCompProvider.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestChemCompProvider.java
@@ -1,0 +1,114 @@
+package org.biojava.nbio.structure.io.mmcif;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.align.util.UserConfiguration;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.biojava.nbio.structure.io.PDBFileReader;
+import org.junit.Test;
+
+public class TestChemCompProvider {
+	
+	// Short test with bad ligand name (QNA is bogus)
+	final	String DNAexample = 
+				
+	"ATOM      1  H   MET A   1      11.756 -15.759  11.647  1.00  7.95\n" +
+	"ATOM      2  N   MET A   1      12.461 -16.373  11.329  1.00  7.95\n" +
+	"ATOM      3  CA  MET A   1      12.297 -17.782  11.674  1.00  7.95\n" +
+	"ATOM      4  C   MET A   1      10.999 -18.339  11.099  1.00  7.95\n" +
+	"ATOM      5  O   MET A   1      10.716 -18.148   9.918  1.00  7.95\n" +
+	"ATOM      6  CB  MET A   1      12.314 -17.962  13.194  1.00  7.95\n" +
+	"ATOM      7  CG  MET A   1      13.685 -17.628  13.781  1.00  7.95\n" +
+	"ATOM      8  SD  MET A   1      13.679 -17.742  15.584  1.00  7.95\n" +
+	"ATOM      9  CE  MET A   1      12.642 -16.314  15.948  1.00  7.95\n" +
+	"ATOM     10  H   GLN A   2      10.381 -19.508  12.646  1.00  6.82\n" +
+	"ATOM     11  N   GLN A   2      10.134 -19.027  11.820  1.00  6.82\n" +
+	"ATOM     12  CA  GLN A   2       8.782 -19.063  11.370  1.00  6.82\n" +
+	"ATOM     13  C   GLN A   2       7.791 -18.046  11.927  1.00  6.82\n" +
+	"ATOM     14  O   GLN A   2       6.616 -18.069  11.565  1.00  6.82\n" +
+	"ATOM     15  CB  GLN A   2       8.285 -20.485  11.642  1.00  6.82\n" +
+	"ATOM     16  CG  GLN A   2       8.996 -21.508  10.755  1.00  6.82\n" +
+	"ATOM     17  CD  GLN A   2       8.708 -21.249   9.280  1.00  6.82\n" +
+	"ATOM     18  NE2 GLN A   2       9.730 -21.006   8.488  1.00  6.82\n" +
+	"ATOM     19  OE1 GLN A   2       7.563 -21.267   8.850  1.00  6.82\n" +
+	"ATOM     20  H   MET A   3       9.163 -17.424  13.270  1.00  5.82\n" +
+	"ATOM     21  N   MET A   3       8.334 -17.182  12.793  1.00  5.82\n" +
+	"ATOM     22  CA  MET A   3       7.753 -15.950  13.031  1.00  5.82\n" +
+	"ATOM     23  C   MET A   3       8.145 -14.729  12.164  1.00  5.82\n" +
+	"ATOM     24  O   MET A   3       7.643 -13.630  12.384  1.00  5.82\n" +
+	"ATOM     25  CB  MET A   3       8.025 -15.652  14.507  1.00  5.82\n" +
+	"ATOM     26  CG  MET A   3       7.282 -16.626  15.421  1.00  5.82\n"+
+	"ATOM     27  SD  MET A   3       5.496 -16.545  15.162  1.00  5.82\n"+
+	"ATOM     28  CE  MET A   3       5.189 -14.910  15.855  1.00  5.82\n" +
+	"TER\n" +
+	"HETATM  101  O5' QNA A  1      15.062 -23.351   2.519  1.00 66.98           O\n" +
+	"HETATM  102  C5' QNA A  1      14.372 -23.705   1.300  1.00 68.27           C\n" +
+	"HETATM  103  C4' QNA A  1      14.836 -22.832   0.142  1.00 68.36           C\n" + 
+	"HETATM  104  O4' QNA A  1      14.402 -23.357  -1.153  1.00 68.93           O\n" +
+	"HETATM  105  C3' QNA A  1      14.235 -21.444   0.256  1.00 68.53           C\n" +
+	"HETATM  106  O3' QNA A  1      15.060 -20.416  -0.271  1.00 66.63           O\n" +
+	"HETATM  107  C2' QNA A  1      12.938 -21.603  -0.522  1.00 69.24           C\n" +
+	"HETATM  108  C1' QNA A  1      13.336 -22.562  -1.653  1.00 69.84           C\n" +
+	"HETATM  109  N1  QNA A  1      12.146 -23.404  -2.068  1.00 70.20           N\n" +
+	"HETATM  110  C2  QNA A  1      11.960 -23.752  -3.392  1.00 69.91           C\n" +
+	"HETATM  111  O2  QNA A  1      12.771 -23.504  -4.264  1.00 69.83           O\n" +
+	"HETATM  112  N3  QNA A  1      10.812 -24.471  -3.645  1.00 69.68           N\n" +
+	"HETATM  113  C4  QNA A  1       9.831 -24.834  -2.730  1.00 70.01           C\n" +
+	"HETATM  114  O4  QNA A  1       8.846 -25.491  -3.072  1.00 70.53           O\n" +
+	"HETATM  115  C5  QNA A  1      10.079 -24.409  -1.385  1.00 70.05           C\n" +
+	"HETATM  116  C7  QNA A  1       9.085 -24.740  -0.319  1.00 69.81           C\n" +
+	"HETATM  117  C6  QNA A  1      11.190 -23.716  -1.124  1.00 70.41           C\n" +
+	"HETATM  118  P   QNA A  2      14.663 -18.896   0.143  1.00 67.23           P\n" +
+	"HETATM  119  OP1 QNA A  2      15.930 -18.124   0.315  1.00 67.71           O\n" +
+	"HETATM  120  OP2 QNA A  2      13.607 -18.874   1.201  1.00 65.55           O\n" +
+	"HETATM  121  O5' QNA A  2      13.985 -18.327  -1.199  1.00 62.80           O\n" +
+	"HETATM  122  C5' QNA A  2      14.827 -18.399  -2.335  1.00 53.86           C\n" +
+	"HETATM  123  C4' QNA A  2      13.982 -18.288  -3.576  1.00 47.13           C\n" +
+	"HETATM  124  O4' QNA A  2      13.020 -19.368  -3.719  1.00 44.32           O\n" +
+	"HETATM  125  C3' QNA A  2      13.193 -17.012  -3.509  1.00 43.63           C\n" +
+	"HETATM  126  O3' QNA A  2      13.373 -16.484  -4.756  1.00 42.30           O\n" +
+	"HETATM  127  C2' QNA A  2      11.765 -17.470  -3.280  1.00 41.55           C\n" +
+	"HETATM  128  C1' QNA A  2      11.759 -18.797  -4.025  1.00 40.38           C\n" +
+	"HETATM  129  N1  QNA A  2      10.633 -19.685  -3.585  1.00 35.19           N\n" +
+	"HETATM  130  C2  QNA A  2       9.891 -20.348  -4.563  1.00 31.53           C\n" +
+	"HETATM  131  O2  QNA A  2      10.201 -20.178  -5.738  1.00 32.59           O\n" +
+	"HETATM  132  N3  QNA A  2       8.861 -21.155  -4.207  1.00 28.77           N\n" +
+	"HETATM  133  C4  QNA A  2       8.559 -21.301  -2.925  1.00 29.06           C\n" +
+	"HETATM  134  N4  QNA A  2       7.535 -22.097  -2.627  1.00 27.42           N\n" +
+	"HETATM  135  C5  QNA A  2       9.289 -20.623  -1.901  1.00 31.45           C\n" +
+	"HETATM  136  C6  QNA A  2      10.305 -19.829  -2.271  1.00 33.51           C\n";
+	
+	@Test
+	public void testZipChemCompProvider() throws IOException {
+		// Test file input from a stream created from a string.
+		InputStream testPDB = new ByteArrayInputStream(DNAexample.getBytes());
+		
+		// we just need this to track where to store PDB files
+		// this checks the PDB_DIR property (and uses a tmp location if not set) 
+		UserConfiguration config = new UserConfiguration();
+		String cachePath = config.getCacheFilePath();
+		
+		// Setup a ChemCompProvider
+		Path pdbdir = Paths.get(cachePath);
+		Path chemComp = pdbdir.resolve("chemcomp.zip");
+		
+		System.out.println("Using PDB_DIR=" + pdbdir.toString() + " as temporary file directory");
+		
+		ChemCompGroupFactory.setChemCompProvider(new ZipChemCompProvider(chemComp.toString(), pdbdir.toString()));
+		
+		// Parameters
+		FileParsingParameters params = new FileParsingParameters();
+		params.setLoadChemCompInfo(true);
+		
+		PDBFileReader pdbreader = new PDBFileReader();
+		pdbreader.setFileParsingParameters(params);
+		
+		Structure s = pdbreader.getStructure(testPDB);
+		
+	}
+}


### PR DESCRIPTION
Adding ZipChemCompProvider: pulls ChemComp files from a zip archive or download.
Adding ZipAppendUtil: manages updating the zip archive with new additions.

DownloadChemCompProvider: updated to add a check if the requested ChemComp
was found or threw FileNotFoundException.  downloadChemCompRecord() returns
true if it was successful.  getChemComp now checks if the download was
successful so that it won't throw an IOException if no chemcomp exists.

TestChemCompProvider unit test checks creation/addition with ZipChemCompProvider and includes 'bad' residues that would cause DownloadChemCompProvider to fail.