### PR TITLE
squid:S2178 - Short-circuit logic should be used in boolean contexts

### DIFF
--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmStructure.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmStructure.java
@@ -244,7 +244,7 @@ public class StockholmStructure {
 	 */
 	public List<AbstractSequence<? extends AbstractCompound>> getBioSequences(boolean ignoreCase,
 			String forcedSequenceType) {
-		if (forcedSequenceType != null && !(forcedSequenceType.equals(PFAM) | forcedSequenceType.equals(RFAM))) {
+		if (forcedSequenceType != null && !(forcedSequenceType.equals(PFAM) || forcedSequenceType.equals(RFAM))) {
 			throw new IllegalArgumentException("Illegal Argument " + forcedSequenceType);
 		}
 		List<AbstractSequence<? extends AbstractCompound>> seqs = new ArrayList<AbstractSequence<? extends AbstractCompound>>();

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/JAutoSuggest.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/JAutoSuggest.java
@@ -229,7 +229,7 @@ public class JAutoSuggest extends JTextField{
 					list.ensureIndexIsVisible(list.getSelectedIndex() - 1);
 					return;
 				} else if (e.getKeyCode() == KeyEvent.VK_ENTER
-						& list.getSelectedIndex() != -1 & suggestions.size() > 0) {
+						&& list.getSelectedIndex() != -1 && suggestions.size() > 0) {
 					setText((String) list.getSelectedValue());
 
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -666,7 +666,7 @@ public class FileConvert {
 
 		str.append(SimpleMMcifParser.MMCIF_TOP_HEADER+"BioJava_mmCIF_file"+newline);
 
-		if (structure.getPDBHeader()!=null & structure.getPDBHeader().getCrystallographicInfo()!=null &&
+		if (structure.getPDBHeader()!=null && structure.getPDBHeader().getCrystallographicInfo()!=null &&
 				structure.getPDBHeader().getCrystallographicInfo().getSpaceGroup()!=null &&
 				structure.getPDBHeader().getCrystallographicInfo().getCrystalCell()!=null) {
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -2431,7 +2431,7 @@ public class PDBFileParser  {
 		List<ResidueNumber> siteResidues = siteToResidueMap.get(siteID);
 
 		//if the siteResidues doesn't yet exist, make a new one.
-		if (siteResidues == null |! siteToResidueMap.containsKey(siteID.trim())){
+		if (siteResidues == null || ! siteToResidueMap.containsKey(siteID.trim())){
 			siteResidues = new ArrayList<ResidueNumber>();
 			siteToResidueMap.put(siteID.trim(), siteResidues);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/CholeskyDecomposition.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/CholeskyDecomposition.java
@@ -81,10 +81,10 @@ public class CholeskyDecomposition implements java.io.Serializable {
 				}
 				Lrowj[k] = s = (A[j][k] - s)/L[k][k];
 				d = d + s*s;
-				isspd = isspd & (A[k][j] == A[j][k]);
+				isspd = isspd && (A[k][j] == A[j][k]);
 			}
 			d = A[j][j] - d;
-			isspd = isspd & (d > 0.0);
+			isspd = isspd && (d > 0.0);
 			L[j][j] = Math.sqrt(Math.max(d,0.0));
 			for (int k = j+1; k < n; k++) {
 				L[j][k] = 0.0;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/EigenvalueDecomposition.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/EigenvalueDecomposition.java
@@ -455,7 +455,7 @@ public class EigenvalueDecomposition implements java.io.Serializable {
 
 		double norm = 0.0;
 		for (int i = 0; i < nn; i++) {
-			if (i < low | i > high) {
+			if (i < low || i > high) {
 				d[i] = H[i][i];
 				e[i] = 0.0;
 			}
@@ -820,7 +820,7 @@ public class EigenvalueDecomposition implements java.io.Serializable {
 							y = H[i+1][i];
 							vr = (d[i] - p) * (d[i] - p) + e[i] * e[i] - q * q;
 							vi = (d[i] - p) * 2.0 * q;
-							if (vr == 0.0 & vi == 0.0) {
+							if (vr == 0.0 && vi == 0.0) {
 								vr = eps * norm * (Math.abs(w) + Math.abs(q) +
 								Math.abs(x) + Math.abs(y) + Math.abs(z));
 							}
@@ -854,7 +854,7 @@ public class EigenvalueDecomposition implements java.io.Serializable {
 		// Vectors of isolated roots
 
 		for (int i = 0; i < nn; i++) {
-			if (i < low | i > high) {
+			if (i < low || i > high) {
 				for (int j = i; j < nn; j++) {
 					V[i][j] = H[i][j];
 				}
@@ -892,8 +892,8 @@ public class EigenvalueDecomposition implements java.io.Serializable {
 		e = new double[n];
 
 		issymmetric = true;
-		for (int j = 0; (j < n) & issymmetric; j++) {
-			for (int i = 0; (i < n) & issymmetric; i++) {
+		for (int j = 0; (j < n) && issymmetric; j++) {
+			for (int i = 0; (i < n) && issymmetric; i++) {
 				issymmetric = (A[i][j] == A[j][i]);
 			}
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/LUDecomposition.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/LUDecomposition.java
@@ -125,7 +125,7 @@ public class LUDecomposition implements java.io.Serializable {
 
 			// Compute multipliers.
 
-			if (j < m & LU[j][j] != 0.0) {
+			if (j < m && LU[j][j] != 0.0) {
 				for (int i = j+1; i < m; i++) {
 					LU[i][j] /= LU[j][j];
 				}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/SingularValueDecomposition.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/SingularValueDecomposition.java
@@ -116,7 +116,7 @@ public class SingularValueDecomposition implements java.io.Serializable {
 				s[k] = -s[k];
 			}
 			for (int j = k+1; j < n; j++) {
-				if ((k < nct) & (s[k] != 0.0))  {
+				if ((k < nct) && (s[k] != 0.0))  {
 
 				// Apply the transformation.
 
@@ -135,7 +135,7 @@ public class SingularValueDecomposition implements java.io.Serializable {
 
 				e[j] = A[k][j];
 			}
-			if (wantu & (k < nct)) {
+			if (wantu && (k < nct)) {
 
 				// Place the transformation in U for subsequent back
 				// multiplication.
@@ -163,7 +163,7 @@ public class SingularValueDecomposition implements java.io.Serializable {
 					e[k+1] += 1.0;
 				}
 				e[k] = -e[k];
-				if ((k+1 < m) & (e[k] != 0.0)) {
+				if ((k+1 < m) && (e[k] != 0.0)) {
 
 				// Apply the transformation.
 
@@ -249,7 +249,7 @@ public class SingularValueDecomposition implements java.io.Serializable {
 
 		if (wantv) {
 			for (int k = n-1; k >= 0; k--) {
-				if ((k < nrt) & (e[k] != 0.0)) {
+				if ((k < nrt) && (e[k] != 0.0)) {
 					for (int j = k+1; j < nu; j++) {
 						double t = 0;
 						for (int i = k+1; i < n; i++) {
@@ -394,7 +394,7 @@ public class SingularValueDecomposition implements java.io.Serializable {
 					double b = ((spm1 + sp)*(spm1 - sp) + epm1*epm1)/2.0;
 					double c = (sp*epm1)*(sp*epm1);
 					double shift = 0.0;
-					if ((b != 0.0) | (c != 0.0)) {
+					if ((b != 0.0) || (c != 0.0)) {
 						shift = Math.sqrt(b*b + c);
 						if (b < 0.0) {
 							shift = -shift;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2178 - Short-circuit logic should be used in boolean contexts

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2178

Please let me know if you have any questions.

M-Ezzat