### PR TITLE
Two small patches on StructureTools and MmtfStructureReader

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1269,7 +1269,11 @@ public class StructureTools {
 		} else {
 			atoms = getAtomArray(chain, atomNames);
 		}
-
+		// If tha
+		if(atoms.length==0){ 
+			logger.warn("No atoms found for buidling grid!");
+			return new AtomContactSet(cutoff);
+		}
 		grid.addAtoms(atoms);
 
 		return grid.getContacts();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -429,6 +429,7 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 		// Now loop through the chain ids and make a list of them
 		for( int index : chainIndices) {
 			chains.add(chainList.get(index));
+			chainList.get(index).setEntityInfo(entityInfo);
 		}
 		entityInfo.setChains(chains);
 		entityInfoList.add(entityInfo);


### PR DESCRIPTION
Fixed a bug in Structure Tools for empty arrays
Mmtf structure reader sets entity information both ways