### PR TITLE
Revised calls to multipleSequenceAlignment.getAlignedSequence()

### DIFF
--- a/biojava-phylo/src/main/java/org/biojava/nbio/phylo/TreeConstructor.java
+++ b/biojava-phylo/src/main/java/org/biojava/nbio/phylo/TreeConstructor.java
@@ -110,7 +110,7 @@ public class TreeConstructor<C extends AbstractSequence<D>, D extends Compound> 
         int numberOfSequences = multipleSequenceAlignment.getSize();
         String[] sequenceString = new String[numberOfSequences];
         for (int i = 0; i < multipleSequenceAlignment.getSize(); i++) {
-            sequenceString[i] = multipleSequenceAlignment.getAlignedSequence(i).getSequenceAsString();
+            sequenceString[i] = multipleSequenceAlignment.getAlignedSequence(i+1).getSequenceAsString();
 
         }
 
@@ -198,7 +198,7 @@ public class TreeConstructor<C extends AbstractSequence<D>, D extends Compound> 
             double[][] distances = calculateDistanceMatrix(multipleSequenceAlignment, treeConstructionAlgorithm);
             matrix = new BasicSymmetricalDistanceMatrix(multipleSequenceAlignment.getSize());
             for (int i = 0; i < matrix.getSize(); i++) {
-                matrix.setIdentifier(i, multipleSequenceAlignment.getAlignedSequence(i).getAccession().getID());
+                matrix.setIdentifier(i, multipleSequenceAlignment.getAlignedSequence(i+1).getAccession().getID());
             }
             for (int col = 0; col < matrix.getSize(); col++) {
                 for (int row = 0; row < matrix.getSize(); row++) {


### PR DESCRIPTION
Revised calls to multipleSequenceAlignment.getAlignedSequence(). Now passing in index plus 1 as the MultipleSequenceAlignment.getAlignedSequence() function uses sequences.get(listIndex - 1). There is a comment on the related function header "bioIndex starting at 1 instead of 0." Let me know if I'm missing something, but it seems pretty clear if a function is called passing in a value of index = 0, then that function is going to blow up when accessing a collection using index -1.