### PR TITLE
Fix #455. Use parsing params for AtomCache

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AtomCache.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AtomCache.java
@@ -152,12 +152,6 @@ public class AtomCache {
 		currentlyLoading.clear();
 		params = new FileParsingParameters();
 
-		// we don't need this here
-		params.setAlignSeqRes(false);
-		// no secstruc either
-		params.setParseSecStruc(false);
-		//
-
 		setUseMmCif(true);
 
 	}


### PR DESCRIPTION
Specifically, set default alignSeqRes parameter in AtomCache  to true.