### PR TITLE
Updates to the parser to use the atom record asymid to authid mapping…

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/Test1o2f.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/Test1o2f.java
@@ -1,0 +1,42 @@
+package org.biojava.nbio.structure.test;
+
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.biojava.nbio.structure.io.LocalPDBDirectory.FetchBehavior;
+
+import junit.framework.TestCase;
+
+public class Test1o2f extends TestCase{
+
+	private static Structure structure = null;
+
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		AtomCache cache = new AtomCache();
+		cache.setUseMmCif(true);
+		cache.setFetchBehavior(FetchBehavior.FETCH_FILES);
+		FileParsingParameters params = cache.getFileParsingParams();
+		params.setLoadChemCompInfo(true);
+		params.setUseInternalChainId(true);
+		cache.setFileParsingParams(params);
+		StructureIO.setAtomCache(cache);
+		String pdbId = "1O2F";
+		structure = StructureIO.getStructure(pdbId);
+	}
+
+
+	public void test1a4wPDBFile(){
+		for(int i=0;i<structure.nrModels();i++){
+			for(Chain c: structure.getChains(i)){
+				assertNotNull(c.getChainID());
+				assertNotNull(c.getInternalChainID());
+			}
+		}
+	}
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -739,6 +739,12 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 			
 			asymStrandId = asymId2StrandIdFromAtomSites;
 		}
+		// If we only parse the header - we have no option but to use the other mapping (which can be broken)
+		if (asymId2StrandIdFromAtomSites.isEmpty()){
+			
+			logger.warn("No  _atom_sites category auth to asymid mappings. Will use chain id mapping from pdbx_poly_seq_scheme/pdbx_non_poly_seq_scheme categories");
+			asymId2StrandIdFromAtomSites = asymStrandId;
+		}
 		
 		// mismatching Author assigned chain IDS and PDB internal chain ids:
 		// fix the chain IDS in the current model:
@@ -748,11 +754,10 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 				List<Chain> model = structure.getModel(i);
 
 				List<Chain> pdbChains = new ArrayList<Chain>();
-
 				for (Chain chain : model) {
-					for (String asym : asymStrandId.keySet()) {
+					for (String asym : asymId2StrandIdFromAtomSites.keySet()) {
 						if ( chain.getChainID().equals(asym)){
-							String newChainId = asymStrandId.get(asym);
+							String newChainId = asymId2StrandIdFromAtomSites.get(asym);
 
 							logger.debug("Renaming chain with asym_id {} ({} atom groups) to author_asym_id/strand_id  {}", 
 									asym, chain.getAtomGroups().size(), newChainId);
@@ -789,13 +794,14 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 			}
 		}
 		else{
+			System.out.println(asymId2StrandIdFromAtomSites);
 			// Just set the internal id as the auth id -> if we're using the asymid 
 			for (int i =0; i< structure.nrModels() ; i++){
 				List<Chain> model = structure.getModel(i);
 				for (Chain chain : model) {
-					for (String asym : asymStrandId.keySet()) {
-						if ( chain.getChainID().equals(asym)){
-							String authChainId = asymStrandId.get(asym);
+					for (String asym : asymId2StrandIdFromAtomSites.keySet()) {
+						if (chain.getChainID().equals(asym)){
+							String authChainId = asymId2StrandIdFromAtomSites.get(asym);
 							chain.setInternalChainID(authChainId);
 							break;
 						}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -794,7 +794,6 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 			}
 		}
 		else{
-			System.out.println(asymId2StrandIdFromAtomSites);
 			// Just set the internal id as the auth id -> if we're using the asymid 
 			for (int i =0; i< structure.nrModels() ; i++){
 				List<Chain> model = structure.getModel(i);


### PR DESCRIPTION
… and not the ones parsed fron the header

This is because this dictionary is wrong in instances such as 1O2F where the first models chains do not include all chains for the subsequent chains