### PR TITLE
Automatically re-download ECOD if the cache is >2weeks old

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/ecod/EcodInstallationTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/ecod/EcodInstallationTest.java
@@ -47,6 +47,7 @@ import org.biojava.nbio.structure.ecod.EcodDatabase;
 import org.biojava.nbio.structure.ecod.EcodDomain;
 import org.biojava.nbio.structure.ecod.EcodFactory;
 import org.biojava.nbio.structure.ecod.EcodInstallation;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -60,13 +61,13 @@ import org.slf4j.LoggerFactory;
 public class EcodInstallationTest {
 
 	private static final Logger logger = LoggerFactory.getLogger(EcodInstallationTest.class);
-	private static final String VERSION = "develop124"; // Should be updated periodically
+	private static final String VERSION = "develop133"; // Should be updated periodically
 
 	// Info about known versions, for testing
-	private static final int DEVELOP_FIRST_VERSION = 45;
-	private static final int DEVELOP_LATEST_VERSTION = 124; // Should be updated periodically
+	private static final int DEVELOP_FIRST_VERSION = 124;
+	private static final int DEVELOP_LATEST_VERSTION = 136; // Should be updated periodically
 	//versions known to be unreleased
-	private static final List<Integer> DEVELOP_VERSIONS_BLACKLIST = Arrays.asList( 85, 107, 113 );
+	private static final List<Integer> DEVELOP_VERSIONS_BLACKLIST = Arrays.asList( 85, 107, 113, 125, 128, 131 );
 
 	static {
 		//System.setProperty("Log4jContextSelector", "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
@@ -105,6 +106,18 @@ public class EcodInstallationTest {
 			break;
 		case "develop124":
 			expected = 468680; //version124
+			break;
+		case "develop133":
+			expected = 479738; //version133
+			break;
+		case "develop134":
+			expected = 483056; //version134 (stats file)
+			break;
+		case "develop135":
+			expected = 483812; //version135 (stats file)
+			break;
+		case "develop136":
+			expected = 484847; //version136 (stats file)
 			break;
 		default:
 			fail("Unrecognized version "+VERSION);
@@ -154,10 +167,9 @@ public class EcodInstallationTest {
 				//				String chainName, String range, String seqId, String architectureName,
 				".", "A:3-97,B:106-346", "A:3-97,B:1-241", "beta barrels",
 				//				String xGroupName, String hGroupName, String tGroupName,
-				"cradle loop barrel", "RIFT-related",
-				"NO_T_NAME",// should be "acid protease" except for bug in develop124
+				"cradle loop barrel", "RIFT-related","acid protease",
 				//				String fGroupName, Boolean isAssembly, List<String> ligands
-				"EF00710",//"UNK_F_TYPE",
+				"EF00710",
 				20669l, Collections.singleton("EPE")
 				);
 		assertEquals(ecodId,expected,domain);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
@@ -28,7 +28,9 @@ import java.io.Reader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -86,6 +88,9 @@ public class EcodInstallation implements EcodDatabase {
 
 	private String url;
 
+	// Frequency of ECOD updates, in days. If non-null, redownloads "latest" if older than this.
+	private Integer updateFrequency = 14;
+	
 	/**
 	 * Use EcodFactory to create instances. The instantiation of multiple
 	 * installations at the same path can lead to race conditions when downloading
@@ -359,7 +364,25 @@ public class EcodInstallation implements EcodDatabase {
 		try {
 			File f = getDomainFile();
 
-			return f.exists() && f.length()>0;
+			if (!f.exists() || f.length() <= 0 )
+				return false;
+			
+			// Re-download old copies of "latest"
+			if(updateFrequency != null && requestedVersion == DEFAULT_VERSION ) {
+				long mod = f.lastModified();
+				// Time of last update
+				Date lastUpdate = new Date();
+				Calendar cal = Calendar.getInstance();
+				cal.setTime(lastUpdate);
+				cal.add(Calendar.DAY_OF_WEEK, -updateFrequency);
+				long updateTime = cal.getTimeInMillis();
+				// Check if file predates last update
+				if( mod < updateTime ) {
+					logger.info("{} is out of date.",f);
+					return false;
+				}
+			}
+			return true;
 		} finally {
 			logger.trace("UNLOCK readlock");
 			domainsFileLock.readLock().unlock();
@@ -401,6 +424,27 @@ public class EcodInstallation implements EcodDatabase {
 	 */
 	private File getDomainFile() {
 		return new File(getCacheLocation(),getDomainFilename());
+	}
+
+	/**
+	 * The expected ECOD update frequency determines whether the version
+	 * "latest" should be re-downloaded
+	 * @return the expected ECOD update frequency, in days
+	 */
+	public Integer getUpdateFrequency() {
+		return updateFrequency;
+	}
+
+	/**
+	 * The "latest" version will be re-downloaded if it is older than
+	 * {@link #getUpdateFrequency()} days. Setting this to null disables
+	 * re-downloading (delete $PDB_CACHE_DIR/ecod.latest.domains.txt manually
+	 * to force updating). Setting to 0 will force downloading for every
+	 * program execution.
+	 * @param updateFrequency the updateFrequency to set
+	 */
+	public void setUpdateFrequency(Integer updateFrequency) {
+		this.updateFrequency = updateFrequency;
 	}
 
 	/**


### PR DESCRIPTION
Since ECOD releases every two weeks, we shouldn't cache version "latest" longer than that.
With this the cache is at most one version behind.