### PR TITLE
Refactoring BioUnitDataProviderFactory to take class arguments

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
@@ -242,7 +242,7 @@ public class SingleLinkageClusterer {
 	/**
 	 * Get the clusters by cutting the dendrogram at given cutoff
 	 * @param cutoff
-	 * @return
+	 * @return Map from cluster numbers to indices of the cluster members
 	 */
 	public Map<Integer, Set<Integer>> getClusters(double cutoff) {
 		

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AtomCache.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AtomCache.java
@@ -51,6 +51,8 @@ import org.biojava.nbio.structure.io.MMCIFFileReader;
 import org.biojava.nbio.structure.io.PDBFileReader;
 import org.biojava.nbio.structure.io.util.FileDownloadUtils;
 import org.biojava.nbio.structure.quaternary.io.BioUnitDataProviderFactory;
+import org.biojava.nbio.structure.quaternary.io.MmCifBiolAssemblyProvider;
+import org.biojava.nbio.structure.quaternary.io.PDBBioUnitDataProvider;
 import org.biojava.nbio.structure.scop.CachedRemoteScopInstallation;
 import org.biojava.nbio.structure.scop.ScopDatabase;
 import org.biojava.nbio.structure.scop.ScopDescription;
@@ -911,11 +913,11 @@ public class AtomCache {
 		if ( useMmCif) {
 			// get bio assembly from mmcif file
 
-			BioUnitDataProviderFactory.setBioUnitDataProvider(BioUnitDataProviderFactory.mmcifProviderClassName);
+			BioUnitDataProviderFactory.setBioUnitDataProvider(MmCifBiolAssemblyProvider.class);
 
 		} else {
 		
-			BioUnitDataProviderFactory.setBioUnitDataProvider(BioUnitDataProviderFactory.pdbProviderClassName);
+			BioUnitDataProviderFactory.setBioUnitDataProvider(PDBBioUnitDataProvider.class);
 			
 		}
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/io/BioUnitDataProviderFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/io/BioUnitDataProviderFactory.java
@@ -23,6 +23,13 @@ package org.biojava.nbio.structure.quaternary.io;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Factory to create BioUnitDataProvider instances.
+ * 
+ * Unlike many other BioJava Factory classes, this class does not store
+ * singletons, but creates a new instance for every call of
+ * {@link #getBioUnitDataProvider()}.
+ */
 public class BioUnitDataProviderFactory {
 
 	private static final Logger logger = LoggerFactory.getLogger(BioUnitDataProviderFactory.class);
@@ -33,24 +40,25 @@ public class BioUnitDataProviderFactory {
 	
 	public static final String pdbProviderClassName       = PDBBioUnitDataProvider.class.getName();
 	
-	public static String DEFAULT_PROVIDER_CLASSNAME =  mmcifProviderClassName;
+	public static Class<? extends BioUnitDataProvider> DEFAULT_PROVIDER_CLASS = MmCifBiolAssemblyProvider.class;
+	public static final String DEFAULT_PROVIDER_CLASSNAME =  DEFAULT_PROVIDER_CLASS.getName();
 	
-	private static String providerClassName = DEFAULT_PROVIDER_CLASSNAME;
+	private static Class<? extends BioUnitDataProvider> providerClass = DEFAULT_PROVIDER_CLASS;
 	
 	private BioUnitDataProviderFactory(){
 		
 	}
 	
+	/**
+	 * 
+	 * @return A new instance of the current BioUnitDataProvider class
+	 */
 	public static BioUnitDataProvider getBioUnitDataProvider() {
 		
 		// use reflection to return a new instance...
 		
 		try {
-			Class<?> cls = Class.forName(providerClassName); 
-			//System.out.println("Using BioUnitProvider: " + providerClassName);
-			return (BioUnitDataProvider) cls.newInstance();
-		} catch (ClassNotFoundException e) {
-			logger.error("Exception caught",e);
+			return providerClass.newInstance();
 		} catch (IllegalAccessException e) {
 			logger.error("Exception caught",e);
 		} catch (InstantiationException e) {
@@ -61,33 +69,27 @@ public class BioUnitDataProviderFactory {
 		
 	}
 
-	public static void setBioUnitDataProvider(String className) {
-		
-		try {
-			Class<?> cls = Class.forName(providerClassName);
-			Class<?> interfaceClass = Class.forName(BioUnitDataProvider.class.getName());
-			Class<?>[] ifs = cls.getInterfaces();
-			boolean found = false;
-			for ( Class<?> c : ifs){
-				if ( c.equals(interfaceClass)){
-					found = true;
-					break;
-				}
-				
-			}
-			if ( ! found){
-				logger.warn("The provided class {} does not implement the correct interface!", className);
-				return ;
-			}
-		} catch (ClassNotFoundException e) {
-			logger.error("Exception caught",e);
-			
-			// we do not set classes that don't exist!
-			return;
-		
-		}
-		providerClassName = className;
+	/**
+	 * Set the type of provider to be created
+	 * @param klass A BioUnitDataProvider
+	 */
+	public static void setBioUnitDataProvider(Class<? extends BioUnitDataProvider> klass) {
+		providerClass = klass;
 	}
-	
-	
+	/**
+	 * Sets the data provider to the specified class name. Use {@link #setBioUnitDataProvider(Class)}
+	 * for better type safety.
+	 * @param className A class implementing BioUnitDataProvider
+	 * @throws ClassNotFoundException If the class cannot be loaded
+	 * @throws ClassCastException If the class does not extend BioUnitDataProvider
+	 */
+	public static void setBioUnitDataProvider(String className) throws ClassNotFoundException, ClassCastException {
+		Class<?> cls = Class.forName(className);
+		Class<BioUnitDataProvider> interfaceClass = BioUnitDataProvider.class;
+		Class<? extends BioUnitDataProvider> castClass = cls.asSubclass(interfaceClass);
+
+		setBioUnitDataProvider(castClass);
+	}
+
+
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestQuaternaryStructureProviders.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestQuaternaryStructureProviders.java
@@ -56,7 +56,7 @@ public class TestQuaternaryStructureProviders {
 		testID("5LDH",2);
 		// in 5ldh there's also PAU and XAU but those are ignored, see github issue #230
 		MmCifBiolAssemblyProvider mmcifProvider = new MmCifBiolAssemblyProvider();
-		BioUnitDataProviderFactory.setBioUnitDataProvider(mmcifProvider.getClass().getCanonicalName());
+		BioUnitDataProviderFactory.setBioUnitDataProvider(mmcifProvider.getClass());
 		
 		boolean gotException = false;
 		try {
@@ -94,15 +94,15 @@ public class TestQuaternaryStructureProviders {
 		
 		// get bio assembly from PDB file
 		PDBBioUnitDataProvider pdbProvider = new PDBBioUnitDataProvider();
-		BioUnitDataProviderFactory.setBioUnitDataProvider(pdbProvider.getClass().getCanonicalName());
+		BioUnitDataProviderFactory.setBioUnitDataProvider(pdbProvider.getClass());
 		Structure pdbS = StructureIO.getBiologicalAssembly(pdbId, bioMolecule);
 
 		// get bio assembly from mmcif file
 		MmCifBiolAssemblyProvider mmcifProvider = new MmCifBiolAssemblyProvider();
-		BioUnitDataProviderFactory.setBioUnitDataProvider(mmcifProvider.getClass().getCanonicalName());			
+		BioUnitDataProviderFactory.setBioUnitDataProvider(mmcifProvider.getClass());
 		Structure mmcifS = StructureIO.getBiologicalAssembly(pdbId, bioMolecule);
 
-		BioUnitDataProviderFactory.setBioUnitDataProvider(BioUnitDataProviderFactory.DEFAULT_PROVIDER_CLASSNAME);
+		BioUnitDataProviderFactory.setBioUnitDataProvider(BioUnitDataProviderFactory.DEFAULT_PROVIDER_CLASS);
 
 
 


### PR DESCRIPTION
The old string-based API still works, but can now throw exceptions rather
than just logging the error and returning null. Better is to just pass the class
you want used directly.

Note that this also fixes a bug where setBioUnitDataProvider(String) checked the
validity of the previous provider, rather than the argument.