### PR TITLE
Fix #480: Allow CIF labels to differ from the java field name

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
@@ -20,7 +20,20 @@
  */
 package org.biojava.nbio.structure.contact;
 
-import org.biojava.nbio.structure.*;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.Element;
+import org.biojava.nbio.structure.EntityInfo;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.GroupType;
+import org.biojava.nbio.structure.ResidueNumber;
+import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.asa.AsaCalculator;
 import org.biojava.nbio.structure.asa.GroupAsa;
 import org.biojava.nbio.structure.io.FileConvert;
@@ -28,16 +41,11 @@ import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.mmcif.MMCIFFileTools;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
 import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
+import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.biojava.nbio.structure.xtal.CrystalTransform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 
 /**
@@ -753,7 +761,7 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 
 		// we reassign atom ids if sym related (otherwise atom ids would be duplicated and some molecular viewers can't cope with that)
 		int atomId = 1;
-		List<Object> atomSites = new ArrayList<Object>();
+		List<AtomSite> atomSites = new ArrayList<>();
 		for (Atom atom:this.molecules.getFirst()) {
 			if (isSymRelated()) {
 				atomSites.add(MMCIFFileTools.convertAtomToAtomSite(atom, 1, molecId1, molecId1, atomId));
@@ -771,7 +779,7 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 			atomId++;
 		}
 
-		sb.append(MMCIFFileTools.toMMCIF(atomSites));
+		sb.append(MMCIFFileTools.toMMCIF(atomSites,AtomSite.class));
 
 		return sb.toString();
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -611,12 +611,10 @@ public class FileConvert {
 
 		str.append(getAtomSiteHeader());
 
-		@SuppressWarnings("unchecked")
-		List<Object> list =
-		(List<Object>) (List<?>) MMCIFFileTools.convertStructureToAtomSites(structure);
+		List<AtomSite> list =  MMCIFFileTools.convertStructureToAtomSites(structure);
 
 
-		str.append(MMCIFFileTools.toMMCIF(list));
+		str.append(MMCIFFileTools.toMMCIF(list,AtomSite.class));
 
 		return str.toString();
 	}
@@ -628,11 +626,9 @@ public class FileConvert {
 			str.append(getAtomSiteHeader());
 
 
-		@SuppressWarnings("unchecked")
-		List<Object> list =
-		(List<Object>) (List<?>) MMCIFFileTools.convertChainToAtomSites(chain, 1, authId, asymId);
+		List<AtomSite> list = MMCIFFileTools.convertChainToAtomSites(chain, 1, authId, asymId);
 
-		str.append(MMCIFFileTools.toMMCIF(list));
+		str.append(MMCIFFileTools.toMMCIF(list,AtomSite.class));
 		return str.toString();
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MMCIFFileTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MMCIFFileTools.java
@@ -22,8 +22,12 @@ package org.biojava.nbio.structure.io.mmcif;
 
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.Chain;
@@ -32,8 +36,10 @@ import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.GroupType;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.io.FileConvert;
+import org.biojava.nbio.structure.io.mmcif.model.AbstractBean;
 import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
 import org.biojava.nbio.structure.io.mmcif.model.Cell;
+import org.biojava.nbio.structure.io.mmcif.model.IgnoreField;
 import org.biojava.nbio.structure.io.mmcif.model.Symmetry;
 import org.biojava.nbio.structure.xtal.CrystalCell;
 import org.biojava.nbio.structure.xtal.SpaceGroup;
@@ -45,7 +51,13 @@ import org.slf4j.LoggerFactory;
  *
  * See http://www.iucr.org/__data/assets/pdf_file/0019/22618/cifguide.pdf
  *
- *
+ * CIF categories are represented as a simple bean, typically extending {@link AbstractBean}.
+ * By default, all fields from the bean are taken as the CIF labels. Fields
+ * may be omitted by annotating them as {@link IgnoreField @IgnoreField}.
+ * The CIF label for a field may be changed (for instance, for fields that
+ * are not valid Java identifiers) by defining a function
+ * <tt>static Map<String,String> getCIFLabelMap()</tt>
+ * mapping from the field's name to the correct label.
  * @author duarte_j
  *
  */
@@ -81,7 +93,7 @@ public class MMCIFFileTools {
 
 		Class<?> c = Class.forName(className);
 
-		for (Field f : c.getDeclaredFields()) {
+		for (Field f : getFields(c)) {
 			str.append(categoryName+"."+f.getName()+newline);
 		}
 
@@ -95,39 +107,55 @@ public class MMCIFFileTools {
 	 * @param o
 	 * @return
 	 */
+	@SuppressWarnings("unchecked")
 	public static String toMMCIF(String categoryName, Object o) {
 
 		StringBuilder sb = new StringBuilder();
 
 		Class<?> c = o.getClass();
 
-		int maxFieldNameLength = getMaxFieldNameLength(o);
 
-		for (Field f : c.getDeclaredFields()) {
-			f.setAccessible(true);
+		// Check if the class requires any fields to be renamed
+		Map<String,String> nameMap = null;
+		try {
+			Method getCIFLabelMap = c.getDeclaredMethod("getCIFLabelMap");
+			getCIFLabelMap.setAccessible(true);
+			nameMap = (Map<String, String>) getCIFLabelMap.invoke(null);
+		} catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | ClassCastException e1) {
+			// no nameMap
+		}
+		
+		Field[] fields = getFields(c);
+		String[] names = getFieldNames(fields, nameMap);
+		
+		int maxFieldNameLength = getMaxStringLength(names);
 
-			sb.append(categoryName+"."+f.getName());
+		for (int i=0;i<fields.length;i++) {
+			Field f = fields[i];
+			String name = names[i];
 
-			int spacing = maxFieldNameLength - f.getName().length() + 3;
+			sb.append(categoryName+"."+name);
+
+			int spacing = maxFieldNameLength - name.length() + 3;
 
 			try {
 				Object obj = f.get(o);
 				String val;
 				if (obj==null) {
-					logger.debug("Field {} is null, will write it out as {}",f.getName(),MMCIF_MISSING_VALUE);
+					logger.debug("Field {} is null, will write it out as {}",name,MMCIF_MISSING_VALUE);
 					val = MMCIF_MISSING_VALUE;
 				} else {
 					val = (String) obj;
 				}
-				for (int i=0;i<spacing;i++) sb.append(' ');
+				for (int j=0;j<spacing;j++) sb.append(' ');
 				sb.append(addMmCifQuoting(val));
 				sb.append(newline);
 
 			} catch (IllegalAccessException e) {
-				logger.warn("Field {} is inaccessible", f.getName());
+				logger.warn("Field {} is inaccessible", name);
 				continue;
 			} catch (ClassCastException e) {
-				logger.warn("Could not cast value to String for field {}",f.getName());
+				logger.warn("Could not cast value to String for field {}",name);
 				continue;
 			}
 
@@ -139,47 +167,122 @@ public class MMCIFFileTools {
 	}
 
 	/**
+	 * Gets all fields for a particular class, filtering fields annotated
+	 * with {@link IgnoreField @IgnoreField}.
+	 * 
+	 * As a side effect, calls {@link Field#setAccessible(boolean) setAccessible(true)}
+	 * on all fields.
+	 * @param c
+	 * @return
+	 */
+	private static Field[] getFields(Class<?> c) {
+		Field[] allFields = c.getDeclaredFields();
+		Field[] fields = new Field[allFields.length];
+		int n = 0;
+		for(Field f : allFields) {
+			f.setAccessible(true);
+			IgnoreField anno = f.getAnnotation(IgnoreField.class);
+			if(anno == null) {
+				fields[n] = f;
+				n++;
+			}
+		}
+		return Arrays.copyOf(fields, n);
+	}
+
+	/**
+	 * Gets the mmCIF record name for each field. This is generally just
+	 * the name of the field, but may be modified by passing a non-null nameMap
+	 * argument.
+	 * 
+	 * As a side effect, calls {@link Field#setAccessible(boolean) setAccessible(true)}
+	 * on all fields.
+	 * @param fields
+	 * @param nameMap
+	 * @return
+	 */
+	private static String[] getFieldNames(Field[] fields, Map<String, String> nameMap) {
+		String[] names = new String[fields.length];
+		for(int i=0;i<fields.length;i++) {
+			fields[i].setAccessible(true);
+			String rawName = fields[i].getName();
+			if(nameMap != null && nameMap.containsKey(rawName)) {
+				names[i] = nameMap.get(rawName);
+			} else {
+				names[i] = rawName;
+			}
+		}
+		return names;
+	}
+
+	/**
 	 * Converts a list of mmCIF beans (see {@link org.biojava.nbio.structure.io.mmcif.model} to
 	 * a String representing them in mmCIF loop format with one record per line.
 	 * @param list
 	 * @return
 	 */
-	public static String toMMCIF(List<Object> list) {
-		int[] sizes = getFieldSizes(list);
+	public static <T> String toMMCIF(List<T> list, Class<T> klass) {
+		if (list.isEmpty()) throw new IllegalArgumentException("List of beans is empty!");
+
+		Field[] fields = getFields(klass);
+		int[] sizes = getFieldSizes(list,fields);
 
 		StringBuilder sb = new StringBuilder();
 
-		for (Object o:list) {
-			sb.append(toSingleLoopLineMmCifString(o, sizes));
+		for (T o:list) {
+			sb.append(toSingleLoopLineMmCifString(o, fields, sizes));
 		}
 
 		sb.append(SimpleMMcifParser.COMMENT_CHAR+newline);
 
 		return sb.toString();
 	}
+	/**
+	 * Converts a list of mmCIF beans (see {@link org.biojava.nbio.structure.io.mmcif.model} to
+	 * a String representing them in mmCIF loop format with one record per line.
+	 * @param list
+	 * @return
+	 * @deprecated The {@link #toMMCIF(List, Class)} provides compile-time type safety
+	 * @throws ClassCastException if not all list elements have the same type
+	 */
+	@Deprecated
+	@SuppressWarnings("unchecked")
+	public static <T> String toMMCIF(List<T> list) {
+		Class<T> klass = (Class<T>)list.get(0).getClass();
+		for(T t : list) {
+			if( klass != t.getClass() ) {
+				throw new ClassCastException("Not all loop elements have the same fields");
+			}
+		}
+		return toMMCIF(list,klass);
+	}
 
 	/**
 	 * Given a mmCIF bean produces a String representing it in mmCIF loop format as a single record line
-	 * @param a
+	 * @param record
+	 * @param fields Set of fields for the record. If null, will be calculated from the class of the record
 	 * @param sizes the size of each of the fields
 	 * @return
 	 */
-	private static String toSingleLoopLineMmCifString(Object a, int[] sizes) {
+	private static String toSingleLoopLineMmCifString(Object record, Field[] fields, int[] sizes) {
 
 		StringBuilder str = new StringBuilder();
 
-		Class<?> c = a.getClass();
+		Class<?> c = record.getClass();
 
-		if (sizes.length!=c.getDeclaredFields().length)
+		if(fields == null)
+			fields = getFields(c);
+		
+		if (sizes.length!=fields.length)
 			throw new IllegalArgumentException("The given sizes of fields differ from the number of declared fields");
 
 		int i = -1;
-		for (Field f : c.getDeclaredFields()) {
+		for (Field f : fields) {
 			i++;
 			f.setAccessible(true);
 
 			try {
-				Object obj = f.get(a);
+				Object obj = f.get(record);
 				String val;
 				if (obj==null) {
 					logger.debug("Field {} is null, will write it out as {}",f.getName(),MMCIF_MISSING_VALUE);
@@ -309,9 +412,11 @@ public class MMCIFFileTools {
 		}
 
 		Character  altLoc = a.getAltLoc()           ;
-		String altLocStr = altLoc.toString();
+		String altLocStr;
 		if (altLoc==null || altLoc == ' ') {
 			altLocStr = MMCIF_DEFAULT_VALUE;
+		} else {
+			altLocStr = altLoc.toString();
 		}
 
 		Element e = a.getElement();
@@ -428,22 +533,24 @@ public class MMCIFFileTools {
 	/**
 	 * Finds the max length of each of the String values contained in each of the fields of the given list of beans.
 	 * Useful for producing mmCIF loop data that is aligned for all columns.
-	 * @param a
+	 * @param list list of objects. All objects should have the same class.
+	 * @param fields Set of fields for the record. If null, will be calculated from the class of the first record
 	 * @return
-	 * @see #toMMCIF(List)
+	 * @see #toMMCIF(List, Class)
 	 */
-	private static int[] getFieldSizes(List<Object> list) {
+	private static <T> int[] getFieldSizes(List<T> list, Field[] fields) {
 
 		if (list.isEmpty()) throw new IllegalArgumentException("List of beans is empty!");
 
-		int[] sizes = new int [list.get(0).getClass().getDeclaredFields().length];
+		if(fields == null)
+			fields = getFields(list.get(0).getClass());
+
+		int[] sizes = new int [fields.length];
 
 
-		for (Object a:list) {
-			Class<?> c = a.getClass();
-
+		for (T a:list) {
 			int i = -1;
-			for (Field f : c.getDeclaredFields()) {
+			for (Field f : fields) {
 				i++;
 
 				f.setAccessible(true);
@@ -473,27 +580,19 @@ public class MMCIFFileTools {
 	}
 
 	/**
-	 * Finds the max length of the field strings corresponding to the given mmCIF bean.
+	 * Finds the max length of a list of strings
 	 * Useful for producing mmCIF single-record data that is aligned for all values.
-	 * @param a
+	 * @param names
 	 * @return
 	 * @see #toMMCIF(String, Object)
 	 */
-	private static int getMaxFieldNameLength(Object a) {
-
+	private static int getMaxStringLength(String[] names) {
 		int size = 0;
-
-		Class<?> c = a.getClass();
-
-		for (Field f : c.getDeclaredFields()) {
-
-			f.setAccessible(true);
-
-			if (f.getName().length() > size) {
-				size = f.getName().length();
+		for(String s : names) {
+			if(s.length()>size) {
+				size = s.length();
 			}
 		}
-
 		return size;
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/CIFLabel.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/CIFLabel.java
@@ -1,0 +1,18 @@
+package org.biojava.nbio.structure.io.mmcif.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation indicating that a specific field of a bean should be mapped to
+ * a different label
+ * @author Spencer Bliven
+ *
+ */
+@Target(value=ElementType.FIELD)
+@Retention(value=RetentionPolicy.RUNTIME)
+public @interface CIFLabel {
+	String label();
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/IgnoreField.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/IgnoreField.java
@@ -1,0 +1,17 @@
+package org.biojava.nbio.structure.io.mmcif.model;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation indicating that a specific field of a bean should be ignored
+ * @author Spencer Bliven
+ *
+ */
+@Target(value=ElementType.FIELD)
+@Retention(value=RetentionPolicy.RUNTIME)
+public @interface IgnoreField {
+
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/Symmetry.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/Symmetry.java
@@ -20,17 +20,13 @@
  */
 package org.biojava.nbio.structure.io.mmcif.model;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 public class Symmetry extends AbstractBean {
 
 	String entry_id;
-	// next 2 fields have actually hyphen between H and M i.e. H-M
-	// but java does not allow hyphens in variable names
-	// this will have to be solved elsewhere down the line
+	@CIFLabel(label="space_group_name_H-M")
 	String space_group_name_H_M;
+	@CIFLabel(label="pdbx_full_space_group_name_H-M")
 	String pdbx_full_space_group_name_H_M;
 	String cell_setting;
 	String Int_Tables_number;
@@ -71,27 +67,5 @@ public class Symmetry extends AbstractBean {
 	}
 	public void setSpace_group_name_Hall(String space_group_name_Hall) {
 		this.space_group_name_Hall = space_group_name_Hall;
-	}
-	
-	@IgnoreField
-	private static Map<String,String> nameMap = null;
-	/**
-	 * Map between field names and their correct mmCIF representation. For
-	 * instance, the <tt>space_group_name_H_M</tt> field corresponds to
-	 * <tt>space_group_name_H-M</tt>.
-	 * 
-	 * If a field is not contained in this map, the field and the mmCIF name
-	 * match.
-	 * @return map from field names to the mmCIF name
-	 */
-	// Note that this function is accessed via reflection
-	static Map<String,String> getCIFLabelMap() {
-		if(nameMap == null) {
-			HashMap<String,String> map = new HashMap<>();
-			map.put("space_group_name_H_M","space_group_name_H-M");
-			map.put("pdbx_full_space_group_name_H_M", "pdbx_full_space_group_name_H-M");
-			nameMap = Collections.unmodifiableMap(map);
-		}
-		return nameMap;
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/Symmetry.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/Symmetry.java
@@ -20,6 +20,10 @@
  */
 package org.biojava.nbio.structure.io.mmcif.model;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class Symmetry extends AbstractBean {
 
 	String entry_id;
@@ -67,5 +71,27 @@ public class Symmetry extends AbstractBean {
 	}
 	public void setSpace_group_name_Hall(String space_group_name_Hall) {
 		this.space_group_name_Hall = space_group_name_Hall;
+	}
+	
+	@IgnoreField
+	private static Map<String,String> nameMap = null;
+	/**
+	 * Map between field names and their correct mmCIF representation. For
+	 * instance, the <tt>space_group_name_H_M</tt> field corresponds to
+	 * <tt>space_group_name_H-M</tt>.
+	 * 
+	 * If a field is not contained in this map, the field and the mmCIF name
+	 * match.
+	 * @return map from field names to the mmCIF name
+	 */
+	// Note that this function is accessed via reflection
+	static Map<String,String> getCIFLabelMap() {
+		if(nameMap == null) {
+			HashMap<String,String> map = new HashMap<>();
+			map.put("space_group_name_H_M","space_group_name_H-M");
+			map.put("pdbx_full_space_group_name_H_M", "pdbx_full_space_group_name_H-M");
+			nameMap = Collections.unmodifiableMap(map);
+		}
+		return nameMap;
 	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -33,9 +33,12 @@ import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
 import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.io.mmcif.MMCIFFileTools;
 import org.biojava.nbio.structure.io.mmcif.MMcifParser;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifConsumer;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
+import org.biojava.nbio.structure.io.mmcif.model.CIFLabel;
+import org.biojava.nbio.structure.io.mmcif.model.IgnoreField;
 import org.junit.Test;
 
 public class TestMMCIFWriting {
@@ -222,5 +225,44 @@ public class TestMMCIFWriting {
 		}
 
 	}
+	
+	private static class DemoBean {
+		@IgnoreField
+		String not_a_field;
+		
+		@SuppressWarnings("unused")//used by reflection
+		String default_field;
+		
+		@CIFLabel(label="custom_label")
+		String custom_field;
 
+		public void setNot_a_field(String not_a_field) {
+			this.not_a_field = not_a_field;
+		}
+		public void setDefault_field(String default_field) {
+			this.default_field = default_field;
+		}
+		public void setCustom_field(String custom_field) {
+			this.custom_field = custom_field;
+		}
+	}
+
+	@Test
+	public void testBeanAnnotations() {
+		DemoBean bean = new DemoBean();
+		bean.setCustom_field("custom_field");
+		bean.setDefault_field(null);
+		bean.setNot_a_field("not_a_field");
+		
+		
+		// Test (1) should have custom_label (@CIFLabel)
+		//      (2) shouldn't have not_a_field (@IgnoreField)
+		String newline = System.getProperty("line.separator");
+		String mmcif = MMCIFFileTools.toMMCIF("_demo", bean);
+		String expected = 
+				  "_demo.default_field   ?" + newline
+				+ "_demo.custom_label    custom_field" + newline
+				+ "#" + newline;
+		assertEquals(expected, mmcif);
+	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -55,7 +55,7 @@ public class TestMMCIFWriting {
 		Structure originalStruct = StructureIO.getStructure("1SMT");
 
 		File outputFile = File.createTempFile("biojava_testing_", ".cif");
-
+		outputFile.deleteOnExit();
 
 		FileWriter fw = new FileWriter(outputFile);
 		fw.write(originalStruct.toMMCIF());
@@ -93,6 +93,8 @@ public class TestMMCIFWriting {
 			//assertEquals(origChain.getSeqResGroups().size(), readChain.getSeqResGroups().size());
 		}
 
+		// Test cell and symmetry
+		assertEquals(originalStruct.getCrystallographicInfo().getSpaceGroup(),readStruct.getCrystallographicInfo().getSpaceGroup());
 	}
 
 	/**
@@ -115,6 +117,7 @@ public class TestMMCIFWriting {
 		Structure originalStruct = StructureIO.getStructure("2N3J");
 
 		File outputFile = File.createTempFile("biojava_testing_", ".cif");
+		outputFile.deleteOnExit();
 
 
 		FileWriter fw = new FileWriter(outputFile);
@@ -179,6 +182,7 @@ public class TestMMCIFWriting {
 		Structure originalStruct = StructureIO.getStructure("1A2C");
 
 		File outputFile = File.createTempFile("biojava_testing_", ".cif");
+		outputFile.deleteOnExit();
 
 
 		FileWriter fw = new FileWriter(outputFile);


### PR DESCRIPTION
This provides a general solution to the problem in #480, which is that some CIF labels contain characters not permitted in java identifiers (like hyphens). Thus, a mechanism is needed for mapping java fields to the correct identifier for cases like `_symmetry.space_group_name_H-M` when writing to mmCIF.

This is implemented by adding two annotations. `@CIFLabel(label="str")` causes the cif property to be `_category.str`. `@IgnoreField` causes the field to be ignored entirely.

This pull also changes the MMCIFFileTools.toMMCIF method to be generic,
so that we enforce at compile time that all loop rows must be of the same type. The old method is deprecated (and should be backwards compatible if I understand type erasure correctly).