### PR TITLE
Refactored compound to entity and altered behaviour to consider non-polymer compounds.

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureTest.java
@@ -119,7 +119,7 @@ public class StructureTest {
 		assertEquals(64, c2.getAtomGroups(GroupType.HETATM).size());
 		assertEquals(0, c2.getAtomGroups(GroupType.NUCLEOTIDE).size());
 
-		List<EntityInfo> compounds= structure.getEntityInformation();
+		List<EntityInfo> compounds= structure.getEntityInfos();
 
 		// from Biojava 4.2 on we are creating compounds whenever an entity is found to be without an assigned compound in the file
 		// see issues https://github.com/biojava/biojava/issues/305 and https://github.com/biojava/biojava/pull/394
@@ -203,7 +203,7 @@ public class StructureTest {
 		assertEquals("the technique in the Header is " + technique, techShould, technique);
 
 
-		List <EntityInfo> compounds = structure.getEntityInformation();
+		List <EntityInfo> compounds = structure.getEntityInfos();
 
 		// from Biojava 4.2 on we are creating compounds whenever an entity is found to be without an assigned compound in the file
 		// see issues https://github.com/biojava/biojava/issues/305 and https://github.com/biojava/biojava/pull/394

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureTest.java
@@ -119,13 +119,13 @@ public class StructureTest {
 		assertEquals(64, c2.getAtomGroups(GroupType.HETATM).size());
 		assertEquals(0, c2.getAtomGroups(GroupType.NUCLEOTIDE).size());
 
-		List<Compound> compounds= structure.getCompounds();
+		List<EntityInfo> compounds= structure.getEntityInformation();
 
 		// from Biojava 4.2 on we are creating compounds whenever an entity is found to be without an assigned compound in the file
 		// see issues https://github.com/biojava/biojava/issues/305 and https://github.com/biojava/biojava/pull/394
 		assertEquals(2, compounds.size());
-		Compound mol = compounds.get(0);
-		assertTrue(mol.getMolName().startsWith("TRYPSIN INHIBITOR"));
+		EntityInfo mol = compounds.get(0);
+		assertTrue(mol.getDescription().startsWith("TRYPSIN INHIBITOR"));
 	}
 
 	@Test
@@ -203,14 +203,14 @@ public class StructureTest {
 		assertEquals("the technique in the Header is " + technique, techShould, technique);
 
 
-		List <Compound> compounds = structure.getCompounds();
+		List <EntityInfo> compounds = structure.getEntityInformation();
 
 		// from Biojava 4.2 on we are creating compounds whenever an entity is found to be without an assigned compound in the file
 		// see issues https://github.com/biojava/biojava/issues/305 and https://github.com/biojava/biojava/pull/394
 		assertEquals("did not find the right number of compounds! ", 2, compounds.size());
 
-		Compound comp = compounds.get(0);
-		assertEquals("did not get the right compounds info",true,comp.getMolName().startsWith("TRYPSIN INHIBITOR"));
+		EntityInfo comp = compounds.get(0);
+		assertEquals("did not get the right compounds info",true,comp.getDescription().startsWith("TRYPSIN INHIBITOR"));
 
 		List<String> chainIds = comp.getChainIds();
 		List<Chain> chains    = comp.getChains();

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestLongPdbVsMmCifParsing.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestLongPdbVsMmCifParsing.java
@@ -210,15 +210,15 @@ public class TestLongPdbVsMmCifParsing {
 		// compounds: there's quite some inconsistencies here between pdb and cif:
 		// sugar polymers are not in pdb at all: we avoid them
 		boolean canCompareCompoundsSize = true;
-		for (Compound compound: sCif.getCompounds()) {
-			if (compound.getMolName()==null || compound.getMolName().contains("SUGAR")) {
+		for (EntityInfo compound: sCif.getEntityInformation()) {
+			if (compound.getDescription()==null || compound.getDescription().contains("SUGAR")) {
 				canCompareCompoundsSize = false;
 				break;
 			}
 		}
 
 		if (canCompareCompoundsSize)
-			assertEquals("failed number of Compounds pdb vs cif", sPdb.getCompounds().size(), sCif.getCompounds().size());
+			assertEquals("failed number of Compounds pdb vs cif", sPdb.getEntityInformation().size(), sCif.getEntityInformation().size());
 
 
 		// ss bonds

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestLongPdbVsMmCifParsing.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestLongPdbVsMmCifParsing.java
@@ -210,7 +210,7 @@ public class TestLongPdbVsMmCifParsing {
 		// compounds: there's quite some inconsistencies here between pdb and cif:
 		// sugar polymers are not in pdb at all: we avoid them
 		boolean canCompareCompoundsSize = true;
-		for (EntityInfo compound: sCif.getEntityInformation()) {
+		for (EntityInfo compound: sCif.getEntityInfos()) {
 			if (compound.getDescription()==null || compound.getDescription().contains("SUGAR")) {
 				canCompareCompoundsSize = false;
 				break;
@@ -218,7 +218,7 @@ public class TestLongPdbVsMmCifParsing {
 		}
 
 		if (canCompareCompoundsSize)
-			assertEquals("failed number of Compounds pdb vs cif", sPdb.getEntityInformation().size(), sCif.getEntityInformation().size());
+			assertEquals("failed number of Compounds pdb vs cif", sPdb.getEntityInfos().size(), sCif.getEntityInfos().size());
 
 
 		// ss bonds
@@ -410,13 +410,13 @@ public class TestLongPdbVsMmCifParsing {
 
 		// getCompound() is some times null for badly formatted PDB files (e.g. 4a10, all waters are in a separate chain F)
 		if (isPolymer(cPdb)) {
-			assertNotNull("getCompound is null in pdb (chain "+chainId+")",cPdb.getCompound());
-			assertNotNull("getCompound is null in cif (chain "+chainId+")",cCif.getCompound());
+			assertNotNull("getCompound is null in pdb (chain "+chainId+")",cPdb.getEntityInfo());
+			assertNotNull("getCompound is null in cif (chain "+chainId+")",cCif.getEntityInfo());
 
 			// for some badly formatted entries there are mismatches of mol_ids on pdb cs mmcif, e.g. 2efw
 			// we thus count them and only warn at the end
-			int molIdPdb = cPdb.getCompound().getMolId();
-			int molIdCif = cCif.getCompound().getMolId();
+			int molIdPdb = cPdb.getEntityInfo().getMolId();
+			int molIdCif = cCif.getEntityInfo().getMolId();
 			if (molIdPdb!=molIdCif) {
 				logger.warn("Mismatching mol_id (entity_id) for {}. pdb: {}, mmCIF: {}",pdbId,molIdPdb,molIdCif);
 				pdbIdsWithMismatchingMolIds.add(pdbId);

--- a/biojava-structure/src/main/java/demo/DemoLoadStructure.java
+++ b/biojava-structure/src/main/java/demo/DemoLoadStructure.java
@@ -105,7 +105,7 @@ public class DemoLoadStructure
 
 			System.out.print(c);
 
-			System.out.println(c.getCompound());
+			System.out.println(c.getEntityInfo());
 
 		} catch (Exception e){
 			e.printStackTrace();

--- a/biojava-structure/src/main/java/demo/DemoMMCIFReader.java
+++ b/biojava-structure/src/main/java/demo/DemoMMCIFReader.java
@@ -102,7 +102,7 @@ public class DemoMMCIFReader
 			System.out.println(h.getAtomSequence());
 			System.out.println(h.getAtomGroups(GroupType.HETATM));
 
-			System.out.println("Compounds: " + s.getEntityInformation());
+			System.out.println("Compounds: " + s.getEntityInfos());
 
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/biojava-structure/src/main/java/demo/DemoMMCIFReader.java
+++ b/biojava-structure/src/main/java/demo/DemoMMCIFReader.java
@@ -102,7 +102,7 @@ public class DemoMMCIFReader
 			System.out.println(h.getAtomSequence());
 			System.out.println(h.getAtomGroups(GroupType.HETATM));
 
-			System.out.println("Compounds: " + s.getCompounds());
+			System.out.println("Compounds: " + s.getEntityInformation());
 
 		} catch (Exception e) {
 			e.printStackTrace();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Chain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Chain.java
@@ -195,15 +195,15 @@ public interface Chain {
 	 * @param compound the Compound
 	 * @see #getCompound()
 	*/
-	public void setCompound(Compound compound);
+	public void setCompound(EntityInfo compound);
 
 	/**
 	 * Returns the Compound for this chain.
 	 *
 	 * @return the Compound object
-	 * @see #setCompound(Compound)
+	 * @see #setCompound(EntityInfo)
 	 */
-	public Compound getCompound();
+	public EntityInfo getCompound();
 
 	/**
 	 * Sets the name of this chain (Chain id in PDB file ).

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Chain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Chain.java
@@ -193,17 +193,17 @@ public interface Chain {
 	/**
 	 * Sets the Compound
 	 * @param compound the Compound
-	 * @see #getCompound()
+	 * @see #getEntityInfo()
 	*/
-	public void setCompound(EntityInfo compound);
+	public void setEntityInfo(EntityInfo compound);
 
 	/**
 	 * Returns the Compound for this chain.
 	 *
 	 * @return the Compound object
-	 * @see #setCompound(EntityInfo)
+	 * @see #setEntityInfo(EntityInfo)
 	 */
-	public EntityInfo getCompound();
+	public EntityInfo getEntityInfo();
 
 	/**
 	 * Sets the name of this chain (Chain id in PDB file ).

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
@@ -159,7 +159,7 @@ public class ChainImpl implements Chain, Serializable {
 
 		// NOTE the Compound will be reset at the parent level (Structure) if cloning is happening from parent level
 		// here we don't deep-copy it and just keep the same reference, in case the cloning is happening at the Chain level only
-		n.setCompound(this.mol);
+		n.setEntityInfo(this.mol);
 
 		n.setInternalChainID(internalChainID);
 
@@ -217,7 +217,7 @@ public class ChainImpl implements Chain, Serializable {
 	 *
 	 */
 	@Override
-	public void setCompound(EntityInfo mol) {
+	public void setEntityInfo(EntityInfo mol) {
 		this.mol = mol;
 	}
 
@@ -225,7 +225,7 @@ public class ChainImpl implements Chain, Serializable {
 	 *
 	 */
 	@Override
-	public EntityInfo getCompound() {
+	public EntityInfo getEntityInfo() {
 		return this.mol;
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
@@ -65,7 +65,7 @@ public class ChainImpl implements Chain, Serializable {
 	private List<Group> seqResGroups;
 
 	private Long id;
-	private Compound mol;
+	private EntityInfo mol;
 	private Structure parent;
 
 	private Map<String, Integer> pdbResnumMap;
@@ -217,7 +217,7 @@ public class ChainImpl implements Chain, Serializable {
 	 *
 	 */
 	@Override
-	public void setCompound(Compound mol) {
+	public void setCompound(EntityInfo mol) {
 		this.mol = mol;
 	}
 
@@ -225,7 +225,7 @@ public class ChainImpl implements Chain, Serializable {
 	 *
 	 */
 	@Override
-	public Compound getCompound() {
+	public EntityInfo getCompound() {
 		return this.mol;
 	}
 
@@ -516,8 +516,8 @@ public class ChainImpl implements Chain, Serializable {
 		StringBuilder str = new StringBuilder();
 		str.append("Chain >").append(getChainID()).append("<").append(newline);
 		if ( mol != null ){
-			if ( mol.getMolName() != null){
-				str.append(mol.getMolName()).append(newline);
+			if ( mol.getDescription() != null){
+				str.append(mol.getDescription()).append(newline);
 			}
 		}
 		str.append("total SEQRES length: ").append(getSeqResGroups().size()).append(" total ATOM length:")

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -48,11 +48,12 @@ import java.util.TreeSet;
  *
  * @author Jules Jacobsen
  * @author Jose Duarte
+ * @author Anthony Bradley
  * @since 1.5
  */
-public class Compound implements Serializable {
+public class EntityInfo implements Serializable {
 
-	private final static Logger logger = LoggerFactory.getLogger(Compound.class);
+	private final static Logger logger = LoggerFactory.getLogger(EntityInfo.class);
 
 
 	//TODO we should consider having the data here as it is in mmCIF dictionary - JD 2014-12-11
@@ -80,21 +81,21 @@ public class Compound implements Serializable {
 	private Map<String, Map<ResidueNumber,Integer>> chains2pdbResNums2ResSerials;
 
 	private String refChainId;
-
-	private String molName = null;
+	private String description = null;
 	private String title = null;
+	/**
+	 * The type of group (polymer, non-polymer, water)
+	 */
+	private String type = null;
 	private List<String> synonyms = null;
 	private List<String> ecNums = null;
 	private String engineered = null;
 	private String mutation = null;
 	private String biologicalUnit = null;
 	private String details = null;
-
 	private String numRes = null;
 	private String resNames = null;
-
 	private String headerVars = null;
-
 	private String synthetic = null;
 	private String fragment = null;
 	private String organismScientific = null;
@@ -130,7 +131,7 @@ public class Compound implements Serializable {
 
 	private Long id;
 
-	public Compound () {
+	public EntityInfo () {
 		chains = new ArrayList<Chain>();
 		chains2pdbResNums2ResSerials = new HashMap<String, Map<ResidueNumber,Integer>>();
 		molId = -1;
@@ -141,7 +142,7 @@ public class Compound implements Serializable {
 	 * but not setting the Chains
 	 * @param c
 	 */
-	public Compound (Compound c) {
+	public EntityInfo (EntityInfo c) {
 
 		this.chains = new ArrayList<Chain>();
 
@@ -151,7 +152,7 @@ public class Compound implements Serializable {
 
 		this.refChainId = c.refChainId;
 
-		this.molName = c.molName;
+		this.description = c.description;
 		this.title = c.title;
 
 		if (c.synonyms!=null) {
@@ -213,7 +214,7 @@ public class Compound implements Serializable {
 	public String toString(){
 		StringBuilder buf = new StringBuilder();
 		buf.append("Compound: ").append(molId).append(" ");
-		buf.append(molName==null?"(no name)":"("+molName+")");
+		buf.append(description==null?"(no name)":"("+description+")");
 		buf.append(" chains: ");
 		if (chains!=null) {
 			for (int i=0;i<chains.size();i++) {
@@ -292,8 +293,8 @@ public class Compound implements Serializable {
 			}
 			System.out.println("Chains: " + buf.toString());
 		}
-		if (this.molName != null) {
-			System.out.println("Mol Name: " + this.molName);
+		if (this.description != null) {
+			System.out.println("Mol Name: " + this.description);
 		}
 		if (this.title != null) {
 			System.out.println("Title: " + this.title);
@@ -619,12 +620,12 @@ public class Compound implements Serializable {
 		this.molId = molId;
 	}
 
-	public String getMolName() {
-		return molName;
+	public String getDescription() {
+		return description;
 	}
 
-	public void setMolName(String molName) {
-		this.molName = molName;
+	public void setDescription(String molName) {
+		this.description = molName;
 	}
 
 	public String getTitle() {
@@ -987,5 +988,19 @@ public class Compound implements Serializable {
 	 */
 	public void setChains(List<Chain> chains){
 		this.chains = chains;
+	}
+
+	/**
+	 * @return the type
+	 */
+	public String getType() {
+		return type;
+	}
+
+	/**
+	 * @param type the type to set
+	 */
+	public void setType(String type) {
+		this.type = type;
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -59,13 +59,13 @@ public class EntityInfo implements Serializable {
 	//TODO we should consider having the data here as it is in mmCIF dictionary - JD 2014-12-11
 	//     Especially useful would be to have the polymer/non-polymer/water classification present in mmCIF
 	//     We could drop a lot of the stuff here that is PDB-file related (actually many PDB files don't contain many of these fields)
-	//     The only really essential part of a Compound is the member chains and the entity_id/mol_id
+	//     The only really essential part of a EntityInfo is the member chains and the entity_id/mol_id
 	// See also issue https://github.com/biojava/biojava/issues/219
 
 	private static final long serialVersionUID = 2991897825657586356L;
 
 	/**
-	 * The list of chains that are described by this Compound
+	 * The list of chains that are described by this EntityInfo
 	 */
 	private List<Chain> chains;
 
@@ -138,7 +138,7 @@ public class EntityInfo implements Serializable {
 	}
 
 	/**
-	 * Constructs a new Compound copying all data from the given one
+	 * Constructs a new EntityInfo copying all data from the given one
 	 * but not setting the Chains
 	 * @param c
 	 */
@@ -213,7 +213,7 @@ public class EntityInfo implements Serializable {
 	@Override
 	public String toString(){
 		StringBuilder buf = new StringBuilder();
-		buf.append("Compound: ").append(molId).append(" ");
+		buf.append("EntityInfo: ").append(molId).append(" ");
 		buf.append(description==null?"(no name)":"("+description+")");
 		buf.append(" chains: ");
 		if (chains!=null) {
@@ -228,10 +228,10 @@ public class EntityInfo implements Serializable {
 	}
 
 	/**
-	 * Get the representative Chain for this Compound.
+	 * Get the representative Chain for this EntityInfo.
 	 * We choose the Chain with the first chain identifier after
 	 * lexicographical sorting (case insensitive),
-	 * e.g. chain A if Compound is composed of chains A,B,C,D,E
+	 * e.g. chain A if EntityInfo is composed of chains A,B,C,D,E
 	 * @return
 	 */
 	public Chain getRepresentative() {
@@ -249,7 +249,7 @@ public class EntityInfo implements Serializable {
 			}
 		}
 
-		logger.error("Could not find a representative chain for compound '{}'", this.toString());
+		logger.error("Could not find a representative chain for EntityInfo '{}'", this.toString());
 
 		return null;
 	}
@@ -276,12 +276,12 @@ public class EntityInfo implements Serializable {
 	 *
 	 */
 	public void showHeader(){
-		this.showCompound();
+		this.showEntityInfo();
 		this.showSource();
 	}
 
-	public void showCompound() {
-		System.out.println("COMPOUND INFO:");
+	public void showEntityInfo() {
+		System.out.println("ENTITY INFO:");
 		if (this.molId != -1) {
 			System.out.println("Mol ID: " + this.molId);
 		}
@@ -433,12 +433,12 @@ public class EntityInfo implements Serializable {
 	}
 
 	/**
-	 * Return the list of member chain IDs that are described by this Compound,
+	 * Return the list of member chain IDs that are described by this EnityInfo,
 	 * only unique chain IDs are contained in the list.
 	 * Note that in the case of multimodel structures this will return just the unique
 	 * chain identifiers whilst {@link #getChains()} will return a corresponding chain
 	 * per model.
-	 * @return the list of unique ChainIDs that are described by this Compound
+	 * @return the list of unique ChainIDs that are described by this EnityInfo
 	 * @see #setChains(List)
 	 * @see #getChains()
 	 */
@@ -453,9 +453,9 @@ public class EntityInfo implements Serializable {
 	}
 
 	/**
-	 * Given a Group g of Chain c (member of this Compound) return the corresponding position in the
+	 * Given a Group g of Chain c (member of this EnityInfo) return the corresponding position in the
 	 * alignment of all member sequences (1-based numbering), i.e. the index (1-based) in the SEQRES sequence.
-	 * This allows for comparisons of residues belonging to different chains of the same Compound (entity).
+	 * This allows for comparisons of residues belonging to different chains of the same EnityInfo (entity).
 	 * <p>
 	 * If {@link FileParsingParameters#setAlignSeqRes(boolean)} is not used or SEQRES not present, a mapping
 	 * will not be available and this method will return {@link ResidueNumber#getSeqNum()} for all residues, which
@@ -468,7 +468,7 @@ public class EntityInfo implements Serializable {
 	 * @return the aligned residue index (1 to n), if no SEQRES groups are available at all then {@link ResidueNumber#getSeqNum()}
 	 * is returned as a fall-back, if the group is not found in the SEQRES groups then -1 is returned
 	 * for the given group and chain
-	 * @throws IllegalArgumentException if the given Chain is not a member of this Compound
+	 * @throws IllegalArgumentException if the given Chain is not a member of this EnityInfo
 	 * @see {@link Chain#getSeqResGroup(int)}
 	 */
 	public int getAlignedResIndex(Group g, Chain c) {
@@ -481,7 +481,7 @@ public class EntityInfo implements Serializable {
 			}
 		}
 		if (!contained)
-			throw new IllegalArgumentException("Given chain "+c.getChainID()+" is not a member of this Compound (entity): "+getChainIds().toString());
+			throw new IllegalArgumentException("Given chain "+c.getChainID()+" is not a member of this entity: "+getChainIds().toString());
 
 		if (!chains2pdbResNums2ResSerials.containsKey(c.getChainID())) {
 			// we do lazy initialisation of the map
@@ -494,7 +494,7 @@ public class EntityInfo implements Serializable {
 
 			ResidueNumber resNum = g.getResidueNumber();
 			// the resNum will be null for groups that are SEQRES only and not in ATOM,
-			// still it can happen that a group is in ATOM in one chain but not in other of the same compound.
+			// still it can happen that a group is in ATOM in one chain but not in other of the same entity.
 			// This is what we try to find out here (analogously to what we do in initResSerialsMap() ):
 			if (resNum==null && c.getSeqResGroups()!=null && !c.getSeqResGroups().isEmpty()) {
 				int index = -1;
@@ -548,9 +548,9 @@ public class EntityInfo implements Serializable {
 
 			// The seqres group will have a null residue number whenever its corresponding atom group doesn't exist
 			// because it is missing in the electron density.
-			// However, it can be observed in the density in other chains of the same compound,
+			// However, it can be observed in the density in other chains of the same entity,
 			// to be complete we go and look for the residue number in other chains, so that we have a
-			// seqres to atom mapping as complete as possible (with all known atom groups of any chain of this compound)
+			// seqres to atom mapping as complete as possible (with all known atom groups of any chain of this entity)
 
 			ResidueNumber resNum = c.getSeqResGroup(i).getResidueNumber();
 
@@ -965,7 +965,7 @@ public class EntityInfo implements Serializable {
 	}
 
 	/**
-	 * Get the list of chains that are part of this Compound. Note that for multi-model
+	 * Get the list of chains that are part of this EntityInfo. Note that for multi-model
 	 * structures chains from all models are returned.
 	 *
 	 * @return a List of Chain objects
@@ -975,7 +975,7 @@ public class EntityInfo implements Serializable {
 	}
 
 	 /**
-	  * Add new Chain to this Compound
+	  * Add new Chain to this EntityInfo
 	  * @param chain
 	  */
 	public void addChain(Chain chain){
@@ -983,7 +983,7 @@ public class EntityInfo implements Serializable {
 	}
 
 	/**
-	 * Set the chains for this Compound
+	 * Set the chains for this EntityInfo
 	 * @param chains
 	 */
 	public void setChains(List<Chain> chains){
@@ -991,14 +991,18 @@ public class EntityInfo implements Serializable {
 	}
 
 	/**
-	 * @return the type
+	 * Get the type of entity this EntityInfo describes.
+	 * Options are polymer, non-polymer or water.
+	 * @return a string describing the type of entity. (polymer, non-polymer or water).
 	 */
 	public String getType() {
 		return type;
 	}
 
 	/**
-	 * @param type the type to set
+	 * Set the type of entity this EntityInfo describes.
+	 * Options are polymer, non-polymer or water.
+	 * @param type a string describing the type of entity. (polymer, non-polymer or water).
 	 */
 	public void setType(String type) {
 		this.type = type;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -84,7 +84,7 @@ public class EntityInfo implements Serializable {
 	private String description = null;
 	private String title = null;
 	/**
-	 * The type of group (polymer, non-polymer, water)
+	 * The type of entity (polymer, non-polymer, water)
 	 */
 	private String type = null;
 	private List<String> synonyms = null;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -86,7 +86,7 @@ public class EntityInfo implements Serializable {
 	/**
 	 * The type of entity (polymer, non-polymer, water)
 	 */
-	private String type = null;
+	private EntityType type = null;
 	private List<String> synonyms = null;
 	private List<String> ecNums = null;
 	private String engineered = null;
@@ -995,8 +995,8 @@ public class EntityInfo implements Serializable {
 	 * Options are polymer, non-polymer or water.
 	 * @return a string describing the type of entity. (polymer, non-polymer or water).
 	 */
-	public String getType() {
-		return type;
+	public EntityType getType() {
+		return this.type;
 	}
 
 	/**
@@ -1004,7 +1004,7 @@ public class EntityInfo implements Serializable {
 	 * Options are polymer, non-polymer or water.
 	 * @param type a string describing the type of entity. (polymer, non-polymer or water).
 	 */
-	public void setType(String type) {
+	public void setType(EntityType type) {
 		this.type = type;
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityType.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityType.java
@@ -1,0 +1,54 @@
+package org.biojava.nbio.structure;
+
+import java.io.Serializable;
+
+/**
+ * This is the type of entity.
+ * @author Anthony Bradley
+ *
+ */
+public enum EntityType implements Serializable {
+
+	/**
+	 * The type of entity (polymer, non-polymer, water, macrolide)
+	 * Defined here:http://mmcif.wwpdb.org/dictionaries/mmcif_pdbx_v40.dic/Items/_entity.type.html
+	 * """Entities are of three types:  polymer, non-polymer and water.
+               Note that the water category includes only water;  ordered
+               solvent such as sulfate ion or acetone would be described as
+               individual non-polymer entities."""
+               NOT SURE WHAT MACROLIDES ARE BUT THEY APPEAR TO BE SUPPORTED.....
+	 */
+	POLYMER("polymer"),
+	NONPOLYMER("non-polymer"), 
+	WATER("water"),
+	MACROLIDE("macrolide");
+	
+	private String entityType;
+	
+	private EntityType(String entType) {
+		
+		this.setEntityType(entType);
+		
+	}
+
+	public String getEntityType() {
+		return entityType;
+	}
+
+	public void setEntityType(String entityType) {
+		this.entityType = entityType;
+	}
+	
+	public static EntityType entityTypeFromString(String entityType)
+	{
+		for(EntityType et : EntityType.values())
+		{
+			if(entityType.equals(et.entityType))
+			{
+				return et;
+			}
+		}
+		return null;
+	}
+	
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
@@ -518,7 +518,7 @@ public interface Structure extends Cloneable {
 	 *
 	 * @param molList
 	 */
-	public void setCompounds(List<EntityInfo> molList);
+	public void setEntityInfos(List<EntityInfo> molList);
 
 	/**
 	 * Get all the Compounds for this Structure.
@@ -526,12 +526,12 @@ public interface Structure extends Cloneable {
 	 *
 	 * @return a list of Compounds
 	 */
-	public List<EntityInfo> getEntityInformation();
+	public List<EntityInfo> getEntityInfos();
 
 	/**
 	 * Add a Compound to this Structure
 	 */
-	public void addCompound(EntityInfo compound);
+	public void addEntityInfo(EntityInfo compound);
 
 	/**
 	 * Set the list of database references for this structure

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
@@ -40,7 +40,7 @@ import java.util.Map;
  * <ul>
  * <li>{@link PDBHeader}</li>
  * <li>{@link DBRef}</li>
- * <li>{@link Compound}</li>
+ * <li>{@link EntityInfo}</li>
  * </ul>
  *
  * The structure object provides access to the data from the ATOM records through
@@ -518,7 +518,7 @@ public interface Structure extends Cloneable {
 	 *
 	 * @param molList
 	 */
-	public void setCompounds(List<Compound> molList);
+	public void setCompounds(List<EntityInfo> molList);
 
 	/**
 	 * Get all the Compounds for this Structure.
@@ -526,12 +526,12 @@ public interface Structure extends Cloneable {
 	 *
 	 * @return a list of Compounds
 	 */
-	public List<Compound> getCompounds();
+	public List<EntityInfo> getEntityInformation();
 
 	/**
 	 * Add a Compound to this Structure
 	 */
-	public void addCompound(Compound compound);
+	public void addCompound(EntityInfo compound);
 
 	/**
 	 * Set the list of database references for this structure
@@ -553,7 +553,7 @@ public interface Structure extends Cloneable {
 	 * @param molId
 	 * @return a compound
 	 */
-	public Compound getCompoundById(int molId);
+	public EntityInfo getCompoundById(int molId);
 
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -177,7 +177,7 @@ public class StructureImpl implements Structure, Serializable {
 					for (int modelNr=0;modelNr<n.nrModels();modelNr++) {
 						try {
 							Chain newChain = n.getChainByPDB(chainId,modelNr);
-							newChain.setCompound(newCompound);
+							newChain.setEntityInfo(newCompound);
 							newCompound.addChain(newChain);
 						} catch (StructureException e) {
 							// this actually happens for structure 1msh, which has no chain B for model 29 (clearly a deposition error)
@@ -187,7 +187,7 @@ public class StructureImpl implements Structure, Serializable {
 			}
 			newCompoundList.add(newCompound);
 		}
-		n.setCompounds(newCompoundList);
+		n.setEntityInfos(newCompoundList);
 
 		// TODO ssbonds are complicated to clone: there are deep references inside Atom objects, how would we do it? - JD 2016-03-03
 
@@ -442,8 +442,8 @@ public class StructureImpl implements Structure, Serializable {
 				List<Group> ngr = cha.getAtomGroups(GroupType.NUCLEOTIDE);
 
 				str.append("chain ").append(j).append(": >").append(cha.getChainID()).append("< ");
-				if ( cha.getCompound() != null){
-					EntityInfo comp = cha.getCompound();
+				if ( cha.getEntityInfo() != null){
+					EntityInfo comp = cha.getEntityInfo();
 					String molName = comp.getDescription();
 					if ( molName != null){
 						str.append(molName);
@@ -665,19 +665,19 @@ public class StructureImpl implements Structure, Serializable {
 
 	/** {@inheritDoc} */
 	@Override
-	public void setCompounds(List<EntityInfo> molList){
+	public void setEntityInfos(List<EntityInfo> molList){
 		this.compounds = molList;
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public void addCompound(EntityInfo compound) {
+	public void addEntityInfo(EntityInfo compound) {
 		this.compounds.add(compound);
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public List<EntityInfo> getEntityInformation() {
+	public List<EntityInfo> getEntityInfos() {
 		// compounds are parsed from the PDB/mmCIF file normally
 		// but if the file is incomplete, it won't have the Compounds information and we try
 		// to guess it from the existing seqres/atom sequences
@@ -688,7 +688,7 @@ public class StructureImpl implements Structure, Serializable {
 			// now we need to set references in chains:
 			for (EntityInfo compound:compounds) {
 				for (Chain c:compound.getChains()) {
-					c.setCompound(compound);
+					c.setEntityInfo(compound);
 				}
 			}
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -57,7 +57,7 @@ public class StructureImpl implements Structure, Serializable {
 	private List<List<Chain>> models;
 
 	private List<Map <String,Integer>> connections ;
-	private List<Compound> compounds;
+	private List<EntityInfo> compounds;
 	private List<DBRef> dbrefs;
 	private List<Bond> ssbonds;
 	private List<Site> sites;
@@ -79,7 +79,7 @@ public class StructureImpl implements Structure, Serializable {
 		models         = new ArrayList<List<Chain>>();
 		name           = "";
 		connections    = new ArrayList<Map<String,Integer>>();
-		compounds      = new ArrayList<Compound>();
+		compounds      = new ArrayList<EntityInfo>();
 		dbrefs         = new ArrayList<DBRef>();
 		pdbHeader      = new PDBHeader();
 		ssbonds        = new ArrayList<Bond>();
@@ -169,9 +169,9 @@ public class StructureImpl implements Structure, Serializable {
 
 		// deep-copying of Compounds is tricky: there's cross references also in the Chains
 		// beware: if we copy the compounds we would also need to reset the references to compounds in the individual chains
-		List<Compound> newCompoundList = new ArrayList<Compound>();
-		for (Compound compound:this.compounds) {
-			Compound newCompound = new Compound(compound); // this sets everything but the chains
+		List<EntityInfo> newCompoundList = new ArrayList<EntityInfo>();
+		for (EntityInfo compound:this.compounds) {
+			EntityInfo newCompound = new EntityInfo(compound); // this sets everything but the chains
 			for (String chainId:compound.getChainIds()) {
 
 					for (int modelNr=0;modelNr<n.nrModels();modelNr++) {
@@ -443,8 +443,8 @@ public class StructureImpl implements Structure, Serializable {
 
 				str.append("chain ").append(j).append(": >").append(cha.getChainID()).append("< ");
 				if ( cha.getCompound() != null){
-					Compound comp = cha.getCompound();
-					String molName = comp.getMolName();
+					EntityInfo comp = cha.getCompound();
+					String molName = comp.getDescription();
 					if ( molName != null){
 						str.append(molName);
 					}
@@ -465,7 +465,7 @@ public class StructureImpl implements Structure, Serializable {
 			str.append(dbref.toPDB()).append(newline);
 		}
 		str.append("Molecules: ").append(newline);
-		for (Compound mol : compounds) {
+		for (EntityInfo mol : compounds) {
 			str.append(mol).append(newline);
 		}
 
@@ -665,19 +665,19 @@ public class StructureImpl implements Structure, Serializable {
 
 	/** {@inheritDoc} */
 	@Override
-	public void setCompounds(List<Compound> molList){
+	public void setCompounds(List<EntityInfo> molList){
 		this.compounds = molList;
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public void addCompound(Compound compound) {
+	public void addCompound(EntityInfo compound) {
 		this.compounds.add(compound);
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public List<Compound> getCompounds() {
+	public List<EntityInfo> getEntityInformation() {
 		// compounds are parsed from the PDB/mmCIF file normally
 		// but if the file is incomplete, it won't have the Compounds information and we try
 		// to guess it from the existing seqres/atom sequences
@@ -686,7 +686,7 @@ public class StructureImpl implements Structure, Serializable {
 			this.compounds = cf.findCompounds();
 
 			// now we need to set references in chains:
-			for (Compound compound:compounds) {
+			for (EntityInfo compound:compounds) {
 				for (Chain c:compound.getChains()) {
 					c.setCompound(compound);
 				}
@@ -697,8 +697,8 @@ public class StructureImpl implements Structure, Serializable {
 
 	/** {@inheritDoc} */
 	@Override
-	public Compound getCompoundById(int molId) {
-		for (Compound mol : this.compounds){
+	public EntityInfo getCompoundById(int molId) {
+		for (EntityInfo mol : this.compounds){
 			if (mol.getMolId()==molId){
 				return mol;
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1046,7 +1046,7 @@ public class StructureTools {
 		newS.setDBRefs(s.getDBRefs());
 		newS.setSites(s.getSites());
 		newS.setBiologicalAssembly(s.isBiologicalAssembly());
-		newS.setCompounds(s.getCompounds());
+		newS.setCompounds(s.getEntityInformation());
 		newS.setConnections(s.getConnections());
 		newS.setSSBonds(s.getSSBonds());
 		newS.setSites(s.getSites());
@@ -1075,13 +1075,13 @@ public class StructureTools {
 		}
 		if (c != null) {
 			newS.addChain(c);
-			for (Compound comp : s.getCompounds()) {
+			for (EntityInfo comp : s.getEntityInformation()) {
 				if (comp.getChainIds() != null
 						&& comp.getChainIds().contains(c.getChainID())) {
 					// found matching compound. set description...
 					newS.getPDBHeader().setDescription(
 							"Chain " + c.getChainID() + " of " + s.getPDBCode()
-									+ " " + comp.getMolName());
+									+ " " + comp.getDescription());
 				}
 			}
 		}
@@ -1116,7 +1116,7 @@ public class StructureTools {
 		newS.setDBRefs(s.getDBRefs());
 		newS.setSites(s.getSites());
 		newS.setBiologicalAssembly(s.isBiologicalAssembly());
-		newS.setCompounds(s.getCompounds());
+		newS.setCompounds(s.getEntityInformation());
 		newS.setConnections(s.getConnections());
 		newS.setSSBonds(s.getSSBonds());
 		newS.setSites(s.getSites());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1046,7 +1046,7 @@ public class StructureTools {
 		newS.setDBRefs(s.getDBRefs());
 		newS.setSites(s.getSites());
 		newS.setBiologicalAssembly(s.isBiologicalAssembly());
-		newS.setCompounds(s.getEntityInformation());
+		newS.setEntityInfos(s.getEntityInfos());
 		newS.setConnections(s.getConnections());
 		newS.setSSBonds(s.getSSBonds());
 		newS.setSites(s.getSites());
@@ -1075,7 +1075,7 @@ public class StructureTools {
 		}
 		if (c != null) {
 			newS.addChain(c);
-			for (EntityInfo comp : s.getEntityInformation()) {
+			for (EntityInfo comp : s.getEntityInfos()) {
 				if (comp.getChainIds() != null
 						&& comp.getChainIds().contains(c.getChainID())) {
 					// found matching compound. set description...
@@ -1116,7 +1116,7 @@ public class StructureTools {
 		newS.setDBRefs(s.getDBRefs());
 		newS.setSites(s.getSites());
 		newS.setBiologicalAssembly(s.isBiologicalAssembly());
-		newS.setCompounds(s.getEntityInformation());
+		newS.setEntityInfos(s.getEntityInfos());
 		newS.setConnections(s.getConnections());
 		newS.setSSBonds(s.getSSBonds());
 		newS.setSites(s.getSites());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -182,7 +182,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 				"sub-range " + ranges + " of "  + newS.getPDBCode() + " "
 						+ s.getPDBHeader().getDescription());
 		// TODO The following should be only copied for atoms which are present in the range.
-		newS.setCompounds(s.getEntityInformation());
+		newS.setEntityInfos(s.getEntityInfos());
 
 		newS.setSSBonds(s.getSSBonds());
 		newS.setSites(s.getSites());
@@ -198,7 +198,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 
 			if(getResidueRanges().isEmpty()) {
 				// Include all residues
-				newS.setCompounds(s.getEntityInformation());
+				newS.setEntityInfos(s.getEntityInfos());
 				newS.setSSBonds(s.getSSBonds());
 				newS.setSites(s.getSites());
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -182,7 +182,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 				"sub-range " + ranges + " of "  + newS.getPDBCode() + " "
 						+ s.getPDBHeader().getDescription());
 		// TODO The following should be only copied for atoms which are present in the range.
-		newS.setCompounds(s.getCompounds());
+		newS.setCompounds(s.getEntityInformation());
 
 		newS.setSSBonds(s.getSSBonds());
 		newS.setSites(s.getSites());
@@ -198,7 +198,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 
 			if(getResidueRanges().isEmpty()) {
 				// Include all residues
-				newS.setCompounds(s.getCompounds());
+				newS.setCompounds(s.getEntityInformation());
 				newS.setSSBonds(s.getSSBonds());
 				newS.setSites(s.getSites());
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/ResidueIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/ResidueIdentifier.java
@@ -23,7 +23,7 @@ package org.biojava.nbio.structure.contact;
 import java.io.Serializable;
 
 import org.biojava.nbio.structure.Chain;
-import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.Group;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +52,7 @@ class ResidueIdentifier implements Serializable {
 			logger.warn("Chain is not available for group {}. Contact comparison will not work for this residue",g.toString());
 			this.seqResIndex = -1;
 		} else {
-			Compound comp = c.getCompound();
+			EntityInfo comp = c.getCompound();
 			if (comp==null) {
 				logger.warn("Compound is not available for group {}. Contact comparison will not work for this residue",g.toString());
 				this.seqResIndex = -1;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/ResidueIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/ResidueIdentifier.java
@@ -52,7 +52,7 @@ class ResidueIdentifier implements Serializable {
 			logger.warn("Chain is not available for group {}. Contact comparison will not work for this residue",g.toString());
 			this.seqResIndex = -1;
 		} else {
-			EntityInfo comp = c.getCompound();
+			EntityInfo comp = c.getEntityInfo();
 			if (comp==null) {
 				logger.warn("Compound is not available for group {}. Contact comparison will not work for this residue",g.toString());
 				this.seqResIndex = -1;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
@@ -372,8 +372,8 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 	 * @return true if homomeric or if either of the entities is unknonw (null Compounds), false otherwise
 	 */
 	public boolean isHomomeric() {
-		EntityInfo first = getParentChains().getFirst().getCompound();
-		EntityInfo second = getParentChains().getSecond().getCompound();
+		EntityInfo first = getParentChains().getFirst().getEntityInfo();
+		EntityInfo second = getParentChains().getSecond().getEntityInfo();
 		if (first==null || second==null) {
 			logger.warn("Some compound of interface {} is null, can't determine whether it is homo/heteromeric. Consider it homomeric", getId());
 			return true;
@@ -586,16 +586,16 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 		Pair<Chain> thisChains = getParentChains();
 		Pair<Chain> otherChains = other.getParentChains();
 
-		if (thisChains.getFirst().getCompound() == null || thisChains.getSecond().getCompound() == null ||
-			otherChains.getFirst().getCompound() == null || otherChains.getSecond().getCompound() == null ) {
+		if (thisChains.getFirst().getEntityInfo() == null || thisChains.getSecond().getEntityInfo() == null ||
+			otherChains.getFirst().getEntityInfo() == null || otherChains.getSecond().getEntityInfo() == null ) {
 			// this happens in cases like 2uub
 			logger.warn("Found chains with null compounds while comparing interfaces {} and {}. Contact overlap score for them will be 0.",
 					this.getId(), other.getId());
 			return 0;
 		}
 
-		Pair<EntityInfo> thisCompounds = new Pair<EntityInfo>(thisChains.getFirst().getCompound(), thisChains.getSecond().getCompound());
-		Pair<EntityInfo> otherCompounds = new Pair<EntityInfo>(otherChains.getFirst().getCompound(), otherChains.getSecond().getCompound());
+		Pair<EntityInfo> thisCompounds = new Pair<EntityInfo>(thisChains.getFirst().getEntityInfo(), thisChains.getSecond().getEntityInfo());
+		Pair<EntityInfo> otherCompounds = new Pair<EntityInfo>(otherChains.getFirst().getEntityInfo(), otherChains.getSecond().getEntityInfo());
 
 		if ( (  (thisCompounds.getFirst() == otherCompounds.getFirst()) &&
 				(thisCompounds.getSecond() == otherCompounds.getSecond())   )  ||
@@ -679,7 +679,7 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 			logger.warn("Could not find parents chains, compounds will be null");
 			return null;
 		}
-		return new Pair<EntityInfo>(chains.getFirst().getCompound(), chains.getSecond().getCompound());
+		return new Pair<EntityInfo>(chains.getFirst().getEntityInfo(), chains.getSecond().getEntityInfo());
 	}
 
 	private Structure getParentStructure() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
@@ -372,8 +372,8 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 	 * @return true if homomeric or if either of the entities is unknonw (null Compounds), false otherwise
 	 */
 	public boolean isHomomeric() {
-		Compound first = getParentChains().getFirst().getCompound();
-		Compound second = getParentChains().getSecond().getCompound();
+		EntityInfo first = getParentChains().getFirst().getCompound();
+		EntityInfo second = getParentChains().getSecond().getCompound();
 		if (first==null || second==null) {
 			logger.warn("Some compound of interface {} is null, can't determine whether it is homo/heteromeric. Consider it homomeric", getId());
 			return true;
@@ -562,7 +562,7 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 	 * The two sides of the given StructureInterface need to match this StructureInterface
 	 * in the sense that they must come from the same Compound (Entity), i.e.
 	 * their residue numbers need to align with 100% identity, except for unobserved
-	 * density residues. The SEQRES indices obtained through {@link Compound#getAlignedResIndex(Group, Chain)} are
+	 * density residues. The SEQRES indices obtained through {@link EntityInfo#getAlignedResIndex(Group, Chain)} are
 	 * used to match residues, thus if no SEQRES is present or if {@link FileParsingParameters#setAlignSeqRes(boolean)}
 	 * is not used, this calculation is not guaranteed to work properly.
 	 * @param other
@@ -594,8 +594,8 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 			return 0;
 		}
 
-		Pair<Compound> thisCompounds = new Pair<Compound>(thisChains.getFirst().getCompound(), thisChains.getSecond().getCompound());
-		Pair<Compound> otherCompounds = new Pair<Compound>(otherChains.getFirst().getCompound(), otherChains.getSecond().getCompound());
+		Pair<EntityInfo> thisCompounds = new Pair<EntityInfo>(thisChains.getFirst().getCompound(), thisChains.getSecond().getCompound());
+		Pair<EntityInfo> otherCompounds = new Pair<EntityInfo>(otherChains.getFirst().getCompound(), otherChains.getSecond().getCompound());
 
 		if ( (  (thisCompounds.getFirst() == otherCompounds.getFirst()) &&
 				(thisCompounds.getSecond() == otherCompounds.getSecond())   )  ||
@@ -673,13 +673,13 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 	 * Finds the parent compounds by looking up the references of first atom of each side of this interface
 	 * @return
 	 */
-	public Pair<Compound> getParentCompounds() {
+	public Pair<EntityInfo> getParentCompounds() {
 		Pair<Chain> chains = getParentChains();
 		if (chains == null) {
 			logger.warn("Could not find parents chains, compounds will be null");
 			return null;
 		}
-		return new Pair<Compound>(chains.getFirst().getCompound(), chains.getSecond().getCompound());
+		return new Pair<EntityInfo>(chains.getFirst().getCompound(), chains.getSecond().getCompound());
 	}
 
 	private Structure getParentStructure() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/CAConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/CAConverter.java
@@ -86,7 +86,7 @@ public class CAConverter {
 
 		Chain newChain = new ChainImpl();
 		newChain.setChainID(chain.getChainID());
-		newChain.setCompound(chain.getCompound());
+		newChain.setEntityInfo(chain.getEntityInfo());
 		newChain.setSwissprotId(chain.getSwissprotId());
 
 		List<Group> groups = chain.getAtomGroups();
@@ -127,7 +127,7 @@ public class CAConverter {
 
 		Chain newChain = new ChainImpl();
 		newChain.setChainID(chain.getChainID());
-		newChain.setCompound(chain.getCompound());
+		newChain.setEntityInfo(chain.getEntityInfo());
 		newChain.setSwissprotId(chain.getSwissprotId());
 
 		List<Group> groups = chain.getAtomGroups();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/CompoundFinder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/CompoundFinder.java
@@ -91,11 +91,11 @@ public class CompoundFinder {
 	 * for this Structure in case the information is missing in PDB/mmCIF file
 	 * @return
 	 */
-	public List<Compound> findCompounds() {
+	public List<EntityInfo> findCompounds() {
 
-		TreeMap<String,Compound> chainIds2entities = findCompoundsFromAlignment();
+		TreeMap<String,EntityInfo> chainIds2entities = findCompoundsFromAlignment();
 
-		List<Compound> compounds = findUniqueCompounds(chainIds2entities);
+		List<EntityInfo> compounds = findUniqueCompounds(chainIds2entities);
 
 		createPurelyNonPolyCompounds(compounds);
 
@@ -106,13 +106,13 @@ public class CompoundFinder {
 	 * Utility method to obtain a list of unique entities from the chainIds2entities map
 	 * @return
 	 */
-	private static List<Compound> findUniqueCompounds(TreeMap<String,Compound> chainIds2entities) {
+	private static List<EntityInfo> findUniqueCompounds(TreeMap<String,EntityInfo> chainIds2entities) {
 
-		List<Compound> list = new ArrayList<Compound>();
+		List<EntityInfo> list = new ArrayList<EntityInfo>();
 
-		for (Compound cluster:chainIds2entities.values()) {
+		for (EntityInfo cluster:chainIds2entities.values()) {
 			boolean present = false;
-			for (Compound cl:list) {
+			for (EntityInfo cl:list) {
 				if (cl==cluster) {
 					present = true;
 					break;
@@ -123,7 +123,7 @@ public class CompoundFinder {
 		return list;
 	}
 
-	private void createPurelyNonPolyCompounds(List<Compound> compounds) {
+	private void createPurelyNonPolyCompounds(List<EntityInfo> compounds) {
 
 		List<Chain> pureNonPolymerChains = new ArrayList<Chain>();
 		for (int i=0;i<s.getChains().size();i++) {
@@ -136,9 +136,9 @@ public class CompoundFinder {
 
 			int maxMolId = 0; // if we have no compounds at all we just use 0, so that first assignment is 1
 			if (!compounds.isEmpty()) {
-				Collections.max(compounds, new Comparator<Compound>() {
+				Collections.max(compounds, new Comparator<EntityInfo>() {
 					@Override
-					public int compare(Compound o1, Compound o2) {
+					public int compare(EntityInfo o1, EntityInfo o2) {
 						return new Integer(o1.getMolId()).compareTo(o2.getMolId());
 					}
 				}).getMolId();
@@ -147,7 +147,7 @@ public class CompoundFinder {
 			int molId = maxMolId + 1;
 			// for the purely non-polymeric chains we assign additional compounds
 			for (Chain c: pureNonPolymerChains) {
-				Compound comp = new Compound();
+				EntityInfo comp = new EntityInfo();
 				comp.addChain(c);
 				comp.setMolId(molId);
 				logger.warn("Chain {} is purely non-polymeric, will assign a new Compound (entity) to it (entity id {})", c.getChainID(), molId);
@@ -204,7 +204,7 @@ public class CompoundFinder {
 
 
 
-	private TreeMap<String,Compound> findCompoundsFromAlignment() {
+	private TreeMap<String,EntityInfo> findCompoundsFromAlignment() {
 
 		// first we determine which chains to consider: anything not looking
 		// polymeric (protein or nucleotide chain) should be discarded
@@ -219,7 +219,7 @@ public class CompoundFinder {
 		}
 
 
-		TreeMap<String, Compound> chainIds2compounds = new TreeMap<String,Compound>();
+		TreeMap<String, EntityInfo> chainIds2compounds = new TreeMap<String,EntityInfo>();
 
 		int molId = 1;
 
@@ -291,7 +291,7 @@ public class CompoundFinder {
 								!chainIds2compounds.containsKey(c2.getChainID())) {
 							logger.debug("Creating Compound with chains {},{}",c1.getChainID(),c2.getChainID());
 
-							Compound ent = new Compound();
+							EntityInfo ent = new EntityInfo();
 							ent.addChain(c1);
 							ent.addChain(c2);
 							ent.setMolId(molId++);
@@ -300,7 +300,7 @@ public class CompoundFinder {
 
 
 						} else {
-							Compound ent = chainIds2compounds.get(c1.getChainID());
+							EntityInfo ent = chainIds2compounds.get(c1.getChainID());
 
 							if (ent==null) {
 								logger.debug("Adding chain {} to entity {}",c1.getChainID(),c2.getChainID());
@@ -338,7 +338,7 @@ public class CompoundFinder {
 			if (!chainIds2compounds.containsKey(c.getChainID())) {
 				logger.debug("Creating a 1-member Compound for chain {}",c.getChainID());
 
-				Compound ent = new Compound();
+				EntityInfo ent = new EntityInfo();
 				ent.addChain(c);
 				ent.setMolId(molId++);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -2881,7 +2881,7 @@ public class PDBFileParser  {
 
 
 		linkChains2Compound(structure);
-		structure.setCompounds(compounds);
+		structure.setEntityInfos(compounds);
 
 		//associate the temporary Groups in the siteMap to the ones
 
@@ -2919,7 +2919,7 @@ public class PDBFileParser  {
 
 		// to make sure we have Compounds linked to chains, we call getCompounds() which will lazily initialise the
 		// compounds using heuristics (see CompoundFinder) in the case that they were not explicitly present in the file
-		structure.getEntityInformation();
+		structure.getEntityInfos();
 	}
 
 	private void setSecStruc(){
@@ -3058,7 +3058,7 @@ public class PDBFileParser  {
 					continue;
 				try {
 					Chain c = s.getChainByPDB(chainId);
-					c.setCompound(comp);
+					c.setEntityInfo(comp);
 				} catch (StructureException e){
 					logger.warn("Chain {} was not found, can't assign a compound (entity) to it.",chainId);
 				}
@@ -3071,12 +3071,12 @@ public class PDBFileParser  {
 
 		if (compounds!=null && !compounds.isEmpty()) {
 			for (Chain c: s.getChains()) {
-				if (c.getCompound() == null) {
+				if (c.getEntityInfo() == null) {
 
 					EntityInfo compound = new EntityInfo();
 					compound.addChain(c);
 					compound.setMolId(findMaxCompoundId(compounds)+1);
-					c.setCompound(compound);
+					c.setEntityInfo(compound);
 					compounds.add(compound);
 
 					logger.warn("No compound (entity) found in file for chain {}. Creating new compound {} for it.", c.getChainID(), compound.getMolId());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -54,7 +54,7 @@ import org.biojava.nbio.structure.AtomImpl;
 import org.biojava.nbio.structure.Author;
 import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.ChainImpl;
-import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.DBRef;
 import org.biojava.nbio.structure.Element;
 import org.biojava.nbio.structure.Group;
@@ -179,8 +179,8 @@ public class PDBFileParser  {
 
 	private boolean isLastCompndLine = false;
 	private boolean isLastSourceLine = false;
-	private Compound current_compound;
-	private List<Compound> compounds = new ArrayList<Compound>();
+	private EntityInfo current_compound;
+	private List<EntityInfo> compounds = new ArrayList<EntityInfo>();
 	private HashMap<Integer,List<String>> compoundMolIds2chainIds = new HashMap<Integer, List<String>>();
 	private List<String> compndLines = new ArrayList<String>();
 	private List<String> sourceLines = new ArrayList<String>();
@@ -1012,7 +1012,7 @@ public class PDBFileParser  {
 
 				logger.debug("Initialising new Compound with mol_id {}", i);
 
-				current_compound = new Compound();
+				current_compound = new EntityInfo();
 
 				current_compound.setMolId(i);
 
@@ -1027,7 +1027,7 @@ public class PDBFileParser  {
 		}
 
 		if (field.equals("MOLECULE:")) {
-			current_compound.setMolName(value);
+			current_compound.setDescription(value);
 
 		}
 		if (field.equals("CHAIN:")) {
@@ -2789,7 +2789,7 @@ public class PDBFileParser  {
 		//		System.out.println("[makeCompounds] adding sources to compounds from sourceLines");
 		// since we're starting again from the first compound, reset it here
 		if ( compounds.size() == 0){
-			current_compound = new Compound();
+			current_compound = new EntityInfo();
 		} else {
 			current_compound = compounds.get(0);
 		}
@@ -2919,7 +2919,7 @@ public class PDBFileParser  {
 
 		// to make sure we have Compounds linked to chains, we call getCompounds() which will lazily initialise the
 		// compounds using heuristics (see CompoundFinder) in the case that they were not explicitly present in the file
-		structure.getCompounds();
+		structure.getEntityInformation();
 	}
 
 	private void setSecStruc(){
@@ -3002,7 +3002,7 @@ public class PDBFileParser  {
 	}
 
 
-	/** After the parsing of a PDB file the {@link Chain} and  {@link Compound}
+	/** After the parsing of a PDB file the {@link Chain} and  {@link EntityInfo}
 	 * objects need to be linked to each other.
 	 *
 	 * @param s the structure
@@ -3010,7 +3010,7 @@ public class PDBFileParser  {
 	public void linkChains2Compound(Structure s){
 
 
-		for(Compound comp : compounds){
+		for(EntityInfo comp : compounds){
 			List<Chain> chains = new ArrayList<Chain>();
 			List<String> chainIds = compoundMolIds2chainIds.get(comp.getMolId());
 			if ( chainIds == null)
@@ -3036,7 +3036,7 @@ public class PDBFileParser  {
 		}
 
 		if ( compounds.size() == 1) {
-			Compound comp = compounds.get(0);
+			EntityInfo comp = compounds.get(0);
 			if ( compoundMolIds2chainIds.get(comp.getMolId()) == null){
 				List<Chain> chains = s.getChains(0);
 				if ( chains.size() == 1) {
@@ -3047,7 +3047,7 @@ public class PDBFileParser  {
 			}
 		}
 
-		for (Compound comp: compounds){
+		for (EntityInfo comp: compounds){
 			if ( compoundMolIds2chainIds.get(comp.getMolId()) == null) {
 				// could not link to chain
 				// TODO: should this be allowed to happen?
@@ -3073,7 +3073,7 @@ public class PDBFileParser  {
 			for (Chain c: s.getChains()) {
 				if (c.getCompound() == null) {
 
-					Compound compound = new Compound();
+					EntityInfo compound = new EntityInfo();
 					compound.addChain(c);
 					compound.setMolId(findMaxCompoundId(compounds)+1);
 					c.setCompound(compound);
@@ -3085,13 +3085,13 @@ public class PDBFileParser  {
 		}
 	}
 
-	private static int findMaxCompoundId(List<Compound> compounds) {
+	private static int findMaxCompoundId(List<EntityInfo> compounds) {
 
 		return
 
-		Collections.max(compounds, new Comparator<Compound>() {
+		Collections.max(compounds, new Comparator<EntityInfo>() {
 			@Override
-			public int compare(Compound o1, Compound o2) {
+			public int compare(EntityInfo o1, EntityInfo o2) {
 				return new Integer(o1.getMolId()).compareTo(o2.getMolId());
 			}
 		}).getMolId();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileReader.java
@@ -147,7 +147,7 @@ public class PDBFileReader extends LocalPDBDirectory {
 			Structure struc = pdbreader.getStructureById("193D");
 			System.out.println(struc);
 
-			List<EntityInfo>	compounds = struc.getEntityInformation();
+			List<EntityInfo>	compounds = struc.getEntityInfos();
 			for (EntityInfo comp : compounds  ){
 				List<Chain> chains = comp.getChains();
 				System.out.print(">Chains :" );

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileReader.java
@@ -26,7 +26,7 @@ package org.biojava.nbio.structure.io;
 
 
 import org.biojava.nbio.structure.Chain;
-import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
@@ -147,8 +147,8 @@ public class PDBFileReader extends LocalPDBDirectory {
 			Structure struc = pdbreader.getStructureById("193D");
 			System.out.println(struc);
 
-			List<Compound>	compounds = struc.getCompounds();
-			for (Compound comp : compounds  ){
+			List<EntityInfo>	compounds = struc.getEntityInformation();
+			for (EntityInfo comp : compounds  ){
 				List<Chain> chains = comp.getChains();
 				System.out.print(">Chains :" );
 				for (Chain c : chains){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/StructureSequenceMatcher.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/StructureSequenceMatcher.java
@@ -83,7 +83,7 @@ public class StructureSequenceMatcher {
 			chain.setChainID(group.getChainId());
 			if (currentChain == null || !currentChain.getChainID().equals(chain.getChainID())) {
 				structure.addChain(chain);
-				chain.setCompound(group.getChain().getCompound());
+				chain.setEntityInfo(group.getChain().getEntityInfo());
 				chain.setStructure(structure);
 				chain.setSwissprotId(group.getChain().getSwissprotId());
 				chain.setInternalChainID(group.getChain().getInternalChainID());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MMCIFFileTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MMCIFFileTools.java
@@ -303,9 +303,9 @@ public class MMCIFFileTools {
 
 		String entityId = "0";
 		String labelSeqId = Integer.toString(g.getResidueNumber().getSeqNum());
-		if (g.getChain()!=null && g.getChain().getCompound()!=null) {
-			entityId = Integer.toString(g.getChain().getCompound().getMolId());
-			labelSeqId = Integer.toString(g.getChain().getCompound().getAlignedResIndex(g, g.getChain()));
+		if (g.getChain()!=null && g.getChain().getEntityInfo()!=null) {
+			entityId = Integer.toString(g.getChain().getEntityInfo().getMolId());
+			labelSeqId = Integer.toString(g.getChain().getEntityInfo().getAlignedResIndex(g, g.getChain()));
 		}
 
 		Character  altLoc = a.getAltLoc()           ;
@@ -394,7 +394,7 @@ public class MMCIFFileTools {
 
 		List<AtomSite> list = new ArrayList<AtomSite>();
 
-		if (c.getCompound()==null) {
+		if (c.getEntityInfo()==null) {
 			logger.warn("No Compound (entity) found for chain {}: entity_id will be set to 0, label_seq_id will be the same as auth_seq_id", c.getChainID());
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -39,6 +39,7 @@ import org.biojava.nbio.structure.AtomImpl;
 import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.ChainImpl;
 import org.biojava.nbio.structure.EntityInfo;
+import org.biojava.nbio.structure.EntityType;
 import org.biojava.nbio.structure.DBRef;
 import org.biojava.nbio.structure.Element;
 import org.biojava.nbio.structure.Group;
@@ -1125,7 +1126,7 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 			// we only add the compound if a polymeric one (to match what the PDB parser does)
 			if (e!=null) {
 				c.setDescription(e.getPdbx_description());
-				c.setType(e.getType());
+				c.setType(EntityType.entityTypeFromString(e.getType()));
 				addAnicilliaryEntityData(asym, eId, e, c);
 				structure.addEntityInfo(c);
 				logger.debug("Adding Compound with entity id {} from _entity, with name: {}",eId, c.getDescription());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -38,7 +38,7 @@ import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.AtomImpl;
 import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.ChainImpl;
-import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.DBRef;
 import org.biojava.nbio.structure.Element;
 import org.biojava.nbio.structure.Group;
@@ -953,13 +953,13 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 				//   - 3o6j: asym_id K, chainId Z, entity_id 6 : a single water molecule
 				//   - 1dz9: asym_id K, chainId K, entity_id 6 : a potassium ion alone
 
-				Compound compound = structure.getCompoundById(eId);
+				EntityInfo compound = structure.getCompoundById(eId);
 				if (compound==null) {
 					// Supports the case where the only chain members were from non-polymeric entity that is missing.
 					// Solved by creating a new Compound(entity) to which this chain will belong.
 					logger.warn("Could not find a compound for entity_id {}, for chain id {}, creating a new compound.",
 							eId, chain.getChainID());
-					compound = new Compound();
+					compound = new EntityInfo();
 					compound.setMolId(eId);
 					compound.addChain(chain);
 					chain.setCompound(compound);
@@ -977,15 +977,15 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 
 		// to make sure we have Compounds linked to chains, we call getCompounds() which will lazily initialise the
 		// compounds using heuristics (see CompoundFinder) in the case that they were not explicitly present in the file
-		List<Compound> compounds = structure.getCompounds();
+		List<EntityInfo> compounds = structure.getEntityInformation();
 
 		// final sanity check: it can happen that from the annotated compounds some are not linked to any chains
 		// e.g. 3s26: a sugar entity does not have any chains associated to it (it seems to be happening with many sugar compounds)
 		// we simply log it, this can sign some other problems if the compounds are used down the line
-		for (Compound compound:compounds) {
+		for (EntityInfo compound:compounds) {
 			if (compound.getChains().isEmpty()) {
 				logger.info("Compound {} '{}' has no chains associated to it",
-						compound.getId()==null?"with no entity id":compound.getId(), compound.getMolName());
+						compound.getId()==null?"with no entity id":compound.getId(), compound.getDescription());
 			}
 		}
 
@@ -1114,127 +1114,104 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 		}
 		Entity e = getEntity(eId);
 
+		// for some mmCIF files like 1yrm all 3 of _entity_src_gen, _entity_src_nat and _pdbx_entity_src_syn are missing
+		// we need to fill the Compounds in some other way:
+
+		EntityInfo c = structure.getCompoundById(eId);
+
+		if (c==null) {
+			c = new EntityInfo();
+			c.setMolId(eId);
+			// we only add the compound if a polymeric one (to match what the PDB parser does)
+			if (e!=null) {
+				c.setDescription(e.getPdbx_description());
+				c.setType(e.getType());
+				addAnicilliaryEntityData(asym, eId, e, c);
+				structure.addCompound(c);
+				logger.debug("Adding Compound with entity id {} from _entity, with name: {}",eId, c.getDescription());
+			}
+		}
+	}
+	
+	
+	/**
+	 * Add any extra information to the entity information.
+	 * @param asym 
+	 * @param entityId 
+	 * @param entity 
+	 * @param entityInfo 
+	 */
+	private void addAnicilliaryEntityData(StructAsym asym, int entityId, Entity entity, EntityInfo entityInfo) {
+		// Loop through each of the entity types and add the corresponding data
+		// We're assuming if data is duplicated between sources it is consistent
+		// This is a potentially huge assumption...
+		
+		
 		for (EntitySrcGen esg : entitySrcGens) {
 
 			if (! esg.getEntity_id().equals(asym.getEntity_id()))
 				continue;
 
-			// found the matching EntitySrcGen
-			// get the corresponding Entity
-			Compound c = structure.getCompoundById(eId);
-			if ( c == null){
-				if (e!=null) {
-					if (e.getType().equals("polymer")) {
-						c = createNewCompoundFromESG(esg, eId);
-						c.setMolName(e.getPdbx_description());
-						structure.addCompound(c);
-						logger.debug("Adding Compound with entity id {} from _entity_src_syn, with name: {}",eId,c.getMolName());
-					} else if (e.getType().equals("non-solvent")) {
-						// TODO handle non-polymer compounds.
-					} else if (e.getType().equals("water")) {
-						// TODO handle solvent entity.
-					} else {
-						logger.warn("Could not add entity id " + esg.getEntity_id() + " that has unknown _entity.type");
-					}
-				}
-			}
+			addInformationFromESG(esg, entityId, entityInfo);
 
 		}
 
 		for (EntitySrcNat esn : entitySrcNats) {
 			if (! esn.getEntity_id().equals(asym.getEntity_id()))
 				continue;
-
-			// found the matching EntitySrcGen
-			// get the corresponding Entity
-			Compound c = structure.getCompoundById(eId);
-			if ( c == null){
-				if (e!=null && e.getType().equals("polymer")) {
-					c = createNewCompoundFromESN(esn, eId);
-					c.setMolName(e.getPdbx_description());
-					structure.addCompound(c);
-					logger.debug("Adding Compound with entity id {} from _entity_src_syn, with name: {}",eId,c.getMolName());
-				}
-			}
+			addInformationFromESN(esn, entityId, entityInfo);
 
 		}
 
 		for (EntitySrcSyn ess : entitySrcSyns) {
 			if (! ess.getEntity_id().equals(asym.getEntity_id()))
 				continue;
-
-			// found the matching EntitySrcGen
-			// get the corresponding Entity
-			Compound c = structure.getCompoundById(eId);
-			if ( c == null){
-				if (e!=null && e.getType().equals("polymer")) {
-					c = createNewCompoundFromESS(ess, eId);
-					c.setMolName(e.getPdbx_description());
-					structure.addCompound(c);
-					logger.debug("Adding Compound with entity id {} from _entity_src_syn, with name: {}",eId,c.getMolName());
-				}
-			}
-		}
-
-		// for some mmCIF files like 1yrm all 3 of _entity_src_gen, _entity_src_nat and _pdbx_entity_src_syn are missing
-		// we need to fill the Compounds in some other way:
-
-		Compound c = structure.getCompoundById(eId);
-
-		if (c==null) {
-			c = new Compound();
-			c.setMolId(eId);
-
-			// we only add the compound if a polymeric one (to match what the PDB parser does)
-			if (e!=null && e.getType().equals("polymer")) {
-				c.setMolName(e.getPdbx_description());
-				structure.addCompound(c);
-				logger.debug("Adding Compound with entity id {} from _entity, with name: {}",eId, c.getMolName());
-			}
-		}
+			addInfoFromESS(ess, entityId, entityInfo);
+			
+		}		
 	}
 
-	private Compound createNewCompoundFromESG(EntitySrcGen esg, int eId) {
-
-		Compound c = new Compound();
-		c.setMolId(eId);
-		c.setAtcc(esg.getPdbx_gene_src_atcc());
-		c.setCell(esg.getPdbx_gene_src_cell());
-		c.setOrganismCommon(esg.getGene_src_common_name());
-		c.setOrganismScientific(esg.getPdbx_gene_src_scientific_name());
-		c.setOrganismTaxId(esg.getPdbx_gene_src_ncbi_taxonomy_id());
-		c.setExpressionSystemTaxId(esg.getPdbx_host_org_ncbi_taxonomy_id());
-		c.setExpressionSystem(esg.getPdbx_host_org_scientific_name());
-		return c;
-
+	/**
+	 * Add the information from an ESG to a compound.
+	 * @param entitySrcInfo
+	 * @param entityId
+	 * @param c
+	 */
+	private void addInformationFromESG(EntitySrcGen entitySrcInfo, int entityId, EntityInfo c) {
+		c.setAtcc(entitySrcInfo.getPdbx_gene_src_atcc());
+		c.setCell(entitySrcInfo.getPdbx_gene_src_cell());
+		c.setOrganismCommon(entitySrcInfo.getGene_src_common_name());
+		c.setOrganismScientific(entitySrcInfo.getPdbx_gene_src_scientific_name());
+		c.setOrganismTaxId(entitySrcInfo.getPdbx_gene_src_ncbi_taxonomy_id());
+		c.setExpressionSystemTaxId(entitySrcInfo.getPdbx_host_org_ncbi_taxonomy_id());
+		c.setExpressionSystem(entitySrcInfo.getPdbx_host_org_scientific_name());
 	}
 
-	private Compound createNewCompoundFromESN(EntitySrcNat esn, int eId) {
+	/**
+	 * Add the information to entity info from ESN.
+	 * @param esn
+	 * @param eId
+	 * @param c
+	 */
+	private void addInformationFromESN(EntitySrcNat esn, int eId, EntityInfo c) {
 
-		Compound c = new Compound();
-
-		c.setMolId(eId);
 		c.setAtcc(esn.getPdbx_atcc());
 		c.setCell(esn.getPdbx_cell());
 		c.setOrganismCommon(esn.getCommon_name());
 		c.setOrganismScientific(esn.getPdbx_organism_scientific());
 		c.setOrganismTaxId(esn.getPdbx_ncbi_taxonomy_id());
 
-		return c;
-
 	}
-
-	private Compound createNewCompoundFromESS(EntitySrcSyn ess, int eId) {
-
-		Compound c = new Compound();
-
-		c.setMolId(eId);
+	/**
+	 * Add the information from ESS to Entity info.
+	 * @param ess
+	 * @param eId
+	 * @param c
+	 */
+	private void addInfoFromESS(EntitySrcSyn ess, int eId, EntityInfo c) {
 		c.setOrganismCommon(ess.getOrganism_common_name());
 		c.setOrganismScientific(ess.getOrganism_scientific());
 		c.setOrganismTaxId(ess.getNcbi_taxonomy_id());
-
-
-		return c;
 
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -962,13 +962,13 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 					compound = new EntityInfo();
 					compound.setMolId(eId);
 					compound.addChain(chain);
-					chain.setCompound(compound);
-					structure.addCompound(compound);
+					chain.setEntityInfo(compound);
+					structure.addEntityInfo(compound);
 				} else {
 					logger.debug("Adding chain with chain id {} (asym id {}) to compound with entity_id {}",
 							chain.getChainID(), chain.getInternalChainID(), eId);
 					compound.addChain(chain);
-					chain.setCompound(compound);
+					chain.setEntityInfo(compound);
 				}
 
 			}
@@ -977,7 +977,7 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 
 		// to make sure we have Compounds linked to chains, we call getCompounds() which will lazily initialise the
 		// compounds using heuristics (see CompoundFinder) in the case that they were not explicitly present in the file
-		List<EntityInfo> compounds = structure.getEntityInformation();
+		List<EntityInfo> compounds = structure.getEntityInfos();
 
 		// final sanity check: it can happen that from the annotated compounds some are not linked to any chains
 		// e.g. 3s26: a sugar entity does not have any chains associated to it (it seems to be happening with many sugar compounds)
@@ -1127,7 +1127,7 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 				c.setDescription(e.getPdbx_description());
 				c.setType(e.getType());
 				addAnicilliaryEntityData(asym, eId, e, c);
-				structure.addCompound(c);
+				structure.addEntityInfo(c);
 				logger.debug("Adding Compound with entity id {} from _entity, with name: {}",eId, c.getDescription());
 			}
 		}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/PdbFileFormat30Test.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/PdbFileFormat30Test.java
@@ -58,7 +58,7 @@ public class PdbFileFormat30Test {
 		int shouldNr = 20;
 		assertEquals("structure does not contain the right number of nucleotides ", shouldNr ,nrNuc);
 
-		List<EntityInfo> compounds= s.getEntityInformation();
+		List<EntityInfo> compounds= s.getEntityInfos();
 		// from Biojava 4.2 on we are creating compounds whenever an entity is found to be without an assigned compound in the file
 		// see issues https://github.com/biojava/biojava/issues/305 and https://github.com/biojava/biojava/pull/394
 		assertEquals(2, compounds.size());
@@ -83,7 +83,7 @@ public class PdbFileFormat30Test {
 		int shouldNr = 24;
 		assertEquals("structure does not contain the right number of nucleotides ", shouldNr , nrNuc);
 
-		List<EntityInfo> compounds= s.getEntityInformation();
+		List<EntityInfo> compounds= s.getEntityInfos();
 		// from Biojava 4.2 on we are creating compounds whenever an entity is found to be without an assigned compound in the file
 		// see issues https://github.com/biojava/biojava/issues/305 and https://github.com/biojava/biojava/pull/394
 		assertEquals(2, compounds.size());
@@ -144,7 +144,7 @@ public class PdbFileFormat30Test {
 
 		Structure s = getStructure("/3mk3.pdb");
 
-		List<EntityInfo> compounds= s.getEntityInformation();
+		List<EntityInfo> compounds= s.getEntityInfos();
 		assertTrue(compounds.size() == 1);
 		EntityInfo mol = compounds.get(0);
 		assertTrue(mol.getDescription().equals("6,7-DIMETHYL-8-RIBITYLLUMAZINE SYNTHASE"));

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/PdbFileFormat30Test.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/PdbFileFormat30Test.java
@@ -58,12 +58,12 @@ public class PdbFileFormat30Test {
 		int shouldNr = 20;
 		assertEquals("structure does not contain the right number of nucleotides ", shouldNr ,nrNuc);
 
-		List<Compound> compounds= s.getCompounds();
+		List<EntityInfo> compounds= s.getEntityInformation();
 		// from Biojava 4.2 on we are creating compounds whenever an entity is found to be without an assigned compound in the file
 		// see issues https://github.com/biojava/biojava/issues/305 and https://github.com/biojava/biojava/pull/394
 		assertEquals(2, compounds.size());
-		Compound mol = compounds.get(0);
-		assertTrue(mol.getMolName().startsWith("DNA"));
+		EntityInfo mol = compounds.get(0);
+		assertTrue(mol.getDescription().startsWith("DNA"));
 
 
 		Structure s2 = getStructure("/104D_v30.pdb");
@@ -83,13 +83,13 @@ public class PdbFileFormat30Test {
 		int shouldNr = 24;
 		assertEquals("structure does not contain the right number of nucleotides ", shouldNr , nrNuc);
 
-		List<Compound> compounds= s.getCompounds();
+		List<EntityInfo> compounds= s.getEntityInformation();
 		// from Biojava 4.2 on we are creating compounds whenever an entity is found to be without an assigned compound in the file
 		// see issues https://github.com/biojava/biojava/issues/305 and https://github.com/biojava/biojava/pull/394
 		assertEquals(2, compounds.size());
-		Compound mol = compounds.get(0);
+		EntityInfo mol = compounds.get(0);
 
-		assertTrue(mol.getMolName().startsWith("DNA"));
+		assertTrue(mol.getDescription().startsWith("DNA"));
 
 
 		Structure s2 = getStructure("/104D_v23.pdb");
@@ -144,10 +144,10 @@ public class PdbFileFormat30Test {
 
 		Structure s = getStructure("/3mk3.pdb");
 
-		List<Compound> compounds= s.getCompounds();
+		List<EntityInfo> compounds= s.getEntityInformation();
 		assertTrue(compounds.size() == 1);
-		Compound mol = compounds.get(0);
-		assertTrue(mol.getMolName().equals("6,7-DIMETHYL-8-RIBITYLLUMAZINE SYNTHASE"));
+		EntityInfo mol = compounds.get(0);
+		assertTrue(mol.getDescription().equals("6,7-DIMETHYL-8-RIBITYLLUMAZINE SYNTHASE"));
 		assertEquals(60, mol.getChainIds().size());
 		assertEquals(60, mol.getChains().size());
 		assertTrue(mol.getChainIds().contains("S"));

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/SourceCompoundTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/SourceCompoundTest.java
@@ -51,8 +51,8 @@ public class SourceCompoundTest extends TestCase{
 	public void testCompoundSourceStructure(){
 
 		Structure s2 = getStructure("/2gox.pdb");
-		assertEquals(2, s2.getEntityInformation().size());
-		for (EntityInfo compound : s2.getEntityInformation()){
+		assertEquals(2, s2.getEntityInfos().size());
+		for (EntityInfo compound : s2.getEntityInfos()){
 			if (compound.getMolId()==1) {
 				assertEquals("COMPLEMENT C3", compound.getDescription());
 				assertEquals("[A, C]", compound.getChainIds().toString());
@@ -91,14 +91,14 @@ public class SourceCompoundTest extends TestCase{
 
 		// this file has a CHAIN: string in the value for the FRAGMENT: filed which breaks the version 1.4 parser
 
-		for (EntityInfo compound : s2.getEntityInformation()) {
+		for (EntityInfo compound : s2.getEntityInfos()) {
 			if (compound.getMolId()==1) {
 				assertEquals("FRAGMENT OF ALPHA CHAIN: RESIDUES 996-1287", compound.getFragment());
 			}
 
 		}
 
-		for (EntityInfo compound : s4.getEntityInformation()) {
+		for (EntityInfo compound : s4.getEntityInfos()) {
 			if (compound.getMolId()==1) {
 				assertEquals("SIGNAL RECEIVER DOMAIN: RESIDUES 2-128", compound.getFragment());
 			}
@@ -109,8 +109,8 @@ public class SourceCompoundTest extends TestCase{
 
 	public void testCOMPNDsectionCHAINS(){
 		Structure s3 = getStructure("/2pos.pdb");
-		assertEquals(1, s3.getEntityInformation().size());
-		for (EntityInfo compound : s3.getEntityInformation()){
+		assertEquals(1, s3.getEntityInfos().size());
+		for (EntityInfo compound : s3.getEntityInfos()){
 			/*System.out.println(compound.getMolId());
 			System.out.println(compound.getMolName());
 			System.out.println(compound.getChainId().toString());
@@ -128,7 +128,7 @@ public class SourceCompoundTest extends TestCase{
 
 	public void testSOURCEsectionSTRAIN(){
 		Structure s4 = getStructure("/3cfy.pdb");
-		for (EntityInfo compound : s4.getEntityInformation()){
+		for (EntityInfo compound : s4.getEntityInfos()){
 			if (compound.getMolId()==1) {
 				/*System.out.println(compound.getMolId());
 				System.out.println(compound.getMolName());
@@ -164,7 +164,7 @@ public class SourceCompoundTest extends TestCase{
 
 	public void testSOURCEsectionORGSCI(){
 		Structure s5 = getStructure("/3cdl.pdb");
-		for (EntityInfo compound : s5.getEntityInformation()){
+		for (EntityInfo compound : s5.getEntityInfos()){
 			if (compound.getMolId()==1) {
 				//System.out.println(compound.getOrganismScientific());
 				assertEquals("PSEUDOMONAS SYRINGAE PV. TOMATO STR. DC3000", compound.getOrganismScientific());

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/SourceCompoundTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/SourceCompoundTest.java
@@ -51,10 +51,10 @@ public class SourceCompoundTest extends TestCase{
 	public void testCompoundSourceStructure(){
 
 		Structure s2 = getStructure("/2gox.pdb");
-		assertEquals(2, s2.getCompounds().size());
-		for (Compound compound : s2.getCompounds()){
+		assertEquals(2, s2.getEntityInformation().size());
+		for (EntityInfo compound : s2.getEntityInformation()){
 			if (compound.getMolId()==1) {
-				assertEquals("COMPLEMENT C3", compound.getMolName());
+				assertEquals("COMPLEMENT C3", compound.getDescription());
 				assertEquals("[A, C]", compound.getChainIds().toString());
 				assertEquals("FRAGMENT OF ALPHA CHAIN: RESIDUES 996-1287", compound.getFragment());
 				assertEquals("YES", compound.getEngineered());
@@ -68,7 +68,7 @@ public class SourceCompoundTest extends TestCase{
 				assertEquals("PT7-", compound.getExpressionSystemPlasmid());
 			}
 			if (compound.getMolId()==2) {
-				assertEquals("FIBRINOGEN-BINDING PROTEIN", compound.getMolName());
+				assertEquals("FIBRINOGEN-BINDING PROTEIN", compound.getDescription());
 				assertEquals("[B, D]", compound.getChainIds().toString());
 				assertEquals("C-TERMINAL DOMAIN: RESIDUES 101-165", compound.getFragment());
 				assertEquals("YES", compound.getEngineered());
@@ -91,14 +91,14 @@ public class SourceCompoundTest extends TestCase{
 
 		// this file has a CHAIN: string in the value for the FRAGMENT: filed which breaks the version 1.4 parser
 
-		for (Compound compound : s2.getCompounds()) {
+		for (EntityInfo compound : s2.getEntityInformation()) {
 			if (compound.getMolId()==1) {
 				assertEquals("FRAGMENT OF ALPHA CHAIN: RESIDUES 996-1287", compound.getFragment());
 			}
 
 		}
 
-		for (Compound compound : s4.getCompounds()) {
+		for (EntityInfo compound : s4.getEntityInformation()) {
 			if (compound.getMolId()==1) {
 				assertEquals("SIGNAL RECEIVER DOMAIN: RESIDUES 2-128", compound.getFragment());
 			}
@@ -109,8 +109,8 @@ public class SourceCompoundTest extends TestCase{
 
 	public void testCOMPNDsectionCHAINS(){
 		Structure s3 = getStructure("/2pos.pdb");
-		assertEquals(1, s3.getCompounds().size());
-		for (Compound compound : s3.getCompounds()){
+		assertEquals(1, s3.getEntityInformation().size());
+		for (EntityInfo compound : s3.getEntityInformation()){
 			/*System.out.println(compound.getMolId());
 			System.out.println(compound.getMolName());
 			System.out.println(compound.getChainId().toString());
@@ -118,7 +118,7 @@ public class SourceCompoundTest extends TestCase{
 			System.out.println(compound.getStrain());
 	*/
 			assertEquals(1, compound.getMolId());
-			assertEquals("SYLVATICIN", compound.getMolName());
+			assertEquals("SYLVATICIN", compound.getDescription());
 			assertEquals("[A, B, C, D]", compound.getChainIds().toString());
 			assertEquals("PYTHIUM SYLVATICUM", compound.getOrganismScientific());
 			assertEquals("STRAIN 37", compound.getStrain());
@@ -128,7 +128,7 @@ public class SourceCompoundTest extends TestCase{
 
 	public void testSOURCEsectionSTRAIN(){
 		Structure s4 = getStructure("/3cfy.pdb");
-		for (Compound compound : s4.getCompounds()){
+		for (EntityInfo compound : s4.getEntityInformation()){
 			if (compound.getMolId()==1) {
 				/*System.out.println(compound.getMolId());
 				System.out.println(compound.getMolName());
@@ -145,7 +145,7 @@ public class SourceCompoundTest extends TestCase{
 				System.out.println(compound.getExpressionSystemPlasmid());
 				 */
 				assertEquals(1, compound.getMolId());
-				assertEquals("PUTATIVE LUXO REPRESSOR PROTEIN", compound.getMolName());
+				assertEquals("PUTATIVE LUXO REPRESSOR PROTEIN", compound.getDescription());
 				assertEquals("[A]", compound.getChainIds().toString());
 				assertEquals("SIGNAL RECEIVER DOMAIN: RESIDUES 2-128", compound.getFragment());
 				assertEquals("YES", compound.getEngineered());
@@ -164,7 +164,7 @@ public class SourceCompoundTest extends TestCase{
 
 	public void testSOURCEsectionORGSCI(){
 		Structure s5 = getStructure("/3cdl.pdb");
-		for (Compound compound : s5.getCompounds()){
+		for (EntityInfo compound : s5.getEntityInformation()){
 			if (compound.getMolId()==1) {
 				//System.out.println(compound.getOrganismScientific());
 				assertEquals("PSEUDOMONAS SYRINGAE PV. TOMATO STR. DC3000", compound.getOrganismScientific());
@@ -181,7 +181,7 @@ public class SourceCompoundTest extends TestCase{
 	public void testSourceTaxIdVersion32File(){
 		Structure structure = getStructure("/3dl7_v32.pdb");
 
-		Compound comp = structure.getCompoundById(1);
+		EntityInfo comp = structure.getCompoundById(1);
 
 		comp.showSource();
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundHeuristics.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundHeuristics.java
@@ -53,28 +53,28 @@ public class TestCompoundHeuristics {
 
 		Structure s = getStructure("1b8g_raw.pdb.gz", true);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		Chain chainA = s.getChainByPDB("A");
 
-		assertEquals(2, chainA.getCompound().getChains().size());
+		assertEquals(2, chainA.getEntityInfo().getChains().size());
 
-		assertEquals(chainA,chainA.getCompound().getRepresentative());
+		assertEquals(chainA,chainA.getEntityInfo().getRepresentative());
 
-		checkCompoundsNumbered(s.getEntityInformation());
+		checkCompoundsNumbered(s.getEntityInfos());
 
 
 		s = getStructure("1b8g_raw.pdb.gz", false);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		chainA = s.getChainByPDB("A");
 
-		assertEquals(2, chainA.getCompound().getChains().size());
+		assertEquals(2, chainA.getEntityInfo().getChains().size());
 
-		assertEquals(chainA,chainA.getCompound().getRepresentative());
+		assertEquals(chainA,chainA.getEntityInfo().getRepresentative());
 
-		checkCompoundsNumbered(s.getEntityInformation());
+		checkCompoundsNumbered(s.getEntityInfos());
 	}
 
 
@@ -83,28 +83,28 @@ public class TestCompoundHeuristics {
 
 		Structure s = getStructure("2m7y_raw.pdb.gz", true);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		Chain chainA = s.getChainByPDB("A");
 
-		assertEquals(1, chainA.getCompound().getChains().size());
+		assertEquals(1, chainA.getEntityInfo().getChains().size());
 
-		assertEquals(chainA,chainA.getCompound().getRepresentative());
+		assertEquals(chainA,chainA.getEntityInfo().getRepresentative());
 
-		checkCompoundsNumbered(s.getEntityInformation());
+		checkCompoundsNumbered(s.getEntityInfos());
 
 
 		s = getStructure("2m7y_raw.pdb.gz", false);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		chainA = s.getChainByPDB("A");
 
-		assertEquals(1, chainA.getCompound().getChains().size());
+		assertEquals(1, chainA.getEntityInfo().getChains().size());
 
-		assertEquals(chainA,chainA.getCompound().getRepresentative());
+		assertEquals(chainA,chainA.getEntityInfo().getRepresentative());
 
-		checkCompoundsNumbered(s.getEntityInformation());
+		checkCompoundsNumbered(s.getEntityInfos());
 	}
 
 	@Test
@@ -112,28 +112,28 @@ public class TestCompoundHeuristics {
 
 		Structure s = getStructure("3c5f_raw.pdb.gz", true);
 
-		assertEquals(4,s.getEntityInformation().size());
+		assertEquals(4,s.getEntityInfos().size());
 
 		Chain chainA = s.getChainByPDB("A");
 
-		assertEquals(2, chainA.getCompound().getChains().size());
+		assertEquals(2, chainA.getEntityInfo().getChains().size());
 
-		assertEquals(chainA,chainA.getCompound().getRepresentative());
+		assertEquals(chainA,chainA.getEntityInfo().getRepresentative());
 
-		checkCompoundsNumbered(s.getEntityInformation());
+		checkCompoundsNumbered(s.getEntityInfos());
 
 
 		s = getStructure("3c5f_raw.pdb.gz", false);
 
-		assertEquals(4,s.getEntityInformation().size());
+		assertEquals(4,s.getEntityInfos().size());
 
 		chainA = s.getChainByPDB("A");
 
-		assertEquals(2, chainA.getCompound().getChains().size());
+		assertEquals(2, chainA.getEntityInfo().getChains().size());
 
-		assertEquals(chainA,chainA.getCompound().getRepresentative());
+		assertEquals(chainA,chainA.getEntityInfo().getRepresentative());
 
-		checkCompoundsNumbered(s.getEntityInformation());
+		checkCompoundsNumbered(s.getEntityInfos());
 	}
 
 	@Test
@@ -141,28 +141,28 @@ public class TestCompoundHeuristics {
 
 		Structure s = getStructure("4b19_raw.pdb.gz", true);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		Chain chainA = s.getChainByPDB("A");
 
-		assertEquals(1, chainA.getCompound().getChains().size());
+		assertEquals(1, chainA.getEntityInfo().getChains().size());
 
-		assertEquals(chainA,chainA.getCompound().getRepresentative());
+		assertEquals(chainA,chainA.getEntityInfo().getRepresentative());
 
-		checkCompoundsNumbered(s.getEntityInformation());
+		checkCompoundsNumbered(s.getEntityInfos());
 
 
 		s = getStructure("4b19_raw.pdb.gz", false);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		chainA = s.getChainByPDB("A");
 
-		assertEquals(1, chainA.getCompound().getChains().size());
+		assertEquals(1, chainA.getEntityInfo().getChains().size());
 
-		assertEquals(chainA,chainA.getCompound().getRepresentative());
+		assertEquals(chainA,chainA.getEntityInfo().getRepresentative());
 
-		checkCompoundsNumbered(s.getEntityInformation());
+		checkCompoundsNumbered(s.getEntityInfos());
 
 	}
 
@@ -178,7 +178,7 @@ public class TestCompoundHeuristics {
 		assertEquals(6, s.getChains().size());
 
 		// checking that heuristics in CompoundFinder work. We should have a single entity (compound)
-		assertEquals(1, s.getEntityInformation().size());
+		assertEquals(1, s.getEntityInfos().size());
 
 		// trying without seqAlignSeqRes
 		s = getStructure("3ddo_raw_noseqres.pdb.gz", false);
@@ -186,7 +186,7 @@ public class TestCompoundHeuristics {
 
 		assertEquals(6, s.getChains().size());
 
-		assertEquals(1, s.getEntityInformation().size());
+		assertEquals(1, s.getEntityInfos().size());
 	}
 
 	@Test
@@ -201,7 +201,7 @@ public class TestCompoundHeuristics {
 		assertEquals(6, s.getChains().size());
 
 		// checking that heuristics in CompoundFinder work. We should have a single entity (compound)
-		assertEquals(1, s.getEntityInformation().size());
+		assertEquals(1, s.getEntityInfos().size());
 
 		// trying without seqAlignSeqRes
 		s = getStructure("3ddo_raw_trunc_seqres.pdb.gz", true);
@@ -209,7 +209,7 @@ public class TestCompoundHeuristics {
 
 		assertEquals(6, s.getChains().size());
 
-		assertEquals(1, s.getEntityInformation().size());
+		assertEquals(1, s.getEntityInfos().size());
 	}
 
 
@@ -224,7 +224,7 @@ public class TestCompoundHeuristics {
 		Structure s = pdbpars.parsePDBFile(inStream) ;
 
 		System.out.println("Entities for file: "+fileName);
-		for (EntityInfo ent:s.getEntityInformation()) {
+		for (EntityInfo ent:s.getEntityInfos()) {
 			System.out.print(ent.getRepresentative().getChainID()+":");
 			for (Chain c:ent.getChains()) {
 				System.out.print(" "+c.getChainID());

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundHeuristics.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundHeuristics.java
@@ -53,7 +53,7 @@ public class TestCompoundHeuristics {
 
 		Structure s = getStructure("1b8g_raw.pdb.gz", true);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		Chain chainA = s.getChainByPDB("A");
 
@@ -61,12 +61,12 @@ public class TestCompoundHeuristics {
 
 		assertEquals(chainA,chainA.getCompound().getRepresentative());
 
-		checkCompoundsNumbered(s.getCompounds());
+		checkCompoundsNumbered(s.getEntityInformation());
 
 
 		s = getStructure("1b8g_raw.pdb.gz", false);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		chainA = s.getChainByPDB("A");
 
@@ -74,7 +74,7 @@ public class TestCompoundHeuristics {
 
 		assertEquals(chainA,chainA.getCompound().getRepresentative());
 
-		checkCompoundsNumbered(s.getCompounds());
+		checkCompoundsNumbered(s.getEntityInformation());
 	}
 
 
@@ -83,7 +83,7 @@ public class TestCompoundHeuristics {
 
 		Structure s = getStructure("2m7y_raw.pdb.gz", true);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		Chain chainA = s.getChainByPDB("A");
 
@@ -91,12 +91,12 @@ public class TestCompoundHeuristics {
 
 		assertEquals(chainA,chainA.getCompound().getRepresentative());
 
-		checkCompoundsNumbered(s.getCompounds());
+		checkCompoundsNumbered(s.getEntityInformation());
 
 
 		s = getStructure("2m7y_raw.pdb.gz", false);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		chainA = s.getChainByPDB("A");
 
@@ -104,7 +104,7 @@ public class TestCompoundHeuristics {
 
 		assertEquals(chainA,chainA.getCompound().getRepresentative());
 
-		checkCompoundsNumbered(s.getCompounds());
+		checkCompoundsNumbered(s.getEntityInformation());
 	}
 
 	@Test
@@ -112,7 +112,7 @@ public class TestCompoundHeuristics {
 
 		Structure s = getStructure("3c5f_raw.pdb.gz", true);
 
-		assertEquals(4,s.getCompounds().size());
+		assertEquals(4,s.getEntityInformation().size());
 
 		Chain chainA = s.getChainByPDB("A");
 
@@ -120,12 +120,12 @@ public class TestCompoundHeuristics {
 
 		assertEquals(chainA,chainA.getCompound().getRepresentative());
 
-		checkCompoundsNumbered(s.getCompounds());
+		checkCompoundsNumbered(s.getEntityInformation());
 
 
 		s = getStructure("3c5f_raw.pdb.gz", false);
 
-		assertEquals(4,s.getCompounds().size());
+		assertEquals(4,s.getEntityInformation().size());
 
 		chainA = s.getChainByPDB("A");
 
@@ -133,7 +133,7 @@ public class TestCompoundHeuristics {
 
 		assertEquals(chainA,chainA.getCompound().getRepresentative());
 
-		checkCompoundsNumbered(s.getCompounds());
+		checkCompoundsNumbered(s.getEntityInformation());
 	}
 
 	@Test
@@ -141,7 +141,7 @@ public class TestCompoundHeuristics {
 
 		Structure s = getStructure("4b19_raw.pdb.gz", true);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		Chain chainA = s.getChainByPDB("A");
 
@@ -149,12 +149,12 @@ public class TestCompoundHeuristics {
 
 		assertEquals(chainA,chainA.getCompound().getRepresentative());
 
-		checkCompoundsNumbered(s.getCompounds());
+		checkCompoundsNumbered(s.getEntityInformation());
 
 
 		s = getStructure("4b19_raw.pdb.gz", false);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		chainA = s.getChainByPDB("A");
 
@@ -162,7 +162,7 @@ public class TestCompoundHeuristics {
 
 		assertEquals(chainA,chainA.getCompound().getRepresentative());
 
-		checkCompoundsNumbered(s.getCompounds());
+		checkCompoundsNumbered(s.getEntityInformation());
 
 	}
 
@@ -178,7 +178,7 @@ public class TestCompoundHeuristics {
 		assertEquals(6, s.getChains().size());
 
 		// checking that heuristics in CompoundFinder work. We should have a single entity (compound)
-		assertEquals(1, s.getCompounds().size());
+		assertEquals(1, s.getEntityInformation().size());
 
 		// trying without seqAlignSeqRes
 		s = getStructure("3ddo_raw_noseqres.pdb.gz", false);
@@ -186,7 +186,7 @@ public class TestCompoundHeuristics {
 
 		assertEquals(6, s.getChains().size());
 
-		assertEquals(1, s.getCompounds().size());
+		assertEquals(1, s.getEntityInformation().size());
 	}
 
 	@Test
@@ -201,7 +201,7 @@ public class TestCompoundHeuristics {
 		assertEquals(6, s.getChains().size());
 
 		// checking that heuristics in CompoundFinder work. We should have a single entity (compound)
-		assertEquals(1, s.getCompounds().size());
+		assertEquals(1, s.getEntityInformation().size());
 
 		// trying without seqAlignSeqRes
 		s = getStructure("3ddo_raw_trunc_seqres.pdb.gz", true);
@@ -209,7 +209,7 @@ public class TestCompoundHeuristics {
 
 		assertEquals(6, s.getChains().size());
 
-		assertEquals(1, s.getCompounds().size());
+		assertEquals(1, s.getEntityInformation().size());
 	}
 
 
@@ -224,7 +224,7 @@ public class TestCompoundHeuristics {
 		Structure s = pdbpars.parsePDBFile(inStream) ;
 
 		System.out.println("Entities for file: "+fileName);
-		for (Compound ent:s.getCompounds()) {
+		for (EntityInfo ent:s.getEntityInformation()) {
 			System.out.print(ent.getRepresentative().getChainID()+":");
 			for (Chain c:ent.getChains()) {
 				System.out.print(" "+c.getChainID());
@@ -235,18 +235,18 @@ public class TestCompoundHeuristics {
 		return s;
 	}
 
-	private void checkCompoundsNumbered(List<Compound> compounds) {
+	private void checkCompoundsNumbered(List<EntityInfo> compounds) {
 
-		Collections.sort(compounds, new Comparator<Compound>() {
+		Collections.sort(compounds, new Comparator<EntityInfo>() {
 
 			@Override
-			public int compare(Compound o1, Compound o2) {
+			public int compare(EntityInfo o1, EntityInfo o2) {
 				return new Integer(o1.getMolId()).compareTo(o2.getMolId());
 			}
 		});
 
 		int id = 1;
-		for (Compound compound:compounds) {
+		for (EntityInfo compound:compounds) {
 			assertEquals(id,compound.getMolId());
 			id++;
 		}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundResIndexMapping.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundResIndexMapping.java
@@ -51,7 +51,7 @@ public class TestCompoundResIndexMapping {
 		Structure s = StructureIO.getStructure("1B8G");
 
 		Chain chainA = s.getChainByPDB("A");
-		int i = chainA.getCompound().getAlignedResIndex(chainA.getAtomGroup(0),chainA);
+		int i = chainA.getEntityInfo().getAlignedResIndex(chainA.getAtomGroup(0),chainA);
 		assertEquals("First residue in 1b8gA "+chainA.getAtomGroup(0).toString()+" should map to 1 in SEQRES",1,i);
 
 		checkAllResidues(s);
@@ -74,10 +74,10 @@ public class TestCompoundResIndexMapping {
 		Structure s = StructureIO.getStructure("1SMT");
 
 		Chain chainA = s.getChainByPDB("A");
-		int i = chainA.getCompound().getAlignedResIndex(chainA.getAtomGroup(0),chainA);
+		int i = chainA.getEntityInfo().getAlignedResIndex(chainA.getAtomGroup(0),chainA);
 		assertEquals("First residue in 1smtA "+chainA.getAtomGroup(0).toString()+" should map to 24 in SEQRES",24,i);
 		Chain chainB = s.getChainByPDB("B");
-		i = chainB.getCompound().getAlignedResIndex(chainB.getAtomGroup(0),chainB);
+		i = chainB.getEntityInfo().getAlignedResIndex(chainB.getAtomGroup(0),chainB);
 		assertEquals("First residue in 1smtB "+chainA.getAtomGroup(0).toString()+" should map to 20 in SEQRES",20,i);
 
 		checkAllResidues(s);
@@ -88,7 +88,7 @@ public class TestCompoundResIndexMapping {
 			for (Group g:c.getAtomGroups()) {
 				if (g.getType() != GroupType.AMINOACID) continue;
 
-				int resIndex = c.getCompound().getAlignedResIndex(g, c);
+				int resIndex = c.getEntityInfo().getAlignedResIndex(g, c);
 				assertNotEquals("Residue "+g.getResidueNumber()+" should not map to -1 in SEQRES",-1, resIndex);
 				assertNotEquals("Residue "+g.getResidueNumber()+" should not map to 0 in SEQRES",0, resIndex);
 				assertTrue(resIndex <= c.getSeqResLength());
@@ -107,7 +107,7 @@ public class TestCompoundResIndexMapping {
 		// 3ddo has 6 chains in 1 entity, all of them with different residue numbering (chain A is 1000+, chain B 2000+ ...)
 		Structure s = getStructure("3ddo_raw_noseqres.pdb.gz", true);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		Chain chainA = s.getChainByPDB("A");
 		Chain chainB = s.getChainByPDB("B");
@@ -116,13 +116,13 @@ public class TestCompoundResIndexMapping {
 		// the last 3 residues of each chain are all the same: they should map to the same index
 		for (int resNum=251;resNum<=253;resNum++) {
 			Group groupInChainA = chainA.getGroupByPDB(new ResidueNumber("A", resNum+1000, null));
-			int indexInChainA = chainA.getCompound().getAlignedResIndex(groupInChainA, chainA);
+			int indexInChainA = chainA.getEntityInfo().getAlignedResIndex(groupInChainA, chainA);
 
 			Group groupInChainB = chainB.getGroupByPDB(new ResidueNumber("B", resNum+2000, null));
-			int indexInChainB = chainB.getCompound().getAlignedResIndex(groupInChainB, chainB);
+			int indexInChainB = chainB.getEntityInfo().getAlignedResIndex(groupInChainB, chainB);
 
 			Group groupInChainC = chainC.getGroupByPDB(new ResidueNumber("C", resNum+3000, null));
-			int indexInChainC = chainC.getCompound().getAlignedResIndex(groupInChainC, chainC);
+			int indexInChainC = chainC.getEntityInfo().getAlignedResIndex(groupInChainC, chainC);
 
 			assertNotEquals(-1, indexInChainA);
 			assertNotEquals(-1, indexInChainB);
@@ -137,7 +137,7 @@ public class TestCompoundResIndexMapping {
 		// this should work either with or without setAlignSeqRes, since the mapping happens in CompoundFinder
 		s = getStructure("3ddo_raw_noseqres.pdb.gz", false);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		chainA = s.getChainByPDB("A");
 		chainB = s.getChainByPDB("B");
@@ -146,13 +146,13 @@ public class TestCompoundResIndexMapping {
 		// the last 3 residues of each chain are all the same: they should map to the same index
 		for (int resNum=251;resNum<=253;resNum++) {
 			Group groupInChainA = chainA.getGroupByPDB(new ResidueNumber("A", resNum+1000, null));
-			int indexInChainA = chainA.getCompound().getAlignedResIndex(groupInChainA, chainA);
+			int indexInChainA = chainA.getEntityInfo().getAlignedResIndex(groupInChainA, chainA);
 
 			Group groupInChainB = chainB.getGroupByPDB(new ResidueNumber("B", resNum+2000, null));
-			int indexInChainB = chainB.getCompound().getAlignedResIndex(groupInChainB, chainB);
+			int indexInChainB = chainB.getEntityInfo().getAlignedResIndex(groupInChainB, chainB);
 
 			Group groupInChainC = chainC.getGroupByPDB(new ResidueNumber("C", resNum+3000, null));
-			int indexInChainC = chainC.getCompound().getAlignedResIndex(groupInChainC, chainC);
+			int indexInChainC = chainC.getEntityInfo().getAlignedResIndex(groupInChainC, chainC);
 
 			assertNotEquals(-1, indexInChainA);
 			assertNotEquals(-1, indexInChainB);
@@ -171,7 +171,7 @@ public class TestCompoundResIndexMapping {
 		// 3ddo has 6 chains in 1 entity, all of them with different residue numbering (chain A is 1000+, chain B 2000+ ...)
 		Structure s = getStructure("3ddo_raw_trunc_seqres.pdb.gz", true);
 
-		assertEquals(1,s.getEntityInformation().size());
+		assertEquals(1,s.getEntityInfos().size());
 
 		Chain chainA = s.getChainByPDB("A");
 		Chain chainB = s.getChainByPDB("B");
@@ -180,13 +180,13 @@ public class TestCompoundResIndexMapping {
 		// the last 3 residues of each chain are all the same: they should map to the same index
 		for (int resNum=28;resNum<=30;resNum++) {
 			Group groupInChainA = chainA.getGroupByPDB(new ResidueNumber("A", resNum+1000, null));
-			int indexInChainA = chainA.getCompound().getAlignedResIndex(groupInChainA, chainA);
+			int indexInChainA = chainA.getEntityInfo().getAlignedResIndex(groupInChainA, chainA);
 
 			Group groupInChainB = chainB.getGroupByPDB(new ResidueNumber("B", resNum+2000, null));
-			int indexInChainB = chainB.getCompound().getAlignedResIndex(groupInChainB, chainB);
+			int indexInChainB = chainB.getEntityInfo().getAlignedResIndex(groupInChainB, chainB);
 
 			Group groupInChainC = chainC.getGroupByPDB(new ResidueNumber("C", resNum+3000, null));
-			int indexInChainC = chainC.getCompound().getAlignedResIndex(groupInChainC, chainC);
+			int indexInChainC = chainC.getEntityInfo().getAlignedResIndex(groupInChainC, chainC);
 
 			assertNotEquals(-1, indexInChainA);
 			assertNotEquals(-1, indexInChainB);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundResIndexMapping.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCompoundResIndexMapping.java
@@ -107,7 +107,7 @@ public class TestCompoundResIndexMapping {
 		// 3ddo has 6 chains in 1 entity, all of them with different residue numbering (chain A is 1000+, chain B 2000+ ...)
 		Structure s = getStructure("3ddo_raw_noseqres.pdb.gz", true);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		Chain chainA = s.getChainByPDB("A");
 		Chain chainB = s.getChainByPDB("B");
@@ -137,7 +137,7 @@ public class TestCompoundResIndexMapping {
 		// this should work either with or without setAlignSeqRes, since the mapping happens in CompoundFinder
 		s = getStructure("3ddo_raw_noseqres.pdb.gz", false);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		chainA = s.getChainByPDB("A");
 		chainB = s.getChainByPDB("B");
@@ -171,7 +171,7 @@ public class TestCompoundResIndexMapping {
 		// 3ddo has 6 chains in 1 entity, all of them with different residue numbering (chain A is 1000+, chain B 2000+ ...)
 		Structure s = getStructure("3ddo_raw_trunc_seqres.pdb.gz", true);
 
-		assertEquals(1,s.getCompounds().size());
+		assertEquals(1,s.getEntityInformation().size());
 
 		Chain chainA = s.getChainByPDB("A");
 		Chain chainB = s.getChainByPDB("B");

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestStructureCrossReferences.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestStructureCrossReferences.java
@@ -205,7 +205,7 @@ public class TestStructureCrossReferences {
 		}
 
 		// compounds linking
-		for (Compound compound:s.getCompounds()) {
+		for (EntityInfo compound:s.getEntityInformation()) {
 			for (Chain c:compound.getChains()) {
 				assertSame(compound, c.getCompound());
 				int count = 0;

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestStructureCrossReferences.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestStructureCrossReferences.java
@@ -205,9 +205,9 @@ public class TestStructureCrossReferences {
 		}
 
 		// compounds linking
-		for (EntityInfo compound:s.getEntityInformation()) {
+		for (EntityInfo compound:s.getEntityInfos()) {
 			for (Chain c:compound.getChains()) {
-				assertSame(compound, c.getCompound());
+				assertSame(compound, c.getEntityInfo());
 				int count = 0;
 				for (int modelNr=0;modelNr<s.nrModels();modelNr++) {
 					// the chain must be matched by 1 and only 1 chain from all models
@@ -221,7 +221,7 @@ public class TestStructureCrossReferences {
 
 	private void testChainRefs(Chain c, boolean emptySeqRes) {
 
-		assertNotNull(c.getCompound());
+		assertNotNull(c.getEntityInfo());
 
 		for (Group g:c.getAtomGroups()) {
 			assertSame("Failed parent chain for group "+g.toString(), c, g.getChain());
@@ -268,11 +268,11 @@ public class TestStructureCrossReferences {
 	private void testInterfaceRefs(Structure s, StructureInterface i) throws StructureException {
 
 		for (Atom a:i.getMolecules().getFirst()) {
-			assertNotNull(a.getGroup().getChain().getCompound());
+			assertNotNull(a.getGroup().getChain().getEntityInfo());
 		}
 
 		for (Atom a:i.getMolecules().getSecond()) {
-			assertNotNull(a.getGroup().getChain().getCompound());
+			assertNotNull(a.getGroup().getChain().getEntityInfo());
 		}
 
 	}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMcifOrganismParsing.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMcifOrganismParsing.java
@@ -24,7 +24,7 @@
 package org.biojava.nbio.structure.io;
 
 
-import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
@@ -89,10 +89,10 @@ public class TestMMcifOrganismParsing {
 	private void checkPDB(String pdbId) throws IOException, StructureException {
 		Structure s = StructureIO.getStructure(pdbId);
 
-		assertNotNull(s.getCompounds());
-		assertTrue(s.getCompounds().size() > 0);
+		assertNotNull(s.getEntityInformation());
+		assertTrue(s.getEntityInformation().size() > 0);
 
-		for ( Compound c : s.getCompounds()) {
+		for ( EntityInfo c : s.getEntityInformation()) {
 			assertNotNull(c.getOrganismTaxId());
 		}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMcifOrganismParsing.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMcifOrganismParsing.java
@@ -85,8 +85,6 @@ public class TestMMcifOrganismParsing {
 	}
 
 
-
-
 	private void checkPDB(String pdbId, String organismTaxId) throws IOException, StructureException {
 		Structure s = StructureIO.getStructure(pdbId);
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMcifOrganismParsing.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMcifOrganismParsing.java
@@ -88,10 +88,10 @@ public class TestMMcifOrganismParsing {
 	private void checkPDB(String pdbId, String organismTaxId) throws IOException, StructureException {
 		Structure s = StructureIO.getStructure(pdbId);
 
-		assertNotNull(s.getEntityInformation());
-		assertTrue(s.getEntityInformation().size() > 0);
+		assertNotNull(s.getEntityInfos());
+		assertTrue(s.getEntityInfos().size() > 0);
 
-		for ( EntityInfo c : s.getEntityInformation()) {
+		for ( EntityInfo c : s.getEntityInfos()) {
 			if(c.getType().equals("polymer")) { 
 				assertNotNull(c.getOrganismTaxId());
 				if(pdbId.equals("3zd6")){

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMcifOrganismParsing.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMcifOrganismParsing.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -54,7 +55,7 @@ public class TestMMcifOrganismParsing {
 	public void test1STP() throws IOException, StructureException{
 		String pdbId = "1stp";
 
-		checkPDB(pdbId);
+		checkPDB(pdbId, "1895");
 
 	}
 
@@ -62,7 +63,7 @@ public class TestMMcifOrganismParsing {
 	public void test1a4w() throws IOException, StructureException{
 		String pdbId = "1a4w";
 
-		checkPDB(pdbId);
+		checkPDB(pdbId, "9606");
 
 	}
 
@@ -70,30 +71,40 @@ public class TestMMcifOrganismParsing {
 	public void test4hhb() throws IOException, StructureException{
 		String pdbId = "4hhb";
 
-		checkPDB(pdbId);
+		checkPDB(pdbId, "9606");
 
 	}
 
 	@Test
 	public void test3ZD6() throws IOException, StructureException {
 		// a PDB ID that contains a synthetic entity
-		String pdbId = "3ZD6";
+		String pdbId = "3zd6";
 
-		checkPDB(pdbId);
+		checkPDB(pdbId, "9606");
 
 	}
 
 
 
 
-	private void checkPDB(String pdbId) throws IOException, StructureException {
+	private void checkPDB(String pdbId, String organismTaxId) throws IOException, StructureException {
 		Structure s = StructureIO.getStructure(pdbId);
 
 		assertNotNull(s.getEntityInformation());
 		assertTrue(s.getEntityInformation().size() > 0);
 
 		for ( EntityInfo c : s.getEntityInformation()) {
-			assertNotNull(c.getOrganismTaxId());
+			if(c.getType().equals("polymer")) { 
+				assertNotNull(c.getOrganismTaxId());
+				if(pdbId.equals("3zd6")){
+					if(c.getMolId()==2) {
+						assertEquals(c.getOrganismTaxId(), "32630");
+						continue;
+					}
+				}
+				assertEquals(c.getOrganismTaxId(), organismTaxId);
+			
+			}
 		}
 
 	}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -86,7 +86,7 @@ public class TestNonDepositedFiles {
 		assertEquals(2,s.getChains().size());
 
 		// checking that heuristics in CompoundFinder work. We should have a single entity (compound)
-		assertEquals(1, s.getEntityInformation().size());
+		assertEquals(1, s.getEntityInfos().size());
 
 		//System.out.println("Chains from incomplete header file: ");
 		//checkChains(s);
@@ -101,7 +101,7 @@ public class TestNonDepositedFiles {
 
 		assertEquals(2,s.getChains().size());
 
-		assertEquals(1, s.getEntityInformation().size());
+		assertEquals(1, s.getEntityInfos().size());
 	}
 
 	//@Test
@@ -220,7 +220,7 @@ public class TestNonDepositedFiles {
 		assertEquals(6, s.getChains().size());
 
 		// 4 entities: 1 protein, 1 nucleotide, 1 water, 1 ligand (EDO)
-		assertEquals(4, s.getEntityInformation().size());
+		assertEquals(4, s.getEntityInfos().size());
 
 	}
 
@@ -243,7 +243,7 @@ public class TestNonDepositedFiles {
 		assertEquals(6, s.getChains().size());
 
 		// 4 entities: 1 protein, 1 nucleotide, 1 water, 1 ligand (EDO)
-		assertEquals(4, s.getEntityInformation().size());
+		assertEquals(4, s.getEntityInfos().size());
 	}
 
 	@Test
@@ -263,7 +263,7 @@ public class TestNonDepositedFiles {
 
 		assertEquals(2, s.getChains().size());
 
-		assertEquals(1, s.getEntityInformation().size());
+		assertEquals(1, s.getEntityInfos().size());
 	}
 
 
@@ -286,7 +286,7 @@ public class TestNonDepositedFiles {
 		assertEquals(3, s.getChains().size());
 
 		// 1 polymer entity, 1 water entity
-		assertEquals(2, s.getEntityInformation().size());
+		assertEquals(2, s.getEntityInfos().size());
 	}
 
 	/**
@@ -356,10 +356,10 @@ public class TestNonDepositedFiles {
 		}
 
 		// checking that compounds are linked
-		assertNotNull(c1.getCompound());
+		assertNotNull(c1.getEntityInfo());
 
 		// checking that the water molecule was assigned an ad-hoc compound
-		assertEquals(2,s1.getEntityInformation().size());
+		assertEquals(2,s1.getEntityInfos().size());
 
 
 
@@ -381,9 +381,9 @@ public class TestNonDepositedFiles {
 		}
 
 		// checking that compounds are linked
-		assertNotNull(c.getCompound());
+		assertNotNull(c.getEntityInfo());
 
 		// checking that the water molecule was assigned an ad-hoc compound
-		assertEquals(2,s2.getEntityInformation().size());
+		assertEquals(2,s2.getEntityInfos().size());
 	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -86,7 +86,7 @@ public class TestNonDepositedFiles {
 		assertEquals(2,s.getChains().size());
 
 		// checking that heuristics in CompoundFinder work. We should have a single entity (compound)
-		assertEquals(1, s.getCompounds().size());
+		assertEquals(1, s.getEntityInformation().size());
 
 		//System.out.println("Chains from incomplete header file: ");
 		//checkChains(s);
@@ -101,7 +101,7 @@ public class TestNonDepositedFiles {
 
 		assertEquals(2,s.getChains().size());
 
-		assertEquals(1, s.getCompounds().size());
+		assertEquals(1, s.getEntityInformation().size());
 	}
 
 	//@Test
@@ -220,7 +220,7 @@ public class TestNonDepositedFiles {
 		assertEquals(6, s.getChains().size());
 
 		// 4 entities: 1 protein, 1 nucleotide, 1 water, 1 ligand (EDO)
-		assertEquals(4, s.getCompounds().size());
+		assertEquals(4, s.getEntityInformation().size());
 
 	}
 
@@ -243,7 +243,7 @@ public class TestNonDepositedFiles {
 		assertEquals(6, s.getChains().size());
 
 		// 4 entities: 1 protein, 1 nucleotide, 1 water, 1 ligand (EDO)
-		assertEquals(4, s.getCompounds().size());
+		assertEquals(4, s.getEntityInformation().size());
 	}
 
 	@Test
@@ -263,7 +263,7 @@ public class TestNonDepositedFiles {
 
 		assertEquals(2, s.getChains().size());
 
-		assertEquals(1, s.getCompounds().size());
+		assertEquals(1, s.getEntityInformation().size());
 	}
 
 
@@ -286,7 +286,7 @@ public class TestNonDepositedFiles {
 		assertEquals(3, s.getChains().size());
 
 		// 1 polymer entity, 1 water entity
-		assertEquals(2, s.getCompounds().size());
+		assertEquals(2, s.getEntityInformation().size());
 	}
 
 	/**
@@ -359,7 +359,7 @@ public class TestNonDepositedFiles {
 		assertNotNull(c1.getCompound());
 
 		// checking that the water molecule was assigned an ad-hoc compound
-		assertEquals(2,s1.getCompounds().size());
+		assertEquals(2,s1.getEntityInformation().size());
 
 
 
@@ -384,6 +384,6 @@ public class TestNonDepositedFiles {
 		assertNotNull(c.getCompound());
 
 		// checking that the water molecule was assigned an ad-hoc compound
-		assertEquals(2,s2.getCompounds().size());
+		assertEquals(2,s2.getEntityInformation().size());
 	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestEntityNameAndType.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestEntityNameAndType.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertArrayEquals;
 import java.io.IOException;
 
 import org.biojava.nbio.structure.Chain;
-import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
@@ -37,7 +37,14 @@ public class TestEntityNameAndType {
 		StructureIO.setAtomCache(cache);
 		// This is hte information we want to test against
 		String[] typeInformation = new String[] {"polymer", "non-polymer", "non-polymer", "non-polymer", "non-polymer", "water"};
-		String[] descriptionInformation = new String[] {"BROMODOMAIN ADJACENT TO ZINC FINGER DOMAIN PROTEIN 2B","4-FLUOROBENZAMIDOXIME", "4-FLUOROBENZAMIDOXIME", "METHANOL", "METHANOL", "water"};	
+		String[] descriptionInformation = new String[] {"BROMODOMAIN ADJACENT TO ZINC FINGER DOMAIN PROTEIN 2B","4-FLUOROBENZAMIDOXIME",  "METHANOL", "METHANOL", "METHANOL", "water"};	
+		
+		// Now some other information fields to test this data is collated correctly
+		String[] geneSourceSciName = new String[] {"HOMO SAPIENS", null, null, null, null, null};
+		String[] geneSourceTaxId = new String[] {"9606", null, null, null, null, null};
+		String[] hostOrganismSciName = new String[] {"ESCHERICHIA COLI", null, null, null, null, null};
+		String[] hostOrganismTaxId = new String[] {"469008", null, null, null, null, null};		
+
 		
 		
 		/// TODO GET ALL THE ENTITY INFORMATION REQUIRED FOR 4CUP 
@@ -45,18 +52,35 @@ public class TestEntityNameAndType {
 		Structure bioJavaStruct = StructureIO.getStructure("4cup");
 		String[] testTypeInfo = new String[6];
 		String[] testDescInfo = new String[6];
+		
+		
+		String[] testGeneSourceSciName = new String[6];
+		String[] testGeneSourceTaxId = new String[6];
+		String[] testHostOrganismSciName = new String[6];
+		String[] testHostOrganismTaxId = new String[6];
+
 		// Now loop through the structure
 		int chainCounter = 0;
 		for (Chain c: bioJavaStruct.getChains()) {
 			// Now get the entity information we want to test
-			Compound thisCmpd = c.getCompound();
-//			testTypeInfo[chainCounter] = thisCmpd.get
-			testDescInfo[chainCounter] = thisCmpd.getMolName();
+			EntityInfo thisCmpd = c.getCompound();
+			testTypeInfo[chainCounter] = thisCmpd.getType();
+			testDescInfo[chainCounter] = thisCmpd.getDescription();
+			testGeneSourceSciName[chainCounter] =  thisCmpd.getOrganismScientific();
+			testGeneSourceTaxId[chainCounter] = thisCmpd.getOrganismTaxId();
+			testHostOrganismSciName[chainCounter] = thisCmpd.getExpressionSystem();
+			testHostOrganismTaxId[chainCounter] = thisCmpd.getExpressionSystemTaxId();
+
 			chainCounter++;
 		}
 		// Now check they're both the same
 		assertArrayEquals(testDescInfo, descriptionInformation);
-//		assertArrayEquals(testTypeInfo, typeInformation);
+		assertArrayEquals(testTypeInfo, typeInformation);
+		// Now check these work too
+		assertArrayEquals(geneSourceSciName, testGeneSourceSciName);
+		assertArrayEquals(geneSourceTaxId, testGeneSourceTaxId);
+		assertArrayEquals(hostOrganismSciName, testHostOrganismSciName);
+		assertArrayEquals(hostOrganismTaxId, testHostOrganismTaxId);
 
 		
 		

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestEntityNameAndType.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestEntityNameAndType.java
@@ -63,7 +63,7 @@ public class TestEntityNameAndType {
 		int chainCounter = 0;
 		for (Chain c: bioJavaStruct.getChains()) {
 			// Now get the entity information we want to test
-			EntityInfo thisCmpd = c.getCompound();
+			EntityInfo thisCmpd = c.getEntityInfo();
 			testTypeInfo[chainCounter] = thisCmpd.getType();
 			testDescInfo[chainCounter] = thisCmpd.getDescription();
 			testGeneSourceSciName[chainCounter] =  thisCmpd.getOrganismScientific();

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestEntityNameAndType.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestEntityNameAndType.java
@@ -1,0 +1,64 @@
+package org.biojava.nbio.structure.io.mmcif;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.IOException;
+
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.Compound;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.junit.Test;
+/**
+ * Test to ensure the entity name and type
+ * @author Anthony Bradley
+ *
+ */
+public class TestEntityNameAndType {
+
+	@Test
+	/**
+	 * 
+	 */
+	public void testEntityId() throws IOException, StructureException {
+		
+		// Set up the atom cache to parse on Internal chain id
+		AtomCache cache = new AtomCache();
+		cache.setUseMmCif(true);
+		FileParsingParameters params = cache.getFileParsingParams();
+		params.setUseInternalChainId(true);
+		DownloadChemCompProvider cc = new DownloadChemCompProvider();
+		ChemCompGroupFactory.setChemCompProvider(cc);
+		cc.checkDoFirstInstall();
+		cache.setFileParsingParams(params);
+		StructureIO.setAtomCache(cache);
+		// This is hte information we want to test against
+		String[] typeInformation = new String[] {"polymer", "non-polymer", "non-polymer", "non-polymer", "non-polymer", "water"};
+		String[] descriptionInformation = new String[] {"BROMODOMAIN ADJACENT TO ZINC FINGER DOMAIN PROTEIN 2B","4-FLUOROBENZAMIDOXIME", "4-FLUOROBENZAMIDOXIME", "METHANOL", "METHANOL", "water"};	
+		
+		
+		/// TODO GET ALL THE ENTITY INFORMATION REQUIRED FOR 4CUP 
+		// Get this structure
+		Structure bioJavaStruct = StructureIO.getStructure("4cup");
+		String[] testTypeInfo = new String[6];
+		String[] testDescInfo = new String[6];
+		// Now loop through the structure
+		int chainCounter = 0;
+		for (Chain c: bioJavaStruct.getChains()) {
+			// Now get the entity information we want to test
+			Compound thisCmpd = c.getCompound();
+//			testTypeInfo[chainCounter] = thisCmpd.get
+			testDescInfo[chainCounter] = thisCmpd.getMolName();
+			chainCounter++;
+		}
+		// Now check they're both the same
+		assertArrayEquals(testDescInfo, descriptionInformation);
+//		assertArrayEquals(testTypeInfo, typeInformation);
+
+		
+		
+	}
+}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestEntityNameAndType.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestEntityNameAndType.java
@@ -36,7 +36,7 @@ public class TestEntityNameAndType {
 		cache.setFileParsingParams(params);
 		StructureIO.setAtomCache(cache);
 		// This is hte information we want to test against
-		String[] typeInformation = new String[] {"polymer", "non-polymer", "non-polymer", "non-polymer", "non-polymer", "water"};
+		String[] typeInformation = new String[] {"POLYMER", "NONPOLYMER", "NONPOLYMER", "NONPOLYMER", "NONPOLYMER", "WATER"};
 		String[] descriptionInformation = new String[] {"BROMODOMAIN ADJACENT TO ZINC FINGER DOMAIN PROTEIN 2B","4-FLUOROBENZAMIDOXIME",  "METHANOL", "METHANOL", "METHANOL", "water"};	
 		
 		// Now some other information fields to test this data is collated correctly
@@ -64,7 +64,7 @@ public class TestEntityNameAndType {
 		for (Chain c: bioJavaStruct.getChains()) {
 			// Now get the entity information we want to test
 			EntityInfo thisCmpd = c.getEntityInfo();
-			testTypeInfo[chainCounter] = thisCmpd.getType();
+			testTypeInfo[chainCounter] = thisCmpd.getType().toString();
 			testDescInfo[chainCounter] = thisCmpd.getDescription();
 			testGeneSourceSciName[chainCounter] =  thisCmpd.getOrganismScientific();
 			testGeneSourceTaxId[chainCounter] = thisCmpd.getOrganismTaxId();

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/xtal/TestInterfaceClustering.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/xtal/TestInterfaceClustering.java
@@ -100,7 +100,7 @@ public class TestInterfaceClustering {
 
 		assertEquals(8, s.getChains().size());
 
-		assertEquals(4, s.getCompounds().size());
+		assertEquals(4, s.getEntityInformation().size());
 
 		CrystalBuilder cb = new CrystalBuilder(s);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
@@ -149,7 +149,7 @@ public class TestInterfaceClustering {
 
 		assertEquals(6, s.getChains().size());
 
-		assertEquals(1, s.getCompounds().size());
+		assertEquals(1, s.getEntityInformation().size());
 
 		CrystalBuilder cb = new CrystalBuilder(s);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/xtal/TestInterfaceClustering.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/xtal/TestInterfaceClustering.java
@@ -100,7 +100,7 @@ public class TestInterfaceClustering {
 
 		assertEquals(8, s.getChains().size());
 
-		assertEquals(4, s.getEntityInformation().size());
+		assertEquals(4, s.getEntityInfos().size());
 
 		CrystalBuilder cb = new CrystalBuilder(s);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
@@ -149,7 +149,7 @@ public class TestInterfaceClustering {
 
 		assertEquals(6, s.getChains().size());
 
-		assertEquals(1, s.getEntityInformation().size());
+		assertEquals(1, s.getEntityInfos().size());
 
 		CrystalBuilder cb = new CrystalBuilder(s);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);


### PR DESCRIPTION
1) Refactored Compound to EntitiyInfo -> it seemed a better descriptiton.

2) Altered behaviour to consider non-polymer entities. 
This was required by MMTF and is I believe desired.

3) Added extra information (description and type).
These were required by MMTF and also generally useful.