### PR TITLE
Fix resource leaks with ChemComp

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
@@ -57,10 +57,8 @@ public class ChemCompGroupFactory {
 		logger.debug("Chem comp "+recordName+" read from provider "+chemCompProvider.getClass().getCanonicalName());
 		cc = chemCompProvider.getChemComp(recordName);
 		
-		// If chemCompProvider fails don't try to cache null & one letter code may be null.
-		if (null != cc && !cc.isEmpty()){
-			cache.put(recordName, cc);
-		}
+		// Note that this also caches null or empty responses
+		cache.put(recordName, cc);
 		return cc;
 	}
 
@@ -79,6 +77,8 @@ public class ChemCompGroupFactory {
 	public static void setChemCompProvider(ChemCompProvider provider) {
 		logger.debug("Setting new chem comp provider to "+provider.getClass().getCanonicalName());
 		chemCompProvider = provider;
+		// clear cache
+		cache.clear();
 	}
 
 	public static ChemCompProvider getChemCompProvider(){
@@ -153,10 +153,5 @@ public class ChemCompGroupFactory {
 		}
 		return oneLetter;
 	}
-
-	public static SoftHashMap<String, ChemComp> getCache() {
-		return cache;
-	}
-
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompGroupFactory.java
@@ -58,7 +58,7 @@ public class ChemCompGroupFactory {
 		cc = chemCompProvider.getChemComp(recordName);
 		
 		// If chemCompProvider fails don't try to cache null & one letter code may be null.
-		if (null != cc && !"?".equals(cc.getOne_letter_code())){
+		if (null != cc && !cc.isEmpty()){
 			cache.put(recordName, cc);
 		}
 		return cc;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ReducedChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ReducedChemCompProvider.java
@@ -20,17 +20,15 @@
  */
 package org.biojava.nbio.structure.io.mmcif;
 
-import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
-import org.biojava.nbio.structure.io.mmcif.chem.ResidueType;
-import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.zip.GZIPInputStream;
+
+import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /** Unlike the {@link DownloadChemCompProvider}, this  {@link ChemCompProvider} does not download any chem comp definitions. 
@@ -51,36 +49,35 @@ public class ReducedChemCompProvider implements ChemCompProvider {
 	@Override
 	public ChemComp getChemComp(String recordName) {
 		String name = recordName.toUpperCase().trim();
-		try {
-			try(InputStream inStream = this.getClass().getResourceAsStream("/chemcomp/"+name + ".cif.gz")) {
+		try(InputStream inStream = this.getClass().getResourceAsStream("/chemcomp/"+name + ".cif.gz")) {
 
-				logger.debug("Reading chemcomp/"+name+".cif.gz");
-				
-				if ( inStream == null){
-					//System.out.println("Could not find chem comp: " + name + " ... using generic Chem Comp");
-					// could not find the chem comp definition for this in the jar file
-					logger.debug("Getting empty chem comp for {}",name);
-					ChemComp cc = ChemComp.getEmptyChemComp();
-					cc.setId(name);
-					return cc;
-				}
+			logger.debug("Reading chemcomp/"+name+".cif.gz");
 
-				MMcifParser parser = new SimpleMMcifParser();
-
-				ChemCompConsumer consumer = new ChemCompConsumer();
-
-				// The Consumer builds up the BioJava - structure object.
-				// you could also hook in your own and build up you own data model.
-				parser.addMMcifConsumer(consumer);
-
-				parser.parse(new BufferedReader(new InputStreamReader(new GZIPInputStream(inStream))));
-
-				ChemicalComponentDictionary dict = consumer.getDictionary();
-
-				ChemComp chemComp = dict.getChemComp(name);
-
-				return chemComp;
+			if ( inStream == null){
+				//System.out.println("Could not find chem comp: " + name + " ... using generic Chem Comp");
+				// could not find the chem comp definition for this in the jar file
+				logger.debug("Getting empty chem comp for {}",name);
+				ChemComp cc = ChemComp.getEmptyChemComp();
+				cc.setId(name);
+				return cc;
 			}
+
+			MMcifParser parser = new SimpleMMcifParser();
+
+			ChemCompConsumer consumer = new ChemCompConsumer();
+
+			// The Consumer builds up the BioJava - structure object.
+			// you could also hook in your own and build up you own data model.
+			parser.addMMcifConsumer(consumer);
+
+			parser.parse(new BufferedReader(new InputStreamReader(new GZIPInputStream(inStream))));
+
+			ChemicalComponentDictionary dict = consumer.getDictionary();
+
+			ChemComp chemComp = dict.getChemComp(name);
+
+			return chemComp;
+
 		} catch (IOException e){
 			logger.error("IOException caught while reading chem comp {}.",name,e);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/ChemComp.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/ChemComp.java
@@ -594,7 +594,7 @@ public class ChemComp implements Serializable, Comparable<ChemComp>{
 		ChemComp comp = new ChemComp();
 
 		comp.setOne_letter_code("?");
-		comp.setThree_letter_code("???");
+		comp.setThree_letter_code("???"); // Main signal for isEmpty()
 		comp.setPolymerType(PolymerType.unknown);
 		comp.setResidueType(ResidueType.atomn);
 		return comp;
@@ -606,7 +606,7 @@ public class ChemComp implements Serializable, Comparable<ChemComp>{
 	 */
 	public boolean isEmpty() {
 		// Is this the best flag for it being empty?
-		return id == null || getThree_letter_code().equals("???");
+		return id == null || getThree_letter_code() == null || getThree_letter_code().equals("???");
 	}
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/ChemComp.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/ChemComp.java
@@ -40,40 +40,40 @@ public class ChemComp implements Serializable, Comparable<ChemComp>{
 	 */
 	private static final long serialVersionUID = -4736341142030215915L;
 
-	String id ;
-	String name;
-	String type;
-	String pdbx_type;
-	String formula;
-	String mon_nstd_parent_comp_id;
-	String pdbx_synonyms;
-	String pdbx_formal_charge;
-	String pdbx_initial_date ;
-	String pdbx_modified_date;
-	String pdbx_ambiguous_flag;
-	String pdbx_release_status ;
-	String pdbx_replaced_by;
-	String pdbx_replaces;
-	String formula_weight;
-	String one_letter_code;
-	String three_letter_code;
-	String pdbx_model_coordinates_details;
-	String pdbx_model_coordinates_missing_flag;
-	String pdbx_ideal_coordinates_details;
-	String pdbx_ideal_coordinates_missing_flag;
-	String pdbx_model_coordinates_db_code;
-	String pdbx_subcomponent_list;
-	String pdbx_processing_site;
-	String mon_nstd_flag;
+	private String id ;
+	private String name;
+	private String type;
+	private String pdbx_type;
+	private String formula;
+	private String mon_nstd_parent_comp_id;
+	private String pdbx_synonyms;
+	private String pdbx_formal_charge;
+	private String pdbx_initial_date ;
+	private String pdbx_modified_date;
+	private String pdbx_ambiguous_flag;
+	private String pdbx_release_status ;
+	private String pdbx_replaced_by;
+	private String pdbx_replaces;
+	private String formula_weight;
+	private String one_letter_code;
+	private String three_letter_code;
+	private String pdbx_model_coordinates_details;
+	private String pdbx_model_coordinates_missing_flag;
+	private String pdbx_ideal_coordinates_details;
+	private String pdbx_ideal_coordinates_missing_flag;
+	private String pdbx_model_coordinates_db_code;
+	private String pdbx_subcomponent_list;
+	private String pdbx_processing_site;
+	private String mon_nstd_flag;
 
-	List<ChemCompDescriptor> descriptors = new ArrayList<ChemCompDescriptor>();
-	List<ChemCompBond> bonds = new ArrayList<ChemCompBond>();
-	List<ChemCompAtom> atoms = new ArrayList<ChemCompAtom>();
+	private List<ChemCompDescriptor> descriptors = new ArrayList<ChemCompDescriptor>();
+	private List<ChemCompBond> bonds = new ArrayList<ChemCompBond>();
+	private List<ChemCompAtom> atoms = new ArrayList<ChemCompAtom>();
 
 	// and some derived data for easier processing...
-	ResidueType residueType;
-	PolymerType polymerType;
-	boolean standard;
+	private ResidueType residueType;
+	private PolymerType polymerType;
+	private boolean standard;
 
 	@Override
 	public String toString(){
@@ -585,6 +585,28 @@ public class ChemComp implements Serializable, Comparable<ChemComp>{
 			return false;
 		return true;
 	}
+	
+	/**
+	 * Creates a new instance of the dummy empty ChemComp.
+	 * @return
+	 */
+	public static ChemComp getEmptyChemComp(){
+		ChemComp comp = new ChemComp();
 
+		comp.setOne_letter_code("?");
+		comp.setThree_letter_code("???");
+		comp.setPolymerType(PolymerType.unknown);
+		comp.setResidueType(ResidueType.atomn);
+		return comp;
+	}
+
+	/**
+	 * Indicates whether this compound was created with 
+	 * @return
+	 */
+	public boolean isEmpty() {
+		// Is this the best flag for it being empty?
+		return id == null || getThree_letter_code().equals("???");
+	}
 
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/ChemCompTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/ChemCompTest.java
@@ -117,10 +117,6 @@ public class ChemCompTest {
 	@Test
     public void testChangingProviders(){
 
-		//reset the cache
-		SoftHashMap<String, ChemComp> cache = ChemCompGroupFactory.getCache();
-		cache.clear();
-		
 		// test for issue #145
 
         String chemID = "MEA";
@@ -134,7 +130,7 @@ public class ChemCompTest {
 
         assertTrue(" is not mea" , cc.getId().equals(chemID));
         
-        assertNull(cc.getThree_letter_code());
+        assertTrue(cc.isEmpty());
 
         // now we change to download chem comp provider
 
@@ -151,7 +147,6 @@ public class ChemCompTest {
         
         
         // now testing in opposite order
-        cache.clear();
 
         // first we test with download chem comp provider
 


### PR DESCRIPTION
Adds additional check that files and streams are being closed in the ChemComp providers.

Also changes the ChemCompGroupFactory's behavior so that it does cache "empty"/stub chemicals
(since they will still be empty for the next fetch), but clears the cache when the provider changes.
This ensures that stub chemicals from a Reduced provider don't poison future fetches with the full
Download provider.

This should fix #395. Waters were being treated as "empty" due to an unfortunate choice of
one-letter code, and therefor not cached, leading to thousands of open handles to HOH.cif.gz.