### PR TITLE
squid:S106 - Standard outputs should not be used directly to log anyt…

### DIFF
--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/CommandPrompt.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/CommandPrompt.java
@@ -28,6 +28,8 @@ import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompoundSet;
 import org.biojava.nbio.core.sequence.io.*;
 import org.biojava.nbio.core.sequence.template.CompoundSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -41,6 +43,8 @@ import java.util.Map.Entry;
 
 
 public class CommandPrompt {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CommandPrompt.class);
 
 	/**
 	 * The main method
@@ -335,46 +339,46 @@ public class CommandPrompt {
 	}
 
 	private static void showHelp(){
-		System.err.println("NAME");
-		System.err.println("\tAn executable to generate physico-chemical properties of protein sequences.");
-		System.err.println();
+		LOGGER.info("NAME");
+		LOGGER.info("\tAn executable to generate physico-chemical properties of protein sequences.");
+		LOGGER.info("\n");
 
-		System.err.println("EXAMPLES");
-		System.err.println("\tjava -jar AAProperties.jar -i test.fasta -a");
-		System.err.println("\t\tGenerates all possible properties.");
-		System.err.println();
-		System.err.println("\tjava -jar AAProperties.jar -i test.fasta -1 -3 -7");
-		System.err.println("\t\tGenerates only molecular weight, extinction coefficient and isoelectric point.");
-		System.err.println();
-		System.err.println("\tjava -jar AAProperties.jar -i test.fasta -0 A -0 N -1");
-		System.err.println("\t\tGenerates composition of two specific amino acid symbol and molecular weight.");
-		System.err.println();
+		LOGGER.info("EXAMPLES");
+		LOGGER.info("\tjava -jar AAProperties.jar -i test.fasta -a");
+		LOGGER.info("\t\tGenerates all possible properties.");
+		LOGGER.info("\n");
+		LOGGER.info("\tjava -jar AAProperties.jar -i test.fasta -1 -3 -7");
+		LOGGER.info("\t\tGenerates only molecular weight, extinction coefficient and isoelectric point.");
+		LOGGER.info("\n");
+		LOGGER.info("\tjava -jar AAProperties.jar -i test.fasta -0 A -0 N -1");
+		LOGGER.info("\t\tGenerates composition of two specific amino acid symbol and molecular weight.");
+		LOGGER.info("\n");
 
-		System.err.println("OPTIONS");
-		System.err.println("\tRequired");
-		System.err.println("\t\t-i location of input FASTA file");
-		System.err.println();
+		LOGGER.info("OPTIONS");
+		LOGGER.info("\tRequired");
+		LOGGER.info("\t\t-i location of input FASTA file");
+		LOGGER.info("\n");
 
-		System.err.println("\tOptional");
-		System.err.println("\t\t-o location of output file [standard output (default)]");
-		System.err.println("\t\t-f output format [csv (default) or tsv]");
-		System.err.println("\t\t-x location of Amino Acid Composition XML file for defining amino acid composition");
-		System.err.println("\t\t-y location of Element Mass XML file for defining mass of elements");
-		System.err.println("\t\t-d number of decimals (int) [4 (default)]");
-		System.err.println();
+		LOGGER.info("\tOptional");
+		LOGGER.info("\t\t-o location of output file [standard output (default)]");
+		LOGGER.info("\t\t-f output format [csv (default) or tsv]");
+		LOGGER.info("\t\t-x location of Amino Acid Composition XML file for defining amino acid composition");
+		LOGGER.info("\t\t-y location of Element Mass XML file for defining mass of elements");
+		LOGGER.info("\t\t-d number of decimals (int) [4 (default)]");
+		LOGGER.info("\n");
 
-		System.err.println("\tProvide at least one of them");
-		System.err.println("\t\t-a compute properties of option 1-9");
-		System.err.println("\t\t-1 compute molecular weight");
-		System.err.println("\t\t-2 compute absorbance");
-		System.err.println("\t\t-3 compute extinction coefficient");
-		System.err.println("\t\t-4 compute instability index");
-		System.err.println("\t\t-5 compute apliphatic index");
-		System.err.println("\t\t-6 compute average hydropathy value");
-		System.err.println("\t\t-7 compute isoelectric point");
-		System.err.println("\t\t-8 compute net charge at pH 7");
-		System.err.println("\t\t-9 compute composition of 20 standard amino acid (A, R, N, D, C, E, Q, G, H, I, L, K, M, F, P, S, T, W, Y, V)");
-		System.err.println("\t\t-0 compute composition of specific amino acid symbol");
-		System.err.println();
+		LOGGER.info("\tProvide at least one of them");
+		LOGGER.info("\t\t-a compute properties of option 1-9");
+		LOGGER.info("\t\t-1 compute molecular weight");
+		LOGGER.info("\t\t-2 compute absorbance");
+		LOGGER.info("\t\t-3 compute extinction coefficient");
+		LOGGER.info("\t\t-4 compute instability index");
+		LOGGER.info("\t\t-5 compute apliphatic index");
+		LOGGER.info("\t\t-6 compute average hydropathy value");
+		LOGGER.info("\t\t-7 compute isoelectric point");
+		LOGGER.info("\t\t-8 compute net charge at pH 7");
+		LOGGER.info("\t\t-9 compute composition of 20 standard amino acid (A, R, N, D, C, E, Q, G, H, I, L, K, M, F, P, S, T, W, Y, V)");
+		LOGGER.info("\t\t-0 compute composition of specific amino acid symbol");
+		LOGGER.info("\n");
 	}
 }

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/CommandPrompt.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/CommandPrompt.java
@@ -28,8 +28,6 @@ import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompoundSet;
 import org.biojava.nbio.core.sequence.io.*;
 import org.biojava.nbio.core.sequence.template.CompoundSet;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -43,8 +41,6 @@ import java.util.Map.Entry;
 
 
 public class CommandPrompt {
-
-	private static final Logger LOGGER = LoggerFactory.getLogger(CommandPrompt.class);
 
 	/**
 	 * The main method
@@ -339,46 +335,46 @@ public class CommandPrompt {
 	}
 
 	private static void showHelp(){
-		LOGGER.info("NAME");
-		LOGGER.info("\tAn executable to generate physico-chemical properties of protein sequences.");
-		LOGGER.info("\n");
+		System.err.println("NAME");
+		System.err.println("\tAn executable to generate physico-chemical properties of protein sequences.");
+		System.err.println();
 
-		LOGGER.info("EXAMPLES");
-		LOGGER.info("\tjava -jar AAProperties.jar -i test.fasta -a");
-		LOGGER.info("\t\tGenerates all possible properties.");
-		LOGGER.info("\n");
-		LOGGER.info("\tjava -jar AAProperties.jar -i test.fasta -1 -3 -7");
-		LOGGER.info("\t\tGenerates only molecular weight, extinction coefficient and isoelectric point.");
-		LOGGER.info("\n");
-		LOGGER.info("\tjava -jar AAProperties.jar -i test.fasta -0 A -0 N -1");
-		LOGGER.info("\t\tGenerates composition of two specific amino acid symbol and molecular weight.");
-		LOGGER.info("\n");
+		System.err.println("EXAMPLES");
+		System.err.println("\tjava -jar AAProperties.jar -i test.fasta -a");
+		System.err.println("\t\tGenerates all possible properties.");
+		System.err.println();
+		System.err.println("\tjava -jar AAProperties.jar -i test.fasta -1 -3 -7");
+		System.err.println("\t\tGenerates only molecular weight, extinction coefficient and isoelectric point.");
+		System.err.println();
+		System.err.println("\tjava -jar AAProperties.jar -i test.fasta -0 A -0 N -1");
+		System.err.println("\t\tGenerates composition of two specific amino acid symbol and molecular weight.");
+		System.err.println();
 
-		LOGGER.info("OPTIONS");
-		LOGGER.info("\tRequired");
-		LOGGER.info("\t\t-i location of input FASTA file");
-		LOGGER.info("\n");
+		System.err.println("OPTIONS");
+		System.err.println("\tRequired");
+		System.err.println("\t\t-i location of input FASTA file");
+		System.err.println();
 
-		LOGGER.info("\tOptional");
-		LOGGER.info("\t\t-o location of output file [standard output (default)]");
-		LOGGER.info("\t\t-f output format [csv (default) or tsv]");
-		LOGGER.info("\t\t-x location of Amino Acid Composition XML file for defining amino acid composition");
-		LOGGER.info("\t\t-y location of Element Mass XML file for defining mass of elements");
-		LOGGER.info("\t\t-d number of decimals (int) [4 (default)]");
-		LOGGER.info("\n");
+		System.err.println("\tOptional");
+		System.err.println("\t\t-o location of output file [standard output (default)]");
+		System.err.println("\t\t-f output format [csv (default) or tsv]");
+		System.err.println("\t\t-x location of Amino Acid Composition XML file for defining amino acid composition");
+		System.err.println("\t\t-y location of Element Mass XML file for defining mass of elements");
+		System.err.println("\t\t-d number of decimals (int) [4 (default)]");
+		System.err.println();
 
-		LOGGER.info("\tProvide at least one of them");
-		LOGGER.info("\t\t-a compute properties of option 1-9");
-		LOGGER.info("\t\t-1 compute molecular weight");
-		LOGGER.info("\t\t-2 compute absorbance");
-		LOGGER.info("\t\t-3 compute extinction coefficient");
-		LOGGER.info("\t\t-4 compute instability index");
-		LOGGER.info("\t\t-5 compute apliphatic index");
-		LOGGER.info("\t\t-6 compute average hydropathy value");
-		LOGGER.info("\t\t-7 compute isoelectric point");
-		LOGGER.info("\t\t-8 compute net charge at pH 7");
-		LOGGER.info("\t\t-9 compute composition of 20 standard amino acid (A, R, N, D, C, E, Q, G, H, I, L, K, M, F, P, S, T, W, Y, V)");
-		LOGGER.info("\t\t-0 compute composition of specific amino acid symbol");
-		LOGGER.info("\n");
+		System.err.println("\tProvide at least one of them");
+		System.err.println("\t\t-a compute properties of option 1-9");
+		System.err.println("\t\t-1 compute molecular weight");
+		System.err.println("\t\t-2 compute absorbance");
+		System.err.println("\t\t-3 compute extinction coefficient");
+		System.err.println("\t\t-4 compute instability index");
+		System.err.println("\t\t-5 compute apliphatic index");
+		System.err.println("\t\t-6 compute average hydropathy value");
+		System.err.println("\t\t-7 compute isoelectric point");
+		System.err.println("\t\t-8 compute net charge at pH 7");
+		System.err.println("\t\t-9 compute composition of 20 standard amino acid (A, R, N, D, C, E, Q, G, H, I, L, K, M, F, P, S, T, W, Y, V)");
+		System.err.println("\t\t-0 compute composition of specific amino acid symbol");
+		System.err.println();
 	}
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaReader.java
@@ -244,7 +244,7 @@ public class FastaReader<S extends Sequence<?>, C extends Compound> {
 
 
 			if ( is == null)
-				System.err.println("Could not get input file " + inputFile);
+				logger.warn("Could not get input file " + inputFile);
 			FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<ProteinSequence, AminoAcidCompound>(is, new GenericFastaHeaderParser<ProteinSequence,AminoAcidCompound>(), new ProteinSequenceCreator(AminoAcidCompoundSet.getAminoAcidCompoundSet()));
 			LinkedHashMap<String,ProteinSequence> proteinSequences = fastaReader.process();
 			is.close();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReader.java
@@ -40,6 +40,8 @@ import org.biojava.nbio.core.sequence.io.template.SequenceCreatorInterface;
 import org.biojava.nbio.core.sequence.io.template.SequenceHeaderParserInterface;
 import org.biojava.nbio.core.sequence.template.AbstractSequence;
 import org.biojava.nbio.core.sequence.template.Compound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.util.ArrayList;
@@ -52,6 +54,7 @@ import java.util.LinkedHashMap;
  *
  */
 public class GenbankReader<S extends AbstractSequence<C>, C extends Compound> {
+	private static final Logger LOGGER = LoggerFactory.getLogger(GenbankReader.class);
 
 	private SequenceCreatorInterface<C> sequenceCreator;
 	private GenbankSequenceParser<S,C> genbankParser;
@@ -180,13 +183,13 @@ public class GenbankReader<S extends AbstractSequence<C>, C extends Compound> {
 
 		GenbankReader<ProteinSequence, AminoAcidCompound> proteinReader = new GenbankReader<ProteinSequence, AminoAcidCompound>(is, new GenericGenbankHeaderParser<ProteinSequence,AminoAcidCompound>(), new ProteinSequenceCreator(AminoAcidCompoundSet.getAminoAcidCompoundSet()));
 		LinkedHashMap<String,ProteinSequence> proteinSequences = proteinReader.process();
-		System.out.println(proteinSequences);
+		LOGGER.info(proteinSequences.toString());
 
 		String inputFile = "src/test/resources/NM_000266.gb";
 		is = new FileInputStream(inputFile);
 		GenbankReader<DNASequence, NucleotideCompound> dnaReader = new GenbankReader<DNASequence, NucleotideCompound>(is, new GenericGenbankHeaderParser<DNASequence,NucleotideCompound>(), new DNASequenceCreator(DNACompoundSet.getDNACompoundSet()));
 		LinkedHashMap<String,DNASequence> dnaSequences = dnaReader.process();
-		System.out.println(dnaSequences);
+		LOGGER.info(dnaSequences.toString());
 
 		String crazyFile = "src/test/resources/CraftedFeature.gb";
 		is = new FileInputStream(crazyFile);
@@ -194,7 +197,7 @@ public class GenbankReader<S extends AbstractSequence<C>, C extends Compound> {
 		LinkedHashMap<String,DNASequence> crazyAnnotatedSequences = crazyReader.process();
 
 		is.close();
-		System.out.println(crazyAnnotatedSequences);
+		LOGGER.info(crazyAnnotatedSequences.toString());
 	}
 
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
@@ -31,6 +31,8 @@ import org.biojava.nbio.core.sequence.location.template.Location;
 import org.biojava.nbio.core.sequence.location.template.Point;
 import org.biojava.nbio.core.sequence.template.AbstractSequence;
 import org.biojava.nbio.core.sequence.template.Compound;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -48,7 +50,7 @@ import java.util.regex.Pattern;
  * @author Paolo Pavan
  */
 public class InsdcParser <S extends AbstractSequence<C>, C extends Compound>{
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(InsdcParser.class);
 	private final DataSource dataSource;
 
 		/**
@@ -313,7 +315,7 @@ public class InsdcParser <S extends AbstractSequence<C>, C extends Compound>{
 
 		for (String s: testStrings){
 			Location l = p.parse(s);
-			System.out.println(l.toString());
+			LOGGER.info(l.toString());
 		}
 
 	}

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/phosphosite/Dataset.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/phosphosite/Dataset.java
@@ -21,6 +21,8 @@
 package org.biojava.nbio.phosphosite;
 
 import org.biojava.nbio.structure.align.util.AtomCache;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URL;
@@ -43,6 +45,7 @@ import java.util.List;
  */
 public class Dataset {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(Dataset.class);
 
 	public static final String ACETYLATION = "http://www.phosphosite.org/downloads/Acetylation_site_dataset.gz";
 
@@ -110,8 +113,8 @@ public class Dataset {
 
 	public void download(){
 
-		System.out.println("Downloading data from www.phosposite.org. Data is under CC-BY-NC-SA license. Please link to site and cite: ");
-		System.out.println("Hornbeck PV, Kornhauser JM, Tkachev S, Zhang B, Skrzypek E, Murray B, Latham V, Sullivan M (2012) PhosphoSitePlus: a comprehensive resource for investigating the structure and function of experimentally determined post-translational modifications in man and mouse. Nucleic Acids Res. 40(Database issue), D261–70.");
+		LOGGER.info("Downloading data from www.phosposite.org. Data is under CC-BY-NC-SA license. Please link to site and cite: ");
+		LOGGER.info("Hornbeck PV, Kornhauser JM, Tkachev S, Zhang B, Skrzypek E, Murray B, Latham V, Sullivan M (2012) PhosphoSitePlus: a comprehensive resource for investigating the structure and function of experimentally determined post-translational modifications in man and mouse. Nucleic Acids Res. 40(Database issue), D261–70.");
 
 		File dir = getLocalDir();
 
@@ -156,7 +159,7 @@ public class Dataset {
 
 	private void downloadFile(URL u, File localFile) throws IOException {
 
-		System.out.println("Downloading " + u);
+		LOGGER.info("Downloading " + u);
 
 		File tmp = File.createTempFile("tmp","phosphosite");
 
@@ -230,13 +233,13 @@ public class Dataset {
 
 			for (File f : ds.getLocalFiles()) {
 
-				System.out.println(f.getAbsoluteFile());
+				LOGGER.info(f.getAbsoluteFile().toString());
 
 				List<Site> sites = Site.parseSites(f);
 
 				for (Site s : sites) {
 					if (s.getUniprot().equals("P50225") || s.getUniprot().equals("P48025")) {
-						System.out.println(s);
+						LOGGER.info(s.toString());
 					}
 				}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/AlignmentCalc.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/AlignmentCalc.java
@@ -108,7 +108,7 @@ public class AlignmentCalc implements AlignmentCalculationRunnable {
 
 			DisplayAFP.showAlignmentPanel(afpChain,ca1,ca2,jmol);
 
-			System.out.println(afpChain.toCE(ca1,ca2));
+			logger.info(afpChain.toCE(ca1,ca2));
 
 		} catch (StructureException e){
 			e.printStackTrace();

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/AlignmentCalcDB.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/AlignmentCalcDB.java
@@ -31,6 +31,8 @@ import org.biojava.nbio.structure.align.StructureAlignment;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.scop.ScopFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,6 +41,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class AlignmentCalcDB implements AlignmentCalculationRunnable {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(AlignmentCalcDB.class);
 
 	public static String SCOP_VERSION =  "1.75";
 
@@ -87,7 +90,7 @@ public class AlignmentCalcDB implements AlignmentCalculationRunnable {
 		this.outFile = outFile;
 		this.domainSplit = domainSplit;
 
-		System.out.println("AlignmentCalcDB: Using SCOP version " + SCOP_VERSION);
+		LOGGER.info("AlignmentCalcDB: Using SCOP version " + SCOP_VERSION);
 		ScopFactory.setScopDatabase(SCOP_VERSION);
 
 	}
@@ -112,9 +115,9 @@ public class AlignmentCalcDB implements AlignmentCalculationRunnable {
 		job = new MultiThreadedDBSearch(name1,structure1, outFile, algorithm, nrCPUs, domainSplit);
 
 		AtomCache cache = new AtomCache(config);
-		System.out.println("using cache: " + cache.getPath());
-		System.out.println("name1: " + name1);
-		System.out.println("structure:" + structure1.getName());
+		LOGGER.info("using cache: " + cache.getPath());
+		LOGGER.info("name1: " + name1);
+		LOGGER.info("structure:" + structure1.getName());
 		job.setAtomCache(cache);
 
 		if ( name1.equals("CUSTOM")) {

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/AlignmentGui.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/AlignmentGui.java
@@ -51,6 +51,8 @@ import org.biojava.nbio.structure.align.webstart.WebStartMain;
 import org.biojava.nbio.structure.gui.util.PDBUploadPanel;
 import org.biojava.nbio.structure.gui.util.ScopSelectPanel;
 import org.biojava.nbio.structure.gui.util.StructurePairSelector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** A JFrame that allows to trigger a pairwise structure alignment,
  * either from files in a directory,
@@ -65,6 +67,7 @@ import org.biojava.nbio.structure.gui.util.StructurePairSelector;
  */
 public class AlignmentGui extends JFrame{
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(AlignmentGui.class);
 	private final static long serialVersionUID =0l;
 
 	StructureAlignment algorithm;
@@ -281,7 +284,7 @@ public class AlignmentGui extends JFrame{
 				else if ( selectedIndex == 1)
 					calcDBSearch();
 				else {
-					System.err.println("Unknown TAB: " + selectedIndex);
+					LOGGER.warn("Unknown TAB: " + selectedIndex);
 				}
 
 			}
@@ -328,7 +331,7 @@ public class AlignmentGui extends JFrame{
 
 	protected void configureParameters() {
 		StructureAlignment algorithm = getStructureAlignment();
-		System.out.println("configure parameters for " + algorithm.getAlgorithmName());
+		LOGGER.info("configure parameters for " + algorithm.getAlgorithmName());
 
 		// show a new config GUI
 		new ParameterGUI(algorithm.getParameters(), algorithm.getAlgorithmName());
@@ -368,12 +371,12 @@ public class AlignmentGui extends JFrame{
 			Structure s2 = tab.getStructure2();
 
 			if ( s1 == null) {
-				System.err.println("please select structure 1");
+				LOGGER.info("please select structure 1");
 				return ;
 			}
 
 			if ( s2 == null) {
-				System.err.println("please select structure 2");
+				LOGGER.info("please select structure 2");
 				return;
 			}
 
@@ -388,7 +391,7 @@ public class AlignmentGui extends JFrame{
 				name2 = s2.getName();
 			}
 
-			System.out.println("aligning: " + name1 + " " + name2);
+			LOGGER.info("aligning: " + name1 + " " + name2);
 
 
 			alicalc = new AlignmentCalc(this,s1,s2, name1, name2);
@@ -412,7 +415,7 @@ public class AlignmentGui extends JFrame{
 	private void calcDBSearch() {
 
 		JTabbedPane tabPane = dbsearch.getTabPane();
-		System.out.println("run DB search " + tabPane.getSelectedIndex());
+		LOGGER.info("run DB search " + tabPane.getSelectedIndex());
 
 		Structure s = null;
 		boolean domainSplit = dbsearch.isDomainSplit();
@@ -454,7 +457,7 @@ public class AlignmentGui extends JFrame{
 
 
 
-		System.out.println("name1 in alig gui:" + name1);
+		LOGGER.info("name1 in alig gui:" + name1);
 		String file = dbsearch.getOutFileLocation();
 		if ( file == null || file.equals("") ){
 			JOptionPane.showMessageDialog(null,"Please select a directory to contain the DB search results.");
@@ -493,9 +496,9 @@ public class AlignmentGui extends JFrame{
 			if ( n < 0)
 				return;
 			useNrCPUs = (Integer) options[n];
-			System.out.println("will use " + useNrCPUs + " CPUs." );
+			LOGGER.info("will use " + useNrCPUs + " CPUs." );
 		}
-		System.out.println("using domainSplit data");
+		LOGGER.info("using domainSplit data");
 		alicalc = new AlignmentCalcDB(this, s,  name1,config,file, domainSplit);
 		alicalc.setNrCPUs(useNrCPUs);
 		abortB.setEnabled(true);
@@ -520,7 +523,7 @@ public class AlignmentGui extends JFrame{
 	}
 
 	private void abortCalc(){
-		System.err.println("Interrupting alignment ...");
+		LOGGER.warn("Interrupting alignment ...");
 		if ( alicalc != null )
 			alicalc.interrupt();
 		notifyCalcFinished();

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ChooseDirAction.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ChooseDirAction.java
@@ -26,6 +26,8 @@ package org.biojava.nbio.structure.align.gui;
 
 import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.align.webstart.WebStartMain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
@@ -39,6 +41,7 @@ import java.io.File;
  */
 public class ChooseDirAction extends AbstractAction{
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(ChooseDirAction.class);
 	JTextField textField;
 	UserConfiguration config;
 	public ChooseDirAction (JTextField textField, UserConfiguration config){
@@ -55,7 +58,7 @@ public class ChooseDirAction extends AbstractAction{
 		String txt = textField.getText();
 
 		if ( config == null) {
-			System.out.println("config == null, calling getWebStartConfig...");
+			LOGGER.warn("config == null, calling getWebStartConfig...");
 			config = WebStartMain.getWebStartConfig();
 		}
 		if ( txt != null){

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ConfigPDBInstallPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ConfigPDBInstallPanel.java
@@ -28,6 +28,8 @@ import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.align.webstart.WebStartMain;
 import org.biojava.nbio.structure.gui.util.PDBUploadPanel;
 import org.biojava.nbio.structure.io.LocalPDBDirectory.FetchBehavior;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
@@ -37,6 +39,8 @@ import java.awt.event.KeyEvent;
 
 public class ConfigPDBInstallPanel extends JPanel
 {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ConfigPDBInstallPanel.class);
 
 	/**
 	 *
@@ -190,7 +194,7 @@ public class ConfigPDBInstallPanel extends JPanel
 	}
 	public void setFromFtp(JCheckBox fromFtp)
 	{
-		System.out.println(fromFtp);
+		LOGGER.info(fromFtp.toString());
 		this.fromFtp = fromFtp;
 	}
 	public JTextField getPDBDirField(){

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DBResultTable.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DBResultTable.java
@@ -41,6 +41,8 @@ import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.align.webstart.WebStartMain;
 import org.biojava.nbio.structure.io.PDBFileReader;
 import org.biojava.nbio.structure.io.StructureIOFile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
@@ -57,6 +59,7 @@ import java.util.List;
 
 public class DBResultTable implements ActionListener{
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(DBResultTable.class);
 	public static final String[] ceColumnNames =  {"name1","tname2","score","z-score"    ,"rmsd","len1","len2","cov1","cov2","%ID","Description",""};
 	public static final String[] fatColumnNames = {"name1","tname2","score","probability","rmsd","len1","len2","cov1","cov2","%ID","Description",""};
 
@@ -143,11 +146,11 @@ public class DBResultTable implements ActionListener{
 							}
 						}
 					} catch (IndexOutOfBoundsException e){
-						System.err.println("Unknown scoring strategy from line: " + str);
+						LOGGER.error("Unknown scoring strategy from line: " + str);
 					} catch (IllegalArgumentException e) {
-						System.err.println("Unknown scoring strategy from line: " + str);
+						LOGGER.error("Unknown scoring strategy from line: " + str);
 					} catch (Exception e) {
-						System.err.println("Unknown parameter can't read parameters from line: " + str);
+						LOGGER.error("Unknown parameter can't read parameters from line: " + str);
 						e.printStackTrace();
 					}
 
@@ -156,8 +159,8 @@ public class DBResultTable implements ActionListener{
 			}
 			String[] spl = str.split("\t");
 			if ( spl.length != ceColumnNames.length -1) {
-				System.err.println("wrong table width! " + spl.length + " should be: " + (ceColumnNames.length -1 ));
-				System.err.println(str);
+				LOGGER.info("wrong table width! " + spl.length + " should be: " + (ceColumnNames.length -1 ));
+				LOGGER.info(str);
 				continue;
 			}
 			tmpdat.add(spl);
@@ -248,7 +251,7 @@ public class DBResultTable implements ActionListener{
 			algorithm = StructureAlignmentFactory.getAlgorithm(algorithmName);
 		} catch (Exception e){
 			e.printStackTrace();
-			System.err.println("Can't guess algorithm from output. Using jCE as default...");
+			LOGGER.error("Can't guess algorithm from output. Using jCE as default...");
 			try {
 				algorithm = StructureAlignmentFactory.getAlgorithm(CeMain.algorithmName);
 			} catch (Exception ex){
@@ -275,7 +278,7 @@ public class DBResultTable implements ActionListener{
 			output.append(String.format(" %d", c));
 		}
 
-		System.out.println(output.toString());
+		LOGGER.info(output.toString());
 	}
 
 	private class RowListener implements ListSelectionListener {
@@ -291,7 +294,7 @@ public class DBResultTable implements ActionListener{
 			if ( name1.equals(oldName1) && oldName2.equals(name2)){
 				return;
 			}
-			System.out.println("recreating alignment of: " + name1 + " " + name2 + " using " + algorithmName);
+			LOGGER.info("recreating alignment of: " + name1 + " " + name2 + " using " + algorithmName);
 			outputSelection();
 			showAlignment(name1,name2);
 			oldName1 = name1;

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DisplayAFP.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DisplayAFP.java
@@ -111,7 +111,7 @@ public class DisplayAFP {
 	public static final List<String> getPDBresnum(int aligPos, AFPChain afpChain, Atom[] ca){
 		List<String> lst = new ArrayList<String>();
 		if ( aligPos > 1) {
-			System.err.println("multiple alignments not supported yet!");
+			logger.warn("multiple alignments not supported yet!");
 			return lst;
 		}
 
@@ -184,11 +184,11 @@ public class DisplayAFP {
 		}
 
 		if ( capos < 0) {
-			System.err.println("could not match position " + aligPos + " in chain " + chainNr +". Returing null...");
+			logger.warn("could not match position " + aligPos + " in chain " + chainNr +". Returing null...");
 			return null;
 		}
 		if ( capos > ca.length){
-			System.err.println("Atom array "+ chainNr + " does not have " + capos +" atoms. Returning null.");
+			logger.warn("Atom array "+ chainNr + " does not have " + capos +" atoms. Returning null.");
 			return null;
 		}
 		return ca[capos];
@@ -552,7 +552,7 @@ public class DisplayAFP {
 		StructureAlignmentJmol jmol = new StructureAlignmentJmol(afpChain,arr1,arr2);
 		//jmol.setStructure(artificial);
 
-		System.out.format("CA2[0]=(%.2f,%.2f,%.2f)%n", arr2[0].getX(), arr2[0].getY(), arr2[0].getZ());
+		logger.info(String.format("CA2[0]=(%.2f,%.2f,%.2f)%n", arr2[0].getX(), arr2[0].getY(), arr2[0].getZ()));
 
 		//jmol.setTitle("Structure Alignment: " + afpChain.getName1() + " vs. " + afpChain.getName2());
 		jmol.setTitle(title);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DotPlotPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DotPlotPanel.java
@@ -32,6 +32,8 @@ import org.biojava.nbio.structure.align.pairwise.AlternativeAlignment;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.gui.ScaleableMatrixPanel;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.event.WindowAdapter;
@@ -51,6 +53,7 @@ import java.util.List;
  */
 public class DotPlotPanel extends ScaleableMatrixPanel {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(DotPlotPanel.class);
 	private static final long serialVersionUID = -7641953255857483895L;
 
 	/**
@@ -203,7 +206,7 @@ public class DotPlotPanel extends ScaleableMatrixPanel {
 			afpChain.setName1(name1);
 			afpChain.setName2(name2);
 			for ( AFP afpI : afpChain.getAfpSet()){
-				System.out.println(afpI);
+				LOGGER.info(afpI.toString());
 			}
 
 			/*
@@ -241,12 +244,12 @@ public class DotPlotPanel extends ScaleableMatrixPanel {
 			// Now make it circular
 			ceA = (CeMain) StructureAlignmentFactory.getAlgorithm(CeCPMain.algorithmName);
 
-			System.out.format("Aligning %s[%d] with %s[%d] with CPs\n",name1,ca1.length,name2,ca2.length);
+			LOGGER.info(String.format("Aligning %s[%d] with %s[%d] with CPs\n",name1,ca1.length,name2,ca2.length));
 			afpChain = ceA.align(ca1,ca2);
 			afpChain.setName1(name1);
 			afpChain.setName2(name2+"-"+name2);
 			for ( AFP afpI : afpChain.getAfpSet()){
-				System.out.println(afpI);
+				LOGGER.info(afpI.toString());
 			}
 
 			/*/ Reuse mat from the non-cp case, for simplicity

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/GUIAlignmentProgressListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/GUIAlignmentProgressListener.java
@@ -22,6 +22,8 @@ package org.biojava.nbio.structure.align.gui;
 
 import org.biojava.nbio.structure.align.FarmJob;
 import org.biojava.nbio.structure.align.events.AlignmentProgressListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
@@ -34,9 +36,7 @@ import java.awt.event.ActionListener;
  *
  */
 public class GUIAlignmentProgressListener extends JPanel implements AlignmentProgressListener, ActionListener {
-
-
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(GUIAlignmentProgressListener.class);
 
 	/**
 	 *
@@ -103,7 +103,7 @@ public class GUIAlignmentProgressListener extends JPanel implements AlignmentPro
 		setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
 		progressBar.setIndeterminate(true);
 		progressBar.setStringPainted(false);
-		System.out.println("terminating jobs");
+		LOGGER.info("terminating jobs");
 
 		farmJob.terminate();
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/JPrintPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/JPrintPanel.java
@@ -24,6 +24,9 @@
 
 package org.biojava.nbio.structure.align.gui;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -34,6 +37,9 @@ import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 
 public class JPrintPanel extends JPanel implements Printable,ActionListener{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JPrintPanel.class);
+
 	/**
 	 *
 	 */
@@ -74,7 +80,7 @@ public class JPrintPanel extends JPanel implements Printable,ActionListener{
 				printJob.print();
 			}
 		} catch (Exception printException) {
-			System.err.println("Error during printing: " +printException.getMessage());
+			LOGGER.error("Error during printing: " +printException.getMessage());
 			printException.printStackTrace();
 		}
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MemoryMonitor.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MemoryMonitor.java
@@ -39,6 +39,9 @@
 
 package org.biojava.nbio.structure.align.gui;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.swing.*;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
@@ -54,7 +57,7 @@ import java.util.Date;
  * Tracks Memory allocated & used, displayed in graph form.
  */
 public class MemoryMonitor extends JPanel {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(MemoryMonitor.class);
 	static JCheckBox dateStampCB = new JCheckBox("Output Date Stamp");
 	public Surface surf;
 	JPanel controls;
@@ -313,7 +316,7 @@ public class MemoryMonitor extends JPanel {
 					Thread.sleep(sleepAmount);
 				} catch (InterruptedException e) { break; }
 				if (MemoryMonitor.dateStampCB.isSelected()) {
-					System.out.println(new Date().toString() + " " + usedStr);
+					LOGGER.info(new Date().toString() + " " + usedStr);
 				}
 			}
 			thread = null;

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MenuCreator.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MenuCreator.java
@@ -27,6 +27,8 @@ import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.multiple.MultipleAlignment;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.align.webstart.WebStartMain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 
@@ -47,6 +49,8 @@ import java.io.File;
  *
  */
 public class MenuCreator {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MenuCreator.class);
 
 	public static final String PRINT     = "Print";
 	public static final String ALIGNMENT_PANEL = "Alignment Panel";
@@ -698,7 +702,7 @@ public class MenuCreator {
 		if (imgURL != null) {
 			return new ImageIcon(imgURL);
 		} else {
-			System.err.println("Couldn't find file: " + path);
+			LOGGER.error("Couldn't find file: " + path);
 			return null;
 		}
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MultipleAlignmentGUI.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MultipleAlignmentGUI.java
@@ -49,6 +49,8 @@ import org.biojava.nbio.structure.align.ce.ConfigStrucAligParams;
 import org.biojava.nbio.structure.align.multiple.mc.MultipleMcMain;
 import org.biojava.nbio.structure.align.webstart.AligUIManager;
 import org.biojava.nbio.structure.gui.util.SelectMultiplePanel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A JFrame that allows to trigger a multiple structure alignment,
@@ -63,7 +65,7 @@ import org.biojava.nbio.structure.gui.util.SelectMultiplePanel;
  *
  */
 public class MultipleAlignmentGUI extends JFrame {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(MultipleAlignmentGUI.class);
 	private final static long serialVersionUID =0l;
 	private final static String version = "1.0";
 
@@ -288,7 +290,7 @@ public class MultipleAlignmentGUI extends JFrame {
 			List<Structure> structures = tab.getStructures();
 
 			if ( structures.size() < 2) {
-				System.err.println("please input more than 1 structure");
+				LOGGER.error("please input more than 1 structure");
 				return;
 			}
 
@@ -298,7 +300,7 @@ public class MultipleAlignmentGUI extends JFrame {
 			for (StructureIdentifier name:names){
 				message += name.getIdentifier() + " ";
 			}
-			System.out.println(message);
+			LOGGER.info(message);
 
 			alicalc = new MultipleAlignmentCalc(this, structures, names);
 
@@ -324,7 +326,7 @@ public class MultipleAlignmentGUI extends JFrame {
 	}
 
 	private void abortCalc(){
-		System.err.println("Interrupting alignment ...");
+		LOGGER.error("Interrupting alignment ...");
 		if (alicalc != null) alicalc.interrupt();
 		notifyCalcFinished();
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MyDistMaxListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MyDistMaxListener.java
@@ -22,6 +22,8 @@ package org.biojava.nbio.structure.align.gui;
 import org.biojava.nbio.structure.align.gui.jmol.AbstractAlignmentJmol;
 import org.biojava.nbio.structure.gui.ScaleableMatrixPanel;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 
@@ -35,6 +37,8 @@ import java.awt.event.WindowEvent;
  */
 public class MyDistMaxListener implements ActionListener{
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(MyDistMaxListener.class);
+
 	AbstractAlignmentJmol parent;
 
 	public MyDistMaxListener(AbstractAlignmentJmol parent){
@@ -44,10 +48,10 @@ public class MyDistMaxListener implements ActionListener{
 	@Override
 	public void actionPerformed(ActionEvent a) {
 
-		System.out.println("Show interatomic Distance Matrices");
+		LOGGER.info("Show interatomic Distance Matrices");
 
 		if (parent.getDistanceMatrices() == null) {
-			System.err.println("Not displaying any alignment currently!");
+			LOGGER.error("Not displaying any alignment currently!");
 			return;
 		}
 		for (int i=0; i<parent.getDistanceMatrices().size(); i++){

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MyExportListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MyExportListener.java
@@ -21,6 +21,9 @@ package org.biojava.nbio.structure.align.gui;
 
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.align.gui.jmol.AbstractAlignmentJmol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.swing.*;
 
 import java.awt.event.ActionEvent;
@@ -31,6 +34,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 
 public class MyExportListener implements ActionListener{
+	private static final Logger LOGGER = LoggerFactory.getLogger(MyExportListener.class);
 
 	AbstractAlignmentJmol parent;
 	MyExportListener(AbstractAlignmentJmol parent){
@@ -46,7 +50,7 @@ public void actionPerformed(ActionEvent arg0)
 		if (returnVal == JFileChooser.APPROVE_OPTION) {
 			File file = fc.getSelectedFile();
 			//This is where a real application would open the file.
-			System.out.println("Exporting PDB file to: " + file.getName());
+			LOGGER.info("Exporting PDB file to: " + file.getName());
 
 			Structure s = parent.getStructure();
 
@@ -60,7 +64,7 @@ public void actionPerformed(ActionEvent arg0)
 
 
 		} else {
-			System.out.println("Export command cancelled by user.");
+			LOGGER.info("Export command cancelled by user.");
 		}
 
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MySaveFileListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MySaveFileListener.java
@@ -28,6 +28,8 @@ import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.align.webstart.WebStartMain;
 import org.biojava.nbio.structure.align.xml.AFPChainXMLConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 
@@ -51,6 +53,8 @@ import java.io.FileWriter;
  *
  */
 public class MySaveFileListener implements ActionListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MySaveFileListener.class);
 
 	private AFPChain afpChain;
 	private MultipleAlignment msa;
@@ -98,13 +102,13 @@ public class MySaveFileListener implements ActionListener {
 		int returnVal = fc.showSaveDialog(null);
 
 		if (returnVal != JFileChooser.APPROVE_OPTION) {
-			System.err.println("User canceled file save.");
+			LOGGER.error("User canceled file save.");
 			return;
 		}
 		File selFile = fc.getSelectedFile();
 		if (selFile == null) return;
 
-		System.out.println("Saving alignment to file: " + selFile.getName());
+		LOGGER.info("Saving alignment to file: " + selFile.getName());
 
 		//XML serialization of the alignment
 		try {

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ParameterGUI.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ParameterGUI.java
@@ -21,6 +21,8 @@
 package org.biojava.nbio.structure.align.gui;
 
 import org.biojava.nbio.structure.align.ce.ConfigStrucAligParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
@@ -50,6 +52,8 @@ import java.util.List;
  *
  */
 public class ParameterGUI extends JFrame{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ParameterGUI.class);
 
 	private static final long serialVersionUID = 723386061184110161L;
 
@@ -248,7 +252,7 @@ public class ParameterGUI extends JFrame{
 			String key  = keys.get(i);
 			// String name = keys.get(i);
 			String value = null;
-			System.out.println(key);
+			LOGGER.info(key);
 			if( type.isEnum() ) {
 				JComboBox field = (JComboBox)  textFields.get(i);
 				Enum sel = (Enum)field.getSelectedItem();
@@ -268,7 +272,7 @@ public class ParameterGUI extends JFrame{
 			setValue(key, type, value);
 		}
 
-		System.out.println("new parameters: " + params.toString());
+		LOGGER.info("new parameters: " + params.toString());
 
 	}
 
@@ -301,7 +305,7 @@ public class ParameterGUI extends JFrame{
 			}
 
 			if (data == null){
-				System.err.println("Could not set value " + value +
+				LOGGER.error("Could not set value " + value +
 						" for field " + name);
 				return;
 			}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/SelectPDBPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/SelectPDBPanel.java
@@ -50,8 +50,6 @@ public class SelectPDBPanel
 extends JPanel
 implements StructurePairSelector{
 
-	boolean debug = true;
-
 	JTextField f1;
 	JTextField f2;
 	JTextField c1;

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/StructureAlignmentDisplay.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/StructureAlignmentDisplay.java
@@ -34,8 +34,12 @@ import org.biojava.nbio.structure.align.fatcat.FatCatRigid;
 import org.biojava.nbio.structure.align.gui.jmol.StructureAlignmentJmol;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StructureAlignmentDisplay {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StructureAlignmentDisplay.class);
 
 	/** Display an AFPChain alignment
 	 *
@@ -73,7 +77,7 @@ public class StructureAlignmentDisplay {
 
 		if ( afpChain.getBlockRotationMatrix().length == 0 ) {
 			// probably the alignment is too short!
-			System.err.println("No rotation matrix found to rotate 2nd structure!");
+			LOGGER.error("No rotation matrix found to rotate 2nd structure!");
 			afpChain.setBlockRotationMatrix(new Matrix[]{Matrix.identity(3, 3)});
 			afpChain.setBlockShiftVector(new Atom[]{new AtomImpl()});
 		}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/StructureLoaderThread.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/StructureLoaderThread.java
@@ -28,11 +28,15 @@ import org.biojava.nbio.structure.align.gui.jmol.StructureAlignmentJmol;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.quaternary.BioAssemblyTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
 
 public class StructureLoaderThread extends SwingWorker<String, Object> {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StructureLoaderThread.class);
 
 	String name;
 	boolean showBiolAssembly;
@@ -49,7 +53,7 @@ public class StructureLoaderThread extends SwingWorker<String, Object> {
 	@Override
 	protected String doInBackground() {
 
-		System.out.println("loading " + name );
+		LOGGER.info("loading " + name );
 
 		AtomCache cache = new AtomCache(config.getPdbFilePath(),config.getCacheFilePath());
 		Structure s = null;
@@ -62,7 +66,7 @@ public class StructureLoaderThread extends SwingWorker<String, Object> {
 				if ( atomCount > 200000){
 					// uh oh, we are probably going to exceed 512 MB usage...
 					// scale down to something smaller
-					System.err.println("Structure very large. Reducing display to C alpha atoms only");
+					LOGGER.error("Structure very large. Reducing display to C alpha atoms only");
 					s = BioAssemblyTools.getReducedStructure(s);
 				}
 
@@ -70,7 +74,7 @@ public class StructureLoaderThread extends SwingWorker<String, Object> {
 				s = cache.getStructure(name);
 			}
 
-			System.out.println("done loading structure...");
+			LOGGER.info("done loading structure...");
 
 
 			StructureAlignmentJmol jmol = new StructureAlignmentJmol();

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/StructureLoaderThread.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/StructureLoaderThread.java
@@ -66,7 +66,7 @@ public class StructureLoaderThread extends SwingWorker<String, Object> {
 				if ( atomCount > 200000){
 					// uh oh, we are probably going to exceed 512 MB usage...
 					// scale down to something smaller
-					LOGGER.error("Structure very large. Reducing display to C alpha atoms only");
+					LOGGER.warn("Structure very large. Reducing display to C alpha atoms only");
 					s = BioAssemblyTools.getReducedStructure(s);
 				}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/AligPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/AligPanel.java
@@ -39,6 +39,8 @@ import org.biojava.nbio.structure.align.xml.AFPChainXMLParser;
 import org.biojava.nbio.structure.gui.events.AlignmentPositionListener;
 import org.biojava.nbio.structure.gui.util.AlignedPosition;
 import org.biojava.nbio.structure.gui.util.color.ColorUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.awt.*;
 import java.awt.event.ActionEvent;
@@ -56,6 +58,8 @@ import java.util.List;
  *
  */
 public class AligPanel  extends JPrintPanel implements AlignmentPositionListener, WindowListener{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AligPanel.class);
 
 	/**
 	 *
@@ -604,7 +608,7 @@ public void actionPerformed(ActionEvent e) {
 			colorByAlignmentBlock();
 		}
 		else {
-			System.err.println("Unknown command:" + cmd);
+			LOGGER.error("Unknown command:" + cmd);
 		}
 
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/MultipleAligPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/MultipleAligPanel.java
@@ -49,6 +49,8 @@ import org.biojava.nbio.structure.align.multiple.util.MultipleAlignmentWriter;
 import org.biojava.nbio.structure.align.util.AFPAlignmentDisplay;
 import org.biojava.nbio.structure.gui.events.AlignmentPositionListener;
 import org.biojava.nbio.structure.gui.util.AlignedPosition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A JPanel that can display the sequence alignment of a
@@ -67,6 +69,8 @@ import org.biojava.nbio.structure.gui.util.AlignedPosition;
  */
 public class MultipleAligPanel extends JPrintPanel
 implements AlignmentPositionListener, WindowListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MultipleAligPanel.class);
 
 	private static final long serialVersionUID = -6892229111166263764L;
 
@@ -457,7 +461,7 @@ implements AlignmentPositionListener, WindowListener {
 		} else if ( cmd.equals(MenuCreator.FATCAT_BLOCK)){
 			colorByAlignmentBlock();
 		} else {
-			System.err.println("Unknown command:" + cmd);
+			LOGGER.error("Unknown command:" + cmd);
 		}
 	}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/JAutoSuggest.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/JAutoSuggest.java
@@ -24,6 +24,9 @@
  */
 package org.biojava.nbio.structure.align.gui.autosuggest;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.*;
@@ -39,6 +42,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *
  */
 public class JAutoSuggest extends JTextField{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JAutoSuggest.class);
 
 	/**
 	 *
@@ -132,7 +137,7 @@ public class JAutoSuggest extends JTextField{
 		addFocusListener(new FocusListener() {
 			@Override
 			public void focusLost(FocusEvent e) {
-				System.out.println("Lost Focus");
+				LOGGER.info("Lost Focus");
 				dialog.setVisible(false);
 
 				if (getText().trim().equals("") && e.getOppositeComponent() != null && e.getOppositeComponent().getName() != null) {
@@ -146,7 +151,7 @@ public class JAutoSuggest extends JTextField{
 
 			@Override
 			public void focusGained(FocusEvent e) {
-				System.out.println("Lost Gained");
+				LOGGER.info("Lost Gained");
 				if (getText().trim().equals(defaultText)) {
 					setText("");
 				}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/SCOPAutoSuggestProvider.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/SCOPAutoSuggestProvider.java
@@ -40,8 +40,6 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(SCOPAutoSuggestProvider.class);
 
-	boolean DEBUG = false;
-
 	int maxResults = 20;
 
 	AtomicBoolean stop = new AtomicBoolean(false);
@@ -75,8 +73,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 
 		long timeE = System.currentTimeMillis();
 
-		if ( DEBUG)
-			LOGGER.debug("ScopAutoSuggestProvider took " + (timeE - timeS) + " ms. to get " + v.size() + " suggestions");
+		LOGGER.debug("ScopAutoSuggestProvider took " + (timeE - timeS) + " ms. to get " + v.size() + " suggestions");
 
 		return v;
 
@@ -128,8 +125,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 			if ( stop.get())
 				return domains;
 
-			if (DEBUG)
-				LOGGER.debug("domains: " + domains);
+			LOGGER.debug("domains: " + domains);
 
 			if ( domains == null || domains.size() < 1) {
 				if ( userInput.length() > 0 ){
@@ -182,8 +178,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 	@Override
 	public void stop() {
 		stop.set(true);
-		if (DEBUG)
-			LOGGER.debug("ScopAutoSuggestProvider got signal stop");
+		LOGGER.debug("ScopAutoSuggestProvider got signal stop");
 
 	}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/SCOPAutoSuggestProvider.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/SCOPAutoSuggestProvider.java
@@ -28,6 +28,8 @@ import org.biojava.nbio.structure.scop.ScopDatabase;
 import org.biojava.nbio.structure.scop.ScopDescription;
 import org.biojava.nbio.structure.scop.ScopDomain;
 import org.biojava.nbio.structure.scop.ScopFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,6 +37,8 @@ import java.util.Vector;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SCOPAutoSuggestProvider.class);
 
 	boolean DEBUG = false;
 
@@ -72,7 +76,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 		long timeE = System.currentTimeMillis();
 
 		if ( DEBUG)
-			System.out.println("ScopAutoSuggestProvider took " + (timeE - timeS) + " ms. to get " + v.size() + " suggestions");
+			LOGGER.debug("ScopAutoSuggestProvider took " + (timeE - timeS) + " ms. to get " + v.size() + " suggestions");
 
 		return v;
 
@@ -125,7 +129,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 				return domains;
 
 			if (DEBUG)
-				System.out.println("domains: " + domains);
+				LOGGER.debug("domains: " + domains);
 
 			if ( domains == null || domains.size() < 1) {
 				if ( userInput.length() > 0 ){
@@ -179,7 +183,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 	public void stop() {
 		stop.set(true);
 		if (DEBUG)
-			System.out.println("ScopAutoSuggestProvider got signal stop");
+			LOGGER.debug("ScopAutoSuggestProvider got signal stop");
 
 	}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/AtomInfo.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/AtomInfo.java
@@ -22,6 +22,9 @@
  */
 package org.biojava.nbio.structure.align.gui.jmol;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,6 +35,8 @@ import java.util.regex.Pattern;
  *
  */
 public class AtomInfo {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AtomInfo.class);
 
 	String chainId;
 	String atomName;
@@ -131,7 +136,7 @@ public class AtomInfo {
 
 			boolean found = matcher.find();
 			if ( ! found) {
-				System.err.println("JmolTools: could not parse the residue number string " + res1);
+				LOGGER.error("JmolTools: could not parse the residue number string " + res1);
 				buf.append(res1);
 			} else {
 				String residueNumber = matcher.group(1);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/AtomInfoParser.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/AtomInfoParser.java
@@ -52,8 +52,8 @@ public class AtomInfoParser {
 	public static void main(String[]args){
 		String s1 = "[GLY]371:A.CA #2811";
 		String s2 = "[ASP]1^A:A.CA/2 #2";
-		System.out.println(s1 + " got: " + AtomInfoParser.parse(s1));
-		System.out.println(s2 + " got: " + AtomInfoParser.parse(s2));
+		logger.info(s1 + " got: " + AtomInfoParser.parse(s1));
+		logger.info(s2 + " got: " + AtomInfoParser.parse(s2));
 	}
 
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolPanel.java
@@ -39,6 +39,7 @@ import org.jmol.api.JmolAdapter;
 import org.jmol.api.JmolStatusListener;
 import org.jmol.api.JmolViewer;
 import org.jmol.util.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
@@ -52,6 +53,8 @@ public class JmolPanel
 extends JPrintPanel
 implements ActionListener
 {
+	private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(JmolPanel.class);
+
 	private static final long serialVersionUID = -3661941083797644242L;
 
 	private JmolViewer viewer;
@@ -255,7 +258,7 @@ implements ActionListener
 
 		List<ScopDomain> domains = scop.getDomainsForPDB(pdbId);
 		if ( domains == null) {
-			System.err.println("No SCOP domains found for " + pdbId);
+			LOGGER.error("No SCOP domains found for " + pdbId);
 			return;
 		}
 		int i = -1;
@@ -267,7 +270,7 @@ implements ActionListener
 			List<String>ranges = domain.getRanges();
 
 			for (String range : ranges){
-				if(verbose) System.out.println(range);
+				if(verbose) LOGGER.info(range);
 				String[] spl = range.split(":");
 				String script = " select  ";
 				if ( spl.length > 1 )
@@ -276,7 +279,7 @@ implements ActionListener
 					script += "*" + spl[0]+"/1;";
 				script += " color [" + c1.getRed() + ","+c1.getGreen() + "," +c1.getBlue()+"];";
 				script += " color cartoon [" + c1.getRed() + ","+c1.getGreen() + "," +c1.getBlue()+"] ;";
-				if(verbose) System.out.println(script);
+				if(verbose) LOGGER.info(script);
 				evalString(script);
 
 			}
@@ -286,7 +289,7 @@ implements ActionListener
 	}
 
 	private void colorByPDP() {
-		if(verbose) System.out.println("colorByPDP");
+		if(verbose) LOGGER.info("colorByPDP");
 		if ( structure == null)
 			return;
 
@@ -310,13 +313,13 @@ implements ActionListener
 					int end = s.getTo();
 					Group startG = ca[start].getGroup();
 					Group endG = ca[end].getGroup();
-					if(verbose) System.out.println("   Segment: " +startG.getResidueNumber() +":" + startG.getChainId() + " - " + endG.getResidueNumber()+":"+endG.getChainId() + " " + s);
+					if(verbose) LOGGER.info("   Segment: " +startG.getResidueNumber() +":" + startG.getChainId() + " - " + endG.getResidueNumber()+":"+endG.getChainId() + " " + s);
 					String j1 = startG.getResidueNumber()+"";
 					String j2 = endG.getResidueNumber()+":"+endG.getChainId();
 					String script = " select  " +j1 +"-" +j2 +"/1;";
 					script += " color [" + c1.getRed() + ","+c1.getGreen() + "," +c1.getBlue()+"];";
 					script += " color cartoon [" + c1.getRed() + ","+c1.getGreen() + "," +c1.getBlue()+"] ;";
-					if(verbose) System.out.println(script);
+					if(verbose) LOGGER.info(script);
 					evalString(script);
 				}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolTools.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolTools.java
@@ -61,7 +61,7 @@ public class JmolTools {
 		g.addAtom(a);
 		c.addGroup(g);
 
-		System.out.println(getPdbInfo(a));
+		LOGGER.info(getPdbInfo(a));
 	}
 
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolTools.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolTools.java
@@ -21,11 +21,15 @@
 package org.biojava.nbio.structure.align.gui.jmol;
 
 import org.biojava.nbio.structure.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class JmolTools {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JmolTools.class);
 
 	/** get jmol style info:
 	 *  jmol style: [MET]508:A.CA/1 #3918
@@ -95,7 +99,7 @@ public class JmolTools {
 
 			boolean found = matcher.find();
 			if ( ! found) {
-				System.err.println("JmolTools: could not parse the residue number string " + res1);
+				LOGGER.error("JmolTools: could not parse the residue number string " + res1);
 				buf.append(res1);
 			} else {
 				String residueNumber = matcher.group(1);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/MyJmolStatusListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/MyJmolStatusListener.java
@@ -26,6 +26,8 @@ package org.biojava.nbio.structure.align.gui.jmol;
 
 import org.jmol.api.JmolStatusListener;
 import org.jmol.constant.EnumCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 
@@ -33,6 +35,8 @@ import java.util.Hashtable;
 import java.util.Map;
 
 public class MyJmolStatusListener implements JmolStatusListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MyJmolStatusListener.class);
 
 	private boolean verbose = false;
 
@@ -52,13 +56,13 @@ public class MyJmolStatusListener implements JmolStatusListener {
 
 	@Override
 	public String eval(String arg0) {
-		if(verbose) System.out.println("eval " + arg0);
+		if(verbose) LOGGER.info("eval " + arg0);
 		return null;
 	}
 
 	@Override
 	public float[][] functionXY(String arg0, int arg1, int arg2) {
-		if(verbose) System.out.println("XY " + arg0 + " " + arg1 + " " + arg2);
+		if(verbose) LOGGER.info("XY " + arg0 + " " + arg1 + " " + arg2);
 		return null;
 	}
 
@@ -93,26 +97,26 @@ public class MyJmolStatusListener implements JmolStatusListener {
 
 	@Override
 	public void setCallbackFunction(String arg0, String arg1) {
-		if(verbose) System.out.println("callback:" + arg0 + " " + arg1);
+		if(verbose) LOGGER.info("callback:" + arg0 + " " + arg1);
 		status.setText(arg0 + " " + arg1);
 
 	}
 
 	public String dialogAsk(String arg0, String arg1) {
 		// TODO Auto-generated method stub
-		if(verbose) System.out.println("dialogAsk");
+		if(verbose) LOGGER.info("dialogAsk");
 		return null;
 	}
 
 	public void handlePopupMenu(int arg0, int arg1) {
 		// TODO Auto-generated method stub
-		if(verbose) System.out.println("handlePopupMenu");
+		if(verbose) LOGGER.info("handlePopupMenu");
 	}
 
 	public void showConsole(boolean arg0) {
 
 		// TODO Auto-generated method stub
-		if(verbose) System.out.println("showConsole");
+		if(verbose) LOGGER.info("showConsole");
 
 	}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/StructureAlignmentJmol.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/StructureAlignmentJmol.java
@@ -35,6 +35,8 @@ import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.align.webstart.AligUIManager;
 import org.biojava.nbio.structure.gui.util.color.ColorUtils;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 
@@ -52,6 +54,8 @@ import java.util.List;
  *
  */
 public class StructureAlignmentJmol extends AbstractAlignmentJmol {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StructureAlignmentJmol.class);
 
 	private Atom[] ca1;
 	private Atom[] ca2;
@@ -201,7 +205,7 @@ public class StructureAlignmentJmol extends AbstractAlignmentJmol {
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				System.out.println("reset!!");
+				LOGGER.info("reset!!");
 				jmolPanel.executeCmd("restore STATE state_1");
 
 			}
@@ -310,7 +314,7 @@ public class StructureAlignmentJmol extends AbstractAlignmentJmol {
 		String cmd = e.getActionCommand();
 		if ( cmd.equals(MenuCreator.TEXT_ONLY)) {
 			if ( afpChain == null) {
-				System.err.println("Currently not viewing an alignment!");
+				LOGGER.error("Currently not viewing an alignment!");
 				return;
 			}
 			//Clone the AFPChain to not override the FatCat numbers in alnsymb
@@ -321,7 +325,7 @@ public class StructureAlignmentJmol extends AbstractAlignmentJmol {
 
 		} else if ( cmd.equals(MenuCreator.PAIRS_ONLY)) {
 			if ( afpChain == null) {
-				System.err.println("Currently not viewing an alignment!");
+				LOGGER.error("Currently not viewing an alignment!");
 				return;
 			}
 			String result = AfpChainWriter.toAlignedPairs(afpChain, ca1, ca2) ;
@@ -330,7 +334,7 @@ public class StructureAlignmentJmol extends AbstractAlignmentJmol {
 
 		} else if (cmd.equals(MenuCreator.ALIGNMENT_PANEL)){
 			if ( afpChain == null) {
-				System.err.println("Currently not viewing an alignment!");
+				LOGGER.error("Currently not viewing an alignment!");
 				return;
 			}
 			try {
@@ -342,7 +346,7 @@ public class StructureAlignmentJmol extends AbstractAlignmentJmol {
 
 		} else if (cmd.equals(MenuCreator.FATCAT_TEXT)){
 			if ( afpChain == null) {
-				System.err.println("Currently not viewing an alignment!");
+				LOGGER.error("Currently not viewing an alignment!");
 				return;
 			}
 			String result = afpChain.toFatcat(ca1, ca2) ;

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/webstart/JNLPProxy.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/webstart/JNLPProxy.java
@@ -36,6 +36,9 @@
 
 package org.biojava.nbio.structure.align.webstart;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.Method;
 import java.net.URL;
 
@@ -44,6 +47,7 @@ public final class  JNLPProxy
 //////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////
 {
+private static final Logger LOGGER = LoggerFactory.getLogger(JNLPProxy.class);
 
 private static final Object  basicServiceObject
 	= getBasicServiceObject ( );
@@ -71,7 +75,7 @@ public static boolean  showDocument ( URL  url )
 {
 	if ( basicServiceObject == null )
 	{
-			System.out.println("basisServiceObject = null");
+			LOGGER.error("basisServiceObject = null");
 			return false;
 	}
 
@@ -85,7 +89,7 @@ public static boolean  showDocument ( URL  url )
 
 		boolean success = resultBoolean.booleanValue ( );
 		if ( ! success )
-		System.out.println("invocation of method failed!");
+			LOGGER.error("invocation of method failed!");
 		return success;
 	}
 	catch ( Exception  ex )

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/webstart/WebStartMain.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/webstart/WebStartMain.java
@@ -39,6 +39,8 @@ import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.seq.SmithWaterman3Daligner;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 
@@ -46,6 +48,7 @@ import java.io.File;
 
 public class WebStartMain
 {
+	private static final Logger LOGGER = LoggerFactory.getLogger(WebStartMain.class);
 
 	static UserConfiguration userConfig;
 
@@ -286,7 +289,7 @@ public class WebStartMain
 		File file = new File(textField.getText());
 		if ( ! file.isDirectory() ){
 			// should not happen
-			System.err.println("did not provide directory, going on level higher! " + file.getAbsolutePath());
+			LOGGER.error("did not provide directory, going on level higher! " + file.getAbsolutePath());
 			file = file.getParentFile();
 		}
 		System.setProperty(UserConfiguration.PDB_DIR, file.getAbsolutePath());
@@ -330,7 +333,7 @@ public class WebStartMain
 		// show results
 		StructureAlignmentJmol jmol =  StructureAlignmentDisplay.display(afpChain,ca1,ca2);
 
-		System.out.println(afpChain.toCE(ca1, ca2));
+		LOGGER.info(afpChain.toCE(ca1, ca2));
 
 		DisplayAFP.showAlignmentPanel(afpChain,ca1,ca2,jmol);
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/webstart/WebStartMain.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/webstart/WebStartMain.java
@@ -130,12 +130,12 @@ public class WebStartMain
 			String name2 = args[2];
 
 			PdbPair pair = new PdbPair(name1, name2);
-			System.out.println("### user provided: " + pair);
+			LOGGER.info("### user provided: " + pair);
 
 			UserConfiguration config = getWebStartConfig();
 
 			System.setProperty(UserConfiguration.PDB_DIR,config.getPdbFilePath());
-			System.out.println("using PDB file path: " + config.getPdbFilePath());
+			LOGGER.info("using PDB file path: " + config.getPdbFilePath());
 
 			AtomCache cache = new AtomCache(config);
 
@@ -149,7 +149,7 @@ public class WebStartMain
 
 			frame.dispose();
 
-			System.out.println("done reading structures");
+			LOGGER.info("done reading structures");
 
 
 			if (arg0.equalsIgnoreCase("ce") ||

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/BiojavaJmol.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/BiojavaJmol.java
@@ -29,6 +29,8 @@ import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.align.gui.jmol.JmolPanel;
 import org.biojava.nbio.structure.gui.util.MenuCreator;
 import org.biojava.nbio.structure.io.PDBFileReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.*;
@@ -44,6 +46,8 @@ import java.awt.event.*;
  *
  */
 public class BiojavaJmol  {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(BiojavaJmol.class);
 
 	public static final String viewer       = "org.jmol.api.JmolSimpleViewer";
 	public static final String adapter      = "org.jmol.api.JmolAdapter";
@@ -153,7 +157,7 @@ public class BiojavaJmol  {
 
 			@Override
 			public void actionPerformed(ActionEvent e) {
-				System.out.println("reset!!");
+				LOGGER.info("reset!!");
 				jmolPanel.executeCmd("restore STATE state_1");
 
 			}
@@ -213,7 +217,7 @@ public class BiojavaJmol  {
 
 	public void evalString(String rasmolScript){
 		if ( jmolPanel == null ){
-			System.err.println("please install Jmol first");
+			LOGGER.warn("please install Jmol first");
 			return;
 		}
 		jmolPanel.evalString(rasmolScript);
@@ -222,7 +226,7 @@ public class BiojavaJmol  {
 	public void setStructure(Structure s) {
 
 		if ( jmolPanel == null ){
-			System.err.println("please install Jmol first");
+			LOGGER.warn("please install Jmol first");
 			return;
 		}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/JmolViewerImpl.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/JmolViewerImpl.java
@@ -71,7 +71,7 @@ public class JmolViewerImpl implements StructureViewer {
 
 		} catch (ClassNotFoundException e) {
 			e.printStackTrace();
-			System.err.println("Could not find Jmol in classpath, please install first. http://www.jmol.org");
+			logger.error("Could not find Jmol in classpath, please install first. http://www.jmol.org");
 			return;
 		}
 		jmolPanel.setPreferredSize(new Dimension(500, 500));
@@ -106,7 +106,7 @@ public class JmolViewerImpl implements StructureViewer {
 	@Override
 	public void setStructure(Structure structure) {
 		if (jmolPanel == null) {
-			System.err.println("please install Jmol first");
+			logger.error("please install Jmol first");
 			return;
 		}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/ScaleableMatrixPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/ScaleableMatrixPanel.java
@@ -32,6 +32,8 @@ import org.biojava.nbio.structure.gui.util.color.*;
 import org.biojava.nbio.structure.gui.util.color.LinearColorInterpolator.InterpolationDirection;
 import org.biojava.nbio.structure.io.PDBFileReader;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
@@ -57,6 +59,8 @@ import java.util.TreeMap;
 public class ScaleableMatrixPanel
 extends JPanel
 implements ChangeListener, ActionListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ActionListener.class);
 
 	/**
 	 *
@@ -100,10 +104,9 @@ implements ChangeListener, ActionListener {
 			Structure s1 = pdbr.getStructureById(pdb1);
 			Structure s2 = pdbr.getStructureById(pdb2);
 
-			System.out.println("aligning " + pdb1 + " vs. " + pdb2);
-			System.out.println(s1);
-			System.out.println();
-			System.out.println(s2);
+			LOGGER.info("aligning " + pdb1 + " vs. " + pdb2);
+			LOGGER.info(s1.toString());
+			LOGGER.info(s2.toString());
 			// step 2 : do the calculations
 			sc.align(s1,s2);
 
@@ -128,7 +131,7 @@ implements ChangeListener, ActionListener {
 
 			for (int i = 0; i < sc.getAlignments().length; i++) {
 				AlternativeAlignment aa =sc.getAlignments()[i];
-				System.out.println(aa);
+				LOGGER.info(aa.toString());
 
 			}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/SequenceDisplay.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/SequenceDisplay.java
@@ -75,7 +75,7 @@ public class SequenceDisplay extends JPanel implements ChangeListener {
 	 */
 	public static final int MAX_SCALE               = 10;
 
-	//private static final Logger logger = LoggerFactory.getLogger(SequenceDisplay.class);
+	private static final Logger logger = LoggerFactory.getLogger(SequenceDisplay.class);
 
 	List<AlignedPosition> apos;
 
@@ -106,7 +106,7 @@ public class SequenceDisplay extends JPanel implements ChangeListener {
 
 			// step1 : read molecules
 
-			System.out.println("aligning " + pdb1 + " vs. " + pdb2);
+			logger.info("aligning " + pdb1 + " vs. " + pdb2);
 
 			Structure s1 = pdbr.getStructureById(pdb1);
 			Structure s2 = pdbr.getStructureById(pdb2);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/SequenceDisplay.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/SequenceDisplay.java
@@ -29,6 +29,8 @@ import org.biojava.nbio.structure.gui.util.AlignedPosition;
 import org.biojava.nbio.structure.gui.util.SequenceMouseListener;
 import org.biojava.nbio.structure.gui.util.SequenceScalePanel;
 import org.biojava.nbio.structure.io.PDBFileReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import javax.swing.event.ChangeEvent;
@@ -47,6 +49,8 @@ import java.util.List;
  * @since 1.7
  */
 public class SequenceDisplay extends JPanel implements ChangeListener {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SequenceDisplay.class);
 
 	/**
 	 *
@@ -345,7 +349,7 @@ public class SequenceDisplay extends JPanel implements ChangeListener {
 
 	private void setAtoms(Structure s, SequenceScalePanel panel){
 		if ( structurePairAligner == null){
-			System.err.println("StructurePairAligner has not been set");
+			LOGGER.error("StructurePairAligner has not been set");
 			return;
 		}
 		Atom[] ca1 = structurePairAligner.getAlignmentAtoms(s);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/events/JmolAlignedPositionListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/events/JmolAlignedPositionListener.java
@@ -28,10 +28,13 @@ import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.align.StructurePairAligner;
 import org.biojava.nbio.structure.gui.BiojavaJmol;
 import org.biojava.nbio.structure.gui.util.AlignedPosition;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class JmolAlignedPositionListener implements AlignmentPositionListener{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(JmolAlignedPositionListener.class);
 
 	BiojavaJmol parent;
 	Atom[] ca1;
@@ -67,7 +70,7 @@ public class JmolAlignedPositionListener implements AlignmentPositionListener{
 		String s = "select ";
 
 		if ((p1 > ca1.length) || (p2 > ca2.length)){
-			System.err.println("requsting atom out of bounds! " );
+			LOGGER.error("requsting atom out of bounds! " );
 			return;
 		}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBDirPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBDirPanel.java
@@ -47,6 +47,8 @@ public class PDBDirPanel
 extends JPanel
 implements StructurePairSelector{
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(PDBDirPanel.class);
+
 	/**
 	 *
 	 */
@@ -107,7 +109,7 @@ implements StructurePairSelector{
 
 		String chain = c.getText();
 		if ( debug )
-			System.out.println("file :" + pdb + " " +  chain);
+			LOGGER.debug("file :" + pdb + " " +  chain);
 		/// prepare structures
 
 		// load them from the file system
@@ -118,7 +120,7 @@ implements StructurePairSelector{
 		PDBFileReader reader = new PDBFileReader(dir);
 
 		if ( debug )
-			System.out.println("dir: " + dir);
+			LOGGER.debug("dir: " + dir);
 
 		Structure tmp1 = new StructureImpl();
 
@@ -131,13 +133,13 @@ implements StructurePairSelector{
 				return structure1;
 			}
 			if ( debug)
-				System.out.println("using chain " + chain +  " for structure " + structure1.getPDBCode());
+				LOGGER.debug("using chain " + chain +  " for structure " + structure1.getPDBCode());
 			Chain c1 = structure1.findChain(chain);
 			tmp1.setPDBCode(structure1.getPDBCode());
 			tmp1.setPDBHeader(structure1.getPDBHeader());
 			tmp1.setPDBCode(structure1.getPDBCode());
 			tmp1.addChain(c1);
-			System.out.println("ok");
+			LOGGER.debug("ok");
 
 		} catch (IOException e){
 			logger.warn(e.getMessage());

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBDirPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBDirPanel.java
@@ -54,7 +54,6 @@ implements StructurePairSelector{
 	 */
 	private static final long serialVersionUID = -5682120627824627408L;
 
-	boolean debug = true;
 	JTextField pdbDir;
 	JTextField f1;
 	JTextField f2;
@@ -108,8 +107,7 @@ implements StructurePairSelector{
 		}
 
 		String chain = c.getText();
-		if ( debug )
-			LOGGER.debug("file :" + pdb + " " +  chain);
+		LOGGER.debug("file :" + pdb + " " +  chain);
 		/// prepare structures
 
 		// load them from the file system
@@ -119,8 +117,7 @@ implements StructurePairSelector{
 		String dir = pdbDir.getText();
 		PDBFileReader reader = new PDBFileReader(dir);
 
-		if ( debug )
-			LOGGER.debug("dir: " + dir);
+		LOGGER.debug("dir: " + dir);
 
 		Structure tmp1 = new StructureImpl();
 
@@ -132,8 +129,7 @@ implements StructurePairSelector{
 			if (( chain == null) || (chain.length()==0)){
 				return structure1;
 			}
-			if ( debug)
-				LOGGER.debug("using chain " + chain +  " for structure " + structure1.getPDBCode());
+			LOGGER.debug("using chain " + chain +  " for structure " + structure1.getPDBCode());
 			Chain c1 = structure1.findChain(chain);
 			tmp1.setPDBCode(structure1.getPDBCode());
 			tmp1.setPDBHeader(structure1.getPDBHeader());

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBServerPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBServerPanel.java
@@ -45,6 +45,8 @@ public class PDBServerPanel
 extends JPanel
 implements StructurePairSelector{
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(PDBServerPanel.class);
+
 	/**
 	 *
 	 */
@@ -96,7 +98,7 @@ implements StructurePairSelector{
 
 		String chain = c.getText();
 		if ( debug )
-			System.out.println("file :" + pdb + " " +  chain);
+			LOGGER.debug("file :" + pdb + " " +  chain);
 		/// prepare structures
 
 		// load them from the file system
@@ -116,13 +118,13 @@ implements StructurePairSelector{
 				return structure1;
 			}
 			if ( debug)
-				System.out.println("using chain " + chain +  " for structure " + structure1.getPDBCode());
+				LOGGER.debug("using chain " + chain +  " for structure " + structure1.getPDBCode());
 			Chain c1 = structure1.findChain(chain);
 			tmp1.setPDBCode(structure1.getPDBCode());
 			tmp1.setPDBHeader(structure1.getPDBHeader());
 			tmp1.setPDBCode(structure1.getPDBCode());
 			tmp1.addChain(c1);
-			System.out.println("ok");
+			LOGGER.debug("ok");
 
 		} catch (IOException e){
 			logger.warn(e.getMessage());

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBServerPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBServerPanel.java
@@ -52,7 +52,6 @@ implements StructurePairSelector{
 	 */
 	private static final long serialVersionUID = -5682120627824627408L;
 
-	boolean debug = true;
 	JTextField pdbDir;
 	JTextField f1;
 	JTextField f2;
@@ -97,8 +96,7 @@ implements StructurePairSelector{
 		}
 
 		String chain = c.getText();
-		if ( debug )
-			LOGGER.debug("file :" + pdb + " " +  chain);
+		LOGGER.debug("file :" + pdb + " " +  chain);
 		/// prepare structures
 
 		// load them from the file system
@@ -117,8 +115,7 @@ implements StructurePairSelector{
 			if (( chain == null) || (chain.length()==0)){
 				return structure1;
 			}
-			if ( debug)
-				LOGGER.debug("using chain " + chain +  " for structure " + structure1.getPDBCode());
+			LOGGER.debug("using chain " + chain +  " for structure " + structure1.getPDBCode());
 			Chain c1 = structure1.findChain(chain);
 			tmp1.setPDBCode(structure1.getPDBCode());
 			tmp1.setPDBHeader(structure1.getPDBHeader());

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/color/ColorUtils.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/color/ColorUtils.java
@@ -24,10 +24,15 @@
 
 package org.biojava.nbio.structure.gui.util.color;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.*;
 
 public class ColorUtils
 {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ColorUtils.class);
 
 	public static Color orange =   Color.decode("#FFA500");
 	public static Color cyan   =   Color.decode("#00FFFF");
@@ -48,8 +53,8 @@ public class ColorUtils
 		int i = -1;
 		for ( Color color : colorWheel){
 			i++;
-			float[] af = Color.RGBtoHSB(color.getRed(), color.getGreen(), color.getBlue(), null);
-			System.out.println("position "  + i + "  " + af[0] + " " + af[1] + " " + af[2]);
+			float[] af = Color.RGBtoHSB(color.getRed(),color.getGreen(),color.getBlue(), null);
+			LOGGER.info("position "  + i + "  " + af[0] + " " + af[1] + " " + af[2]);
 			//System.out.println(rotateHue(color, 0.1f));
 		}
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/color/HSVColorSpace.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/color/HSVColorSpace.java
@@ -21,6 +21,10 @@
  */
 package org.biojava.nbio.structure.gui.util.color;
 
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.awt.*;
 import java.awt.color.ColorSpace;
 
@@ -29,6 +33,8 @@ import java.awt.color.ColorSpace;
  *
  */
 public class HSVColorSpace extends ColorSpace {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(HSVColorSpace.class);
 
 	private static final long serialVersionUID = 8324413992279510075L;
 
@@ -44,38 +50,38 @@ public class HSVColorSpace extends ColorSpace {
 		hsvComp = c.getColorComponents(csHSV, null);
 		assert(rgbComp.length == 3);
 		assert(hsvComp.length == 3);
-		System.out.format("RED\tRGB[%f %f %f] HSV[%f %f %f]\n",
+		LOGGER.info(String.format("RED\tRGB[%f %f %f] HSV[%f %f %f]\n",
 				rgbComp[0], rgbComp[1], rgbComp[2],
-				hsvComp[0], hsvComp[1], hsvComp[2] );
+				hsvComp[0], hsvComp[1], hsvComp[2]));
 
 
 		c = Color.WHITE;
 		rgbComp = c.getColorComponents(csRGB,null);
 		hsvComp = c.getColorComponents(csHSV, null);
-		System.out.format("WHITE\tRGB[%f %f %f] HSV[%f %f %f]\n",
+		LOGGER.info(String.format("WHITE\tRGB[%f %f %f] HSV[%f %f %f]\n",
 				rgbComp[0], rgbComp[1], rgbComp[2],
-				hsvComp[0], hsvComp[1], hsvComp[2] );
+				hsvComp[0], hsvComp[1], hsvComp[2]));
 
 		c = Color.BLACK;
 		rgbComp = c.getColorComponents(csRGB,null);
 		hsvComp = c.getColorComponents(csHSV, null);
-		System.out.format("BLACK\tRGB[%f %f %f] HSV[%f %f %f]\n",
+		LOGGER.info(String.format("BLACK\tRGB[%f %f %f] HSV[%f %f %f]\n",
 				rgbComp[0], rgbComp[1], rgbComp[2],
-				hsvComp[0], hsvComp[1], hsvComp[2] );
+				hsvComp[0], hsvComp[1], hsvComp[2] ));
 
 		c = Color.GRAY;
 		rgbComp = c.getColorComponents(csRGB,null);
 		hsvComp = c.getColorComponents(csHSV, null);
-		System.out.format("GRAY\tRGB[%f %f %f] HSV[%f %f %f]\n",
+		LOGGER.info(String.format("GRAY\tRGB[%f %f %f] HSV[%f %f %f]\n",
 				rgbComp[0], rgbComp[1], rgbComp[2],
-				hsvComp[0], hsvComp[1], hsvComp[2] );
+				hsvComp[0], hsvComp[1], hsvComp[2] ));
 
 		c = Color.CYAN;
 		rgbComp = c.getColorComponents(csRGB,null);
 		hsvComp = c.getColorComponents(csHSV, null);
-		System.out.format("CYAN\tRGB[%f %f %f] HSV[%f %f %f]\n",
+		LOGGER.info(String.format("CYAN\tRGB[%f %f %f] HSV[%f %f %f]\n",
 				rgbComp[0], rgbComp[1], rgbComp[2],
-				hsvComp[0], hsvComp[1], hsvComp[2] );
+				hsvComp[0], hsvComp[1], hsvComp[2] ));
 
 
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryGui.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryGui.java
@@ -52,6 +52,8 @@ import org.biojava.nbio.structure.gui.util.ScopSelectPanel;
 import org.biojava.nbio.structure.gui.util.StructurePairSelector;
 import org.biojava.nbio.structure.symmetry.internal.CESymmParameters;
 import org.biojava.nbio.structure.symmetry.internal.CeSymm;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A JFrame that allows to trigger a symmetry analysis, either from files
@@ -64,6 +66,8 @@ import org.biojava.nbio.structure.symmetry.internal.CeSymm;
  *
  */
 public class SymmetryGui extends JFrame {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SymmetryGui.class);
 
 	private final static long serialVersionUID = 0l;
 
@@ -198,7 +202,7 @@ public class SymmetryGui extends JFrame {
 				if (selectedIndex == 0)
 					calcAlignment();
 				else {
-					System.err.println("Unknown TAB: " + selectedIndex);
+					LOGGER.warn("Unknown TAB: " + selectedIndex);
 				}
 			}
 		};
@@ -244,7 +248,7 @@ public class SymmetryGui extends JFrame {
 	}
 
 	protected void configureParameters() {
-		System.out.println("configure parameters for " +
+		LOGGER.info("configure parameters for " +
 				CeSymm.algorithmName);
 
 		// show a new config GUI
@@ -278,7 +282,7 @@ public class SymmetryGui extends JFrame {
 			Structure s = tab.getStructure1();
 
 			if ( s == null) {
-				System.err.println("Please select structure");
+				LOGGER.warn("Please select structure");
 				return ;
 			}
 
@@ -290,7 +294,7 @@ public class SymmetryGui extends JFrame {
 				name = s.getStructureIdentifier();
 			}
 
-			System.out.println("Analyzing: " + name);
+			LOGGER.info("Analyzing: " + name);
 
 
 			alicalc = new SymmetryCalc(this, s);
@@ -319,7 +323,7 @@ public class SymmetryGui extends JFrame {
 	}
 
 	private void abortCalc(){
-		System.err.println("Interrupting alignment ...");
+		LOGGER.error("Interrupting alignment ...");
 		if ( alicalc != null )
 			alicalc.interrupt();
 		notifyCalcFinished();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/FarmJob.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/FarmJob.java
@@ -227,23 +227,23 @@ public class FarmJob implements Runnable {
 	}
 
 	public void printHelp(){
-		logger.info("-------------------");
-		logger.info("FarmJob help:");
-		logger.info("-------------------");
+		System.out.println("-------------------");
+		System.out.println("FarmJob help:");
+		System.out.println("-------------------");
 
-		logger.info("FarmJob accepts the following parameters:");
-		logger.info("");
-		logger.info(" Mandatory:");
-		logger.info("   -pdbFilePath (mandatory) Path to the directory in your file system that contains the PDB files.");
+		System.out.println("FarmJob accepts the following parameters:");
+		System.out.println("");
+		System.out.println(" Mandatory:");
+		System.out.println("   -pdbFilePath (mandatory) Path to the directory in your file system that contains the PDB files.");
 
-		logger.info("   provide either -time or -nrAlignments. If both are provided the job stops as soon as any of the criteria has been reached.");
-		logger.info("   -time maximum number of time to run (in seconds). -1 means no time limit, but run -nrAlignment arguments. Default: " + FarmJobParameters.DEFAULT_JOB_TIME );
-		logger.info("   -nrAlignments number of alignments to calculate. Default: " + FarmJobParameters.DEFAULT_NR_ALIGNMENTS) ;
-		logger.info("");
-		logger.info(" Optional: ");
-		logger.info("   -threads number of parallel threads to calculate alignments. Should be nr. of available CPUs. Default: " + FarmJobParameters.DEFAULT_NR_THREADS);
-		logger.info("   -server the location of the server URL to talk to. Default : " + FarmJobParameters.DEFAULT_SERVER_URL);
-		logger.info("   -username a unique name that can be given to this client. Can be used to give credit for who is doing the calculations. Default: IP and a random id");
-		logger.info("   -stepSize the number of pairs to be requsted from server. Default: " + FarmJobParameters.DEFAULT_BATCH_SIZE);
+		System.out.println("   provide either -time or -nrAlignments. If both are provided the job stops as soon as any of the criteria has been reached.");
+		System.out.println("   -time maximum number of time to run (in seconds). -1 means no time limit, but run -nrAlignment arguments. Default: " + FarmJobParameters.DEFAULT_JOB_TIME );
+		System.out.println("   -nrAlignments number of alignments to calculate. Default: " + FarmJobParameters.DEFAULT_NR_ALIGNMENTS) ;
+		System.out.println("");
+		System.out.println(" Optional: ");
+		System.out.println("   -threads number of parallel threads to calculate alignments. Should be nr. of available CPUs. Default: " + FarmJobParameters.DEFAULT_NR_THREADS);
+		System.out.println("   -server the location of the server URL to talk to. Default : " + FarmJobParameters.DEFAULT_SERVER_URL);
+		System.out.println("   -username a unique name that can be given to this client. Can be used to give credit for who is doing the calculations. Default: IP and a random id");
+		System.out.println("   -stepSize the number of pairs to be requsted from server. Default: " + FarmJobParameters.DEFAULT_BATCH_SIZE);
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/FarmJob.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/FarmJob.java
@@ -227,23 +227,23 @@ public class FarmJob implements Runnable {
 	}
 
 	public void printHelp(){
-		System.out.println("-------------------");
-		System.out.println("FarmJob help:");
-		System.out.println("-------------------");
+		logger.info("-------------------");
+		logger.info("FarmJob help:");
+		logger.info("-------------------");
 
-		System.out.println("FarmJob accepts the following parameters:");
-		System.out.println("");
-		System.out.println(" Mandatory:");
-		System.out.println("   -pdbFilePath (mandatory) Path to the directory in your file system that contains the PDB files.");
+		logger.info("FarmJob accepts the following parameters:");
+		logger.info("");
+		logger.info(" Mandatory:");
+		logger.info("   -pdbFilePath (mandatory) Path to the directory in your file system that contains the PDB files.");
 
-		System.out.println("   provide either -time or -nrAlignments. If both are provided the job stops as soon as any of the criteria has been reached.");
-		System.out.println("   -time maximum number of time to run (in seconds). -1 means no time limit, but run -nrAlignment arguments. Default: " + FarmJobParameters.DEFAULT_JOB_TIME );
-		System.out.println("   -nrAlignments number of alignments to calculate. Default: " + FarmJobParameters.DEFAULT_NR_ALIGNMENTS) ;
-		System.out.println("");
-		System.out.println(" Optional: ");
-		System.out.println("   -threads number of parallel threads to calculate alignments. Should be nr. of available CPUs. Default: " + FarmJobParameters.DEFAULT_NR_THREADS);
-		System.out.println("   -server the location of the server URL to talk to. Default : " + FarmJobParameters.DEFAULT_SERVER_URL);
-		System.out.println("   -username a unique name that can be given to this client. Can be used to give credit for who is doing the calculations. Default: IP and a random id");
-		System.out.println("   -stepSize the number of pairs to be requsted from server. Default: " + FarmJobParameters.DEFAULT_BATCH_SIZE);
+		logger.info("   provide either -time or -nrAlignments. If both are provided the job stops as soon as any of the criteria has been reached.");
+		logger.info("   -time maximum number of time to run (in seconds). -1 means no time limit, but run -nrAlignment arguments. Default: " + FarmJobParameters.DEFAULT_JOB_TIME );
+		logger.info("   -nrAlignments number of alignments to calculate. Default: " + FarmJobParameters.DEFAULT_NR_ALIGNMENTS) ;
+		logger.info("");
+		logger.info(" Optional: ");
+		logger.info("   -threads number of parallel threads to calculate alignments. Should be nr. of available CPUs. Default: " + FarmJobParameters.DEFAULT_NR_THREADS);
+		logger.info("   -server the location of the server URL to talk to. Default : " + FarmJobParameters.DEFAULT_SERVER_URL);
+		logger.info("   -username a unique name that can be given to this client. Can be used to give credit for who is doing the calculations. Default: IP and a random id");
+		logger.info("   -stepSize the number of pairs to be requsted from server. Default: " + FarmJobParameters.DEFAULT_BATCH_SIZE);
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/AbstractUserArgumentProcessor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/AbstractUserArgumentProcessor.java
@@ -36,6 +36,8 @@ import org.biojava.nbio.structure.align.util.*;
 import org.biojava.nbio.structure.align.xml.AFPChainXMLConverter;
 import org.biojava.nbio.structure.io.LocalPDBDirectory.FetchBehavior;
 import org.biojava.nbio.structure.io.PDBFileReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.beans.Introspector;
 import java.io.*;
@@ -77,6 +79,8 @@ import java.util.List;
  *
  */
 public abstract class AbstractUserArgumentProcessor implements UserArgumentProcessor {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AbstractUserArgumentProcessor.class);
 
 	public static String newline = System.getProperty("line.separator");
 
@@ -121,13 +125,13 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			if(arg.equalsIgnoreCase("-h") || arg.equalsIgnoreCase("-help")
 					|| arg.equalsIgnoreCase("--help") )
 			{
-				System.out.println(printHelp());
+				LOGGER.info(printHelp());
 				return;
 			}
 			// version
 			if(arg.equalsIgnoreCase("-version") || arg.equalsIgnoreCase("--version")) {
 				StructureAlignment alg = getAlgorithm();
-				System.out.println(alg.getAlgorithmName() + " v." + alg.getVersion() );
+				LOGGER.info(alg.getAlgorithmName() + " v." + alg.getVersion() );
 				return;
 			}
 
@@ -151,7 +155,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 				CliTools.configureBean(params, tmp);
 
 			} catch (ConfigurationException e){
-				System.err.println("Error: "+e.getLocalizedMessage());
+				LOGGER.error("Error: "+e.getLocalizedMessage());
 				System.exit(1); return;
 			}
 		}
@@ -165,11 +169,11 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 		}
 
 		if ( params.isShowMenu()){
-			System.err.println("showing menu...");
+			LOGGER.info("showing menu...");
 			try {
 				GuiWrapper.showAlignmentGUI();
 			} catch (Exception e){
-				System.err.println(e.getMessage());
+				LOGGER.error(e.getMessage());
 				e.printStackTrace();
 			}
 		}
@@ -178,11 +182,11 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			// user wants to view DB search results:
 
 
-			System.err.println("showing DB results...");
+			LOGGER.info("showing DB results...");
 			try {
 				GuiWrapper.showDBResults(params);
 			} catch (Exception e){
-				System.err.println(e.getMessage());
+				LOGGER.error(e.getMessage());
 				e.printStackTrace();
 			}
 
@@ -208,12 +212,12 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 				return;
 			}
 		} catch (ConfigurationException e) {
-			System.err.println(e.getLocalizedMessage());
+			LOGGER.error(e.getLocalizedMessage());
 			System.exit(1); return;
 		}
 
-		System.out.println(printHelp());
-		System.err.println("Error: insufficient arguments.");
+		LOGGER.info(printHelp());
+		LOGGER.error("Error: insufficient arguments.");
 		System.exit(1); return;
 	}
 
@@ -228,7 +232,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			String version = about.getString("project_version");
 			String build   = about.getString("build");
 
-			System.out.println("Protein Comparison Tool " + version + " " + build);
+			LOGGER.info("Protein Comparison Tool " + version + " " + build);
 		} catch (Exception e){
 			e.printStackTrace();
 		}
@@ -246,7 +250,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 
 			UserConfiguration c = new UserConfiguration();
 			pdbFilePath = c.getPdbFilePath();
-			System.err.println("You did not specify the -pdbFilePath parameter. Defaulting to "+pdbFilePath+".");
+			LOGGER.error("You did not specify the -pdbFilePath parameter. Defaulting to "+pdbFilePath+".");
 		}
 
 		String cacheFilePath = params.getCacheFilePath();
@@ -275,7 +279,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			throw new ConfigurationException("Please specify the mandatory argument -outFile!");
 		}
 
-		System.out.println("running DB search with parameters: " + params);
+		LOGGER.info("running DB search with parameters: " + params);
 
 		if ( alignPairs != null && ! alignPairs.equals("")) {
 			runAlignPairs(cache, alignPairs, outputFile);
@@ -300,7 +304,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			String outputFile,int useNrCPUs, StartupParameters params) throws ConfigurationException {
 
 
-		System.out.println("will use " + useNrCPUs + " CPUs.");
+		LOGGER.info("will use " + useNrCPUs + " CPUs.");
 
 		PDBFileReader reader = new PDBFileReader();
 		Structure structure1 = null ;
@@ -350,7 +354,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			out.write("#Legend: " + newline );
 			String legend = getDbSearchLegend();
 			out.write(legend + newline );
-			System.out.println(legend);
+			LOGGER.info(legend);
 			String line = null;
 			while ( (line = is.readLine()) != null){
 				if ( line.startsWith("#"))
@@ -359,7 +363,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 				String[] spl = line.split(" ");
 
 				if ( spl.length != 2) {
-					System.err.println("wrongly formattted line. Expected format: 4hhb.A 4hhb.B but found " + line);
+					LOGGER.error("wrongly formattted line. Expected format: 4hhb.A 4hhb.B but found " + line);
 					continue;
 				}
 
@@ -387,7 +391,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 
 				String result = getDbSearchResult(afpChain);
 				out.write(result);
-				System.out.print(result);
+				LOGGER.info(result);
 
 				checkWriteFile(afpChain,ca1,ca2,true);
 			}
@@ -440,7 +444,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			if ( path == null){
 				UserConfiguration c = new UserConfiguration();
 				path = c.getPdbFilePath();
-				System.err.println("You did not specify the -pdbFilePath parameter. Defaulting to "+path+".");
+				LOGGER.error("You did not specify the -pdbFilePath parameter. Defaulting to "+path+".");
 			}
 
 			AtomCache cache = new AtomCache(path, path);
@@ -460,12 +464,12 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 
 
 		if ( structure1 == null){
-			System.err.println("structure 1 is null, can't run alignment.");
+			LOGGER.error("structure 1 is null, can't run alignment.");
 			System.exit(1); return;
 		}
 
 		if ( structure2 == null){
-			System.err.println("structure 2 is null, can't run alignment.");
+			LOGGER.error("structure 2 is null, can't run alignment.");
 			System.exit(1); return;
 		}
 
@@ -505,7 +509,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			if ( params.isShow3d()){
 
 				if (! GuiWrapper.isGuiModuleInstalled()) {
-					System.err.println("The biojava-structure-gui module is not installed. Please install!");
+					LOGGER.error("The biojava-structure-gui module is not installed. Please install!");
 				} else {
 
 					try {
@@ -516,7 +520,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 
 					} catch (Exception e){
 
-						System.err.println(e.getMessage());
+						LOGGER.error(e.getMessage());
 						e.printStackTrace();
 					}
 					//StructureAlignmentJmol jmol = algorithm.display(afpChain,ca1,ca2,hetatms1, nucs1, hetatms2, nucs2);
@@ -536,14 +540,14 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 
 			if ( params.isPrintXML()){
 				String fatcatXML = AFPChainXMLConverter.toXML(afpChain,ca1,ca2);
-				System.out.println(fatcatXML);
+				LOGGER.info(fatcatXML);
 			}
 			if ( params.isPrintFatCat()) {
 				// default output is to XML on sysout...
-				System.out.println(afpChain.toFatcat(ca1, ca2));
+				LOGGER.info(afpChain.toFatcat(ca1, ca2));
 			}
 			if ( params. isPrintCE()){
-				System.out.println(afpChain.toCE(ca1, ca2));
+				LOGGER.info(afpChain.toCE(ca1, ca2));
 			}
 
 		} catch (IOException e) {
@@ -584,7 +588,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 		String output = null;
 		if ( params.isOutputPDB()){
 			if (! GuiWrapper.isGuiModuleInstalled()) {
-				System.err.println("The biojava-structure-gui module is not installed. Please install!");
+				LOGGER.error("The biojava-structure-gui module is not installed. Please install!");
 				output = AFPChainXMLConverter.toXML(afpChain,ca1,ca2);
 			} else {
 
@@ -634,7 +638,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			}
 
 		if (fileName == null) {
-			System.err.println("Can't write outputfile. Either provide a filename using -outFile or set -autoOutputFile to true .");
+			LOGGER.error("Can't write outputfile. Either provide a filename using -outFile or set -autoOutputFile to true .");
 			System.exit(1); return;
 		}
 		//System.out.println("writing results to " + fileName + " " + params.getSaveOutputDir());
@@ -677,22 +681,22 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 				// check if it is a URL:
 				try {
 					URL url = new URL(file);
-					System.out.println(url);
+					LOGGER.info(url.toString());
 
 					Structure s = reader.getStructure(url);
 
 					return fixStructureName(s,file);
 
 				} catch ( Exception e){
-					System.err.println(e.getMessage());
+					LOGGER.error(e.getMessage());
 				}
 				File f= new File(file);
-				System.out.println("file from local " + f.getAbsolutePath());
+				LOGGER.info("file from local " + f.getAbsolutePath());
 				Structure s= reader.getStructure(f);
 				return fixStructureName(s, file);
 			} catch (Exception e){
-				System.err.println("general exception:" + e.getMessage());
-				System.err.println("unable to load structure from " + file);
+				LOGGER.error("general exception:" + e.getMessage());
+				LOGGER.error("unable to load structure from " + file);
 				return null;
 			}
 		}
@@ -700,8 +704,8 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			Structure s = cache.getStructure(name1);
 			return s;
 		} catch ( Exception e){
-			System.err.println(e.getMessage());
-			System.err.println("unable to load structure from dir: " + cache.getPath() + "/"+ name1);
+			LOGGER.error(e.getMessage());
+			LOGGER.error("unable to load structure from dir: " + cache.getPath() + "/"+ name1);
 			return null;
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/AbstractUserArgumentProcessor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/AbstractUserArgumentProcessor.java
@@ -125,7 +125,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 			if(arg.equalsIgnoreCase("-h") || arg.equalsIgnoreCase("-help")
 					|| arg.equalsIgnoreCase("--help") )
 			{
-				LOGGER.info(printHelp());
+				System.out.println(printHelp());
 				return;
 			}
 			// version

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
@@ -61,8 +61,6 @@ public class CECalculator {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(CECalculator.class);
 
-	protected static final boolean isPrint = false;
-
 	int[] f1;
 	int[] f2;
 	double[][]dist1;
@@ -757,12 +755,8 @@ public class CECalculator {
 							}
 					}
 
-				if ( isPrint) {
-					LOGGER.info("fragment length: " + params.getWinSize());
-					LOGGER.info("ntraces : " + nTraces );
-				}
-
-
+					LOGGER.debug("fragment length: " + params.getWinSize());
+					LOGGER.debug("ntraces : " + nTraces );
 
 			}
 
@@ -955,7 +949,9 @@ nBestTrace=nTrace;
 
 		// removing some loops that are run in orig CE
 		// and which did not do anything
-		checkPrintRmsdNew(traceMaxSize, winSize, ca1, ca2);
+		if (LOGGER.isDebugEnabled()) {
+			checkPrintRmsdNew(traceMaxSize, winSize, ca1, ca2);
+		}
 
 		double rmsd=100.0;
 
@@ -965,8 +961,7 @@ nBestTrace=nTrace;
 			if(bestTracesN[ir]!=nBestTrace) continue;
 
 			rmsdNew = getRMSDForBestTrace(ir, strBuf1, strBuf2, bestTracesN,bestTraces1, bestTrace2,winSize,ca1,ca2);
-			if ( isPrint)
-				LOGGER.info(String.format("%d %d %d %.2f", ir, bestTracesN[ir], nBestTrace, rmsdNew));
+			LOGGER.debug(String.format("%d %d %d %.2f", ir, bestTracesN[ir], nBestTrace, rmsdNew));
 
 			if(rmsd>rmsdNew) {
 				iBestTrace=ir;
@@ -1038,8 +1033,7 @@ nBestTrace=nTrace;
 
 		rmsd=calc_rmsd(strBuf1, strBuf2, strLen,true);
 
-		if ( isPrint)
-			LOGGER.info("got first rmsd: " + rmsd);
+		LOGGER.debug("got first rmsd: " + rmsd);
 		boolean isCopied=false;
 
 		outer_loop:
@@ -1111,8 +1105,7 @@ nBestTrace=nTrace;
 					}
 			}
 		rmsdNew=calc_rmsd(strBuf1, strBuf2, strLen,true);
-		if ( isPrint)
-			LOGGER.info("rmsdNew: " + rmsdNew + " rmsd " + rmsd);
+		LOGGER.debug("rmsdNew: " + rmsdNew + " rmsd " + rmsd);
 		afpChain.setTotalRmsdIni(rmsdNew);
 		afpChain.setTotalLenIni(strBuf1.length);
 
@@ -1202,10 +1195,8 @@ nBestTrace=nTrace;
 		long time_q=(timeEnd-timeStart);
 
 		double gapsP = ( nGaps*100.0/nAtom) ;
-		if(isPrint) {
-			String msg = String.format("Alignment length = %d Rmsd = %.2fA Z-Score = %.1f Gaps = %d(%.1f%%)",nAtom,rmsd,z,nGaps, gapsP);
-			LOGGER.info(msg + " CPU = " + time_q);
-		}
+		String msg = String.format("Alignment length = %d Rmsd = %.2fA Z-Score = %.1f Gaps = %d(%.1f%%)",nAtom,rmsd,z,nGaps, gapsP);
+		LOGGER.debug(msg + " CPU = " + time_q);
 
 		//      if ( params.isShowAFPRanges()){
 
@@ -1309,17 +1300,12 @@ nBestTrace=nTrace;
 		double rmsdNew=calc_rmsd(strBuf1, strBuf2, nBestTrace*winSize, true);
 		//afpChain.setTotalRmsdIni(rmsdNew);
 
-
-		if ( isPrint){
-			LOGGER.info("rmsdNew after trace: " +rmsdNew);
+		LOGGER.debug("rmsdNew after trace: " + rmsdNew);
 
 			for(int k=0; k<nBestTrace; k++)
-				LOGGER.info(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,8));
-		}
+				LOGGER.debug(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,8));
 
-		if ( isPrint){
-			LOGGER.info("best traces: " + nBestTraces);
-		}
+		LOGGER.debug("best traces: " + nBestTraces);
 
 
 	}
@@ -1438,8 +1424,7 @@ nBestTrace=nTrace;
 			//sup_str(strBuf1, strBuf2, nAtom, _d);
 			// here we don't store the rotation matrix for the user!
 			rmsd= calc_rmsd(strBuf1, strBuf2, nAtom,false);
-			if ( isPrint )
-				LOGGER.info("iter: " + counter + " nAtom " + nAtom + " rmsd: " + rmsd);
+			LOGGER.debug("iter: " + counter + " nAtom " + nAtom + " rmsd: " + rmsd);
 			//afpChain.setTotalRmsdOpt(rmsd);
 			//System.out.println("rmsd: " + rmsd);
 
@@ -1957,13 +1942,11 @@ nBestTrace=nTrace;
 
 	private void noBestTrace(){
 
-		if(isPrint) {
 			timeEnd = System.currentTimeMillis();
 			long time_q=(timeEnd-timeStart);
 
 			String msg = String.format("size=0 time=%d comb=%d\n", (int)(time_q), nTraces);
-			LOGGER.info(msg);
-		}
+			LOGGER.debug(msg);
 	}
 
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
@@ -38,6 +38,8 @@ import org.biojava.nbio.structure.align.util.AFPAlignmentDisplay;
 import org.biojava.nbio.structure.jama.Matrix;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompoundSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,6 +58,8 @@ import java.util.List;
  *
  */
 public class CECalculator {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CECalculator.class);
 
 	protected static final boolean isPrint = false;
 	private static final boolean debug = false;
@@ -145,7 +149,7 @@ public class CECalculator {
 
 
 		if ( debug )
-			System.out.println("parameters: " + params);
+			LOGGER.info("parameters: " + params);
 
 		if ( params.getScoringStrategy() == CeParameters.ScoringStrategy.SEQUENCE_CONSERVATION){
 			if ( params.getSeqWeight() < 1)
@@ -756,8 +760,8 @@ public class CECalculator {
 					}
 
 				if ( isPrint) {
-					System.out.println("fragment length: " + params.getWinSize());
-					System.out.println("ntraces : " + nTraces );
+					LOGGER.info("fragment length: " + params.getWinSize());
+					LOGGER.info("ntraces : " + nTraces );
 				}
 
 
@@ -787,8 +791,8 @@ public class CECalculator {
 
 
 		if ( params.isShowAFPRanges()){
-			System.out.println("fragment length: " + params.getWinSize());
-			System.out.println("ntraces : " + nTraces );
+			LOGGER.info("fragment length: " + params.getWinSize());
+			LOGGER.info("ntraces : " + nTraces );
 
 		}
 
@@ -966,7 +970,7 @@ nBestTrace=nTrace;
 
 			rmsdNew = getRMSDForBestTrace(ir, strBuf1, strBuf2, bestTracesN,bestTraces1, bestTrace2,winSize,ca1,ca2);
 			if ( isPrint)
-				System.out.println(String.format("%d %d %d %.2f", ir, bestTracesN[ir], nBestTrace, rmsdNew));
+				LOGGER.info(String.format("%d %d %d %.2f", ir, bestTracesN[ir], nBestTrace, rmsdNew));
 
 			if(rmsd>rmsdNew) {
 				iBestTrace=ir;
@@ -1039,7 +1043,7 @@ nBestTrace=nTrace;
 		rmsd=calc_rmsd(strBuf1, strBuf2, strLen,true);
 
 		if ( isPrint)
-			System.out.println("got first rmsd: " + rmsd);
+			LOGGER.info("got first rmsd: " + rmsd);
 		boolean isCopied=false;
 
 		outer_loop:
@@ -1112,7 +1116,7 @@ nBestTrace=nTrace;
 			}
 		rmsdNew=calc_rmsd(strBuf1, strBuf2, strLen,true);
 		if ( isPrint)
-			System.out.println("rmsdNew: " + rmsdNew + " rmsd " + rmsd);
+			LOGGER.info("rmsdNew: " + rmsdNew + " rmsd " + rmsd);
 		afpChain.setTotalRmsdIni(rmsdNew);
 		afpChain.setTotalLenIni(strBuf1.length);
 
@@ -1123,15 +1127,15 @@ nBestTrace=nTrace;
 		z=zStrAlign(winSize, strLen/winSize, bestTraceScore, nGaps);
 
 		if(params.isShowAFPRanges()) {
-			System.out.println("win size: " + winSize + " strLen/winSize: " + strLen/winSize + " best trace score: " + String.format("%.2f",bestTraceScore) + " nr gaps: " + nGaps + " nr residues: " + nAtom);
+			LOGGER.info("win size: " + winSize + " strLen/winSize: " + strLen/winSize + " best trace score: " + String.format("%.2f",bestTraceScore) + " nr gaps: " + nGaps + " nr residues: " + nAtom);
 
-			System.out.println(String.format("size=%d rmsd=%.2f z=%.1f gaps=%d(%.1f%%) comb=%d",
+			LOGGER.info(String.format("size=%d rmsd=%.2f z=%.1f gaps=%d(%.1f%%) comb=%d",
 					nAtom, rmsd, z, nGaps, nGaps*100.0/nAtom,
 					nTraces));
 
-			System.out.println("Best Trace, before optimization");
+			LOGGER.info("Best Trace, before optimization");
 			for(int k=0; k<nBestTrace; k++)
-				System.out.println(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,
+				LOGGER.info(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,
 						bestTraceLen[k]));
 
 		}
@@ -1204,7 +1208,7 @@ nBestTrace=nTrace;
 		double gapsP = ( nGaps*100.0/nAtom) ;
 		if(isPrint) {
 			String msg = String.format("Alignment length = %d Rmsd = %.2fA Z-Score = %.1f Gaps = %d(%.1f%%)",nAtom,rmsd,z,nGaps, gapsP);
-			System.out.println(msg + " CPU = " + time_q);
+			LOGGER.info(msg + " CPU = " + time_q);
 		}
 
 		//      if ( params.isShowAFPRanges()){
@@ -1311,14 +1315,14 @@ nBestTrace=nTrace;
 
 
 		if ( isPrint){
-			System.out.println("rmsdNew after trace: " +rmsdNew);
+			LOGGER.info("rmsdNew after trace: " +rmsdNew);
 
 			for(int k=0; k<nBestTrace; k++)
-				System.out.println(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,8));
+				LOGGER.info(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,8));
 		}
 
 		if ( isPrint){
-			System.out.println("best traces: " + nBestTraces);
+			LOGGER.info("best traces: " + nBestTraces);
 		}
 
 
@@ -1370,7 +1374,7 @@ nBestTrace=nTrace;
 
 			counter++;
 			if ( debug)
-			   System.out.println("nAtom: " + nAtom + " " + nAtomPrev + " " + rmsdLen + " " + isRmsdLenAssigned + " strLen:" + strLen);
+			   LOGGER.info("nAtom: " + nAtom + " " + nAtomPrev + " " + rmsdLen + " " + isRmsdLenAssigned + " strLen:" + strLen);
 			nAtomPrev=nAtom;
 			oRmsdThr += distanceIncrement;
 
@@ -1413,7 +1417,7 @@ nBestTrace=nTrace;
 			double score = dpAlign( nse1, nse2, gapOpen , gapExtension , false, false);
 
 			if (debug)
-				System.out.println("iter: "+ counter + "  score:"  + score + " " + " nAtomPrev: " + nAtomPrev + " nAtom:" + nAtom + " oRmsdThr: " + oRmsdThr);
+				LOGGER.info("iter: "+ counter + "  score:"  + score + " " + " nAtomPrev: " + nAtomPrev + " nAtom:" + nAtom + " oRmsdThr: " + oRmsdThr);
 
 			afpChain.setAlignScore(score);
 
@@ -1441,7 +1445,7 @@ nBestTrace=nTrace;
 			// here we don't store the rotation matrix for the user!
 			rmsd= calc_rmsd(strBuf1, strBuf2, nAtom,false);
 			if ( isPrint )
-				System.out.println("iter: " + counter + " nAtom " + nAtom + " rmsd: " + rmsd);
+				LOGGER.info("iter: " + counter + " nAtom " + nAtom + " rmsd: " + rmsd);
 			//afpChain.setTotalRmsdOpt(rmsd);
 			//System.out.println("rmsd: " + rmsd);
 
@@ -1964,7 +1968,7 @@ nBestTrace=nTrace;
 			long time_q=(timeEnd-timeStart);
 
 			String msg = String.format("size=0 time=%d comb=%d\n", (int)(time_q), nTraces);
-			System.out.println(msg);
+			LOGGER.info(msg);
 		}
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
@@ -62,7 +62,6 @@ public class CECalculator {
 	private static final Logger LOGGER = LoggerFactory.getLogger(CECalculator.class);
 
 	protected static final boolean isPrint = false;
-	private static final boolean debug = false;
 
 	int[] f1;
 	int[] f2;
@@ -148,8 +147,7 @@ public class CECalculator {
 		dist2 = initIntraDistmatrix(ca2, nse2);
 
 
-		if ( debug )
-			LOGGER.info("parameters: " + params);
+		LOGGER.debug("parameters: " + params);
 
 		if ( params.getScoringStrategy() == CeParameters.ScoringStrategy.SEQUENCE_CONSERVATION){
 			if ( params.getSeqWeight() < 1)
@@ -957,9 +955,7 @@ nBestTrace=nTrace;
 
 		// removing some loops that are run in orig CE
 		// and which did not do anything
-		if ( debug ){
-			checkPrintRmsdNew(traceMaxSize, winSize, ca1, ca2);
-		}
+		checkPrintRmsdNew(traceMaxSize, winSize, ca1, ca2);
 
 		double rmsd=100.0;
 
@@ -1373,8 +1369,7 @@ nBestTrace=nTrace;
 				(isRmsdLenAssigned && rmsd<rmsdLen*1.1 && nAtomPrev!=nAtom)) && ( counter< maxNrIterations)) {
 
 			counter++;
-			if ( debug)
-			   LOGGER.info("nAtom: " + nAtom + " " + nAtomPrev + " " + rmsdLen + " " + isRmsdLenAssigned + " strLen:" + strLen);
+			LOGGER.debug("nAtom: " + nAtom + " " + nAtomPrev + " " + rmsdLen + " " + isRmsdLenAssigned + " strLen:" + strLen);
 			nAtomPrev=nAtom;
 			oRmsdThr += distanceIncrement;
 
@@ -1416,8 +1411,7 @@ nBestTrace=nTrace;
 
 			double score = dpAlign( nse1, nse2, gapOpen , gapExtension , false, false);
 
-			if (debug)
-				LOGGER.info("iter: "+ counter + "  score:"  + score + " " + " nAtomPrev: " + nAtomPrev + " nAtom:" + nAtom + " oRmsdThr: " + oRmsdThr);
+			LOGGER.debug("iter: "+ counter + "  score:"  + score + " " + " nAtomPrev: " + nAtomPrev + " nAtom:" + nAtom + " oRmsdThr: " + oRmsdThr);
 
 			afpChain.setAlignScore(score);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCPMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCPMain.java
@@ -53,7 +53,6 @@ import java.util.List;
  */
 public class CeCPMain extends CeMain {
 	private static final Logger LOGGER = LoggerFactory.getLogger(CeCPMain.class);
-	private static boolean debug = false;
 
 	public static final String algorithmName = "jCE Circular Permutation";
 
@@ -127,9 +126,7 @@ public class CeCPMain extends CeMain {
 		if( duplicateRight ) {
 			return alignRight(ca1, ca2, cpparams);
 		} else {
-			if(debug) {
-				LOGGER.info("Swapping alignment order.");
-			}
+			LOGGER.debug("Swapping alignment order.");
 			AFPChain afpChain = this.alignRight(ca2, ca1, cpparams);
 			return invertAlignment(afpChain);
 		}
@@ -150,10 +147,8 @@ public class CeCPMain extends CeMain {
 
 		Atom[] ca2m = StructureTools.duplicateCA2(ca2);
 
-		if(debug) {
-			LOGGER.info(String.format("Duplicating ca2 took %s ms\n",System.currentTimeMillis()-startTime));
-			startTime = System.currentTimeMillis();
-		}
+		LOGGER.debug(String.format("Duplicating ca2 took %s ms\n",System.currentTimeMillis()-startTime));
+		startTime = System.currentTimeMillis();
 
 		// Do alignment
 		AFPChain afpChain = super.align(ca1, ca2m,params);
@@ -163,16 +158,12 @@ public class CeCPMain extends CeMain {
 			afpChain.setName2(ca2[0].getGroup().getChain().getStructure().getName());
 		} catch( Exception e) {}
 
-		if(debug) {
-			LOGGER.info(String.format("Running %dx2*%d alignment took %s ms\n",ca1.length,ca2.length,System.currentTimeMillis()-startTime));
-			startTime = System.currentTimeMillis();
-		}
+		LOGGER.debug(String.format("Running %dx2*%d alignment took %s ms\n",ca1.length,ca2.length,System.currentTimeMillis()-startTime));
+		startTime = System.currentTimeMillis();
 		afpChain = postProcessAlignment(afpChain, ca1, ca2m, calculator, cpparams);
 
-		if(debug) {
-			LOGGER.info("Finding CP point took %s ms\n",System.currentTimeMillis()-startTime);
-			startTime = System.currentTimeMillis();
-		}
+		LOGGER.debug("Finding CP point took %s ms\n",System.currentTimeMillis()-startTime);
+		startTime = System.currentTimeMillis();
 
 		return afpChain;
 	}
@@ -373,21 +364,17 @@ public class CeCPMain extends CeMain {
 				if(firstRes > minCP.n) {
 					firstRes = ca2len;
 
-					if(debug) {
-						LOGGER.info("Discarding n-terminal block as too " +
-								"short (%d residues, needs %d)\n",
-								minCP.mid, minCPlength);
-					}
+					LOGGER.debug("Discarding n-terminal block as too " +
+									"short (%d residues, needs %d)\n",
+							minCP.mid, minCPlength);
 				}
 
 				if(lastRes < minCP.c) {
 					lastRes = ca2len-1;
 
-					if(debug) {
-						LOGGER.info("Discarding c-terminal block as too " +
-								"short (%d residues, needs %d)\n",
-								optLen[0] - minCP.mid, minCPlength);
-					}
+					LOGGER.debug("Discarding c-terminal block as too " +
+									"short (%d residues, needs %d)\n",
+							optLen[0] - minCP.mid, minCPlength);
 				}
 
 			}
@@ -742,10 +729,8 @@ public class CeCPMain extends CeMain {
 		cp.numResiduesCut = numResiduesCut;
 		cp.lastRes = lastRes;
 
-		if(debug) {
-			LOGGER.info("Found a CP at residue %d. Trimming %d aligned residues from %d-%d of block 0 and %d-%d of block 1.\n",
-					firstRes,cp.numResiduesCut,nStart,firstRes-1,firstRes, cEnd-ca2len);
-		}
+		LOGGER.debug("Found a CP at residue %d. Trimming %d aligned residues from %d-%d of block 0 and %d-%d of block 1.\n",
+				firstRes, cp.numResiduesCut, nStart, firstRes - 1, firstRes, cEnd - ca2len);
 
 		return cp;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCPMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCPMain.java
@@ -30,6 +30,8 @@ import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.util.AFPAlignmentDisplay;
 import org.biojava.nbio.structure.align.util.ConfigurationException;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -50,6 +52,7 @@ import java.util.List;
  *
  */
 public class CeCPMain extends CeMain {
+	private static final Logger LOGGER = LoggerFactory.getLogger(CeCPMain.class);
 	private static boolean debug = false;
 
 	public static final String algorithmName = "jCE Circular Permutation";
@@ -125,7 +128,7 @@ public class CeCPMain extends CeMain {
 			return alignRight(ca1, ca2, cpparams);
 		} else {
 			if(debug) {
-				System.out.println("Swapping alignment order.");
+				LOGGER.info("Swapping alignment order.");
 			}
 			AFPChain afpChain = this.alignRight(ca2, ca1, cpparams);
 			return invertAlignment(afpChain);
@@ -148,7 +151,7 @@ public class CeCPMain extends CeMain {
 		Atom[] ca2m = StructureTools.duplicateCA2(ca2);
 
 		if(debug) {
-			System.out.format("Duplicating ca2 took %s ms\n",System.currentTimeMillis()-startTime);
+			LOGGER.info(String.format("Duplicating ca2 took %s ms\n",System.currentTimeMillis()-startTime));
 			startTime = System.currentTimeMillis();
 		}
 
@@ -161,13 +164,13 @@ public class CeCPMain extends CeMain {
 		} catch( Exception e) {}
 
 		if(debug) {
-			System.out.format("Running %dx2*%d alignment took %s ms\n",ca1.length,ca2.length,System.currentTimeMillis()-startTime);
+			LOGGER.info(String.format("Running %dx2*%d alignment took %s ms\n",ca1.length,ca2.length,System.currentTimeMillis()-startTime));
 			startTime = System.currentTimeMillis();
 		}
 		afpChain = postProcessAlignment(afpChain, ca1, ca2m, calculator, cpparams);
 
 		if(debug) {
-			System.out.format("Finding CP point took %s ms\n",System.currentTimeMillis()-startTime);
+			LOGGER.info("Finding CP point took %s ms\n",System.currentTimeMillis()-startTime);
 			startTime = System.currentTimeMillis();
 		}
 
@@ -371,7 +374,7 @@ public class CeCPMain extends CeMain {
 					firstRes = ca2len;
 
 					if(debug) {
-						System.out.format("Discarding n-terminal block as too " +
+						LOGGER.info("Discarding n-terminal block as too " +
 								"short (%d residues, needs %d)\n",
 								minCP.mid, minCPlength);
 					}
@@ -381,7 +384,7 @@ public class CeCPMain extends CeMain {
 					lastRes = ca2len-1;
 
 					if(debug) {
-						System.out.format("Discarding c-terminal block as too " +
+						LOGGER.info("Discarding c-terminal block as too " +
 								"short (%d residues, needs %d)\n",
 								optLen[0] - minCP.mid, minCPlength);
 					}
@@ -740,7 +743,7 @@ public class CeCPMain extends CeMain {
 		cp.lastRes = lastRes;
 
 		if(debug) {
-			System.out.format("Found a CP at residue %d. Trimming %d aligned residues from %d-%d of block 0 and %d-%d of block 1.\n",
+			LOGGER.info("Found a CP at residue %d. Trimming %d aligned residues from %d-%d of block 0 and %d-%d of block 1.\n",
 					firstRes,cp.numResiduesCut,nStart,firstRes-1,firstRes, cEnd-ca2len);
 		}
 
@@ -756,9 +759,9 @@ public class CeCPMain extends CeMain {
 		Atom[] ca1clone = StructureTools.cloneAtomArray(ca1);
 		Atom[] ca2clone = StructureTools.cloneAtomArray(ca2);
 		if (! GuiWrapper.isGuiModuleInstalled()) {
-			System.err.println("The biojava-structure-gui and/or JmolApplet modules are not installed. Please install!");
+			LOGGER.info("The biojava-structure-gui and/or JmolApplet modules are not installed. Please install!");
 			// display alignment in console
-			System.out.println(afpChain.toCE(ca1clone, ca2clone));
+			LOGGER.info(afpChain.toCE(ca1clone, ca2clone));
 		} else {
 			Object jmol = GuiWrapper.display(afpChain,ca1clone,ca2clone);
 			GuiWrapper.showAlignmentImage(afpChain, ca1clone,ca2clone,jmol);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCalculatorEnhanced.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCalculatorEnhanced.java
@@ -33,6 +33,8 @@ import org.biojava.nbio.structure.align.util.AFPAlignmentDisplay;
 import org.biojava.nbio.structure.jama.Matrix;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompoundSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +55,8 @@ import java.util.List;
  *
  */
 public class CeCalculatorEnhanced {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CeCalculatorEnhanced.class);
 
 	protected static final boolean isPrint = true;
 	private static final boolean showAlignmentSteps = true;
@@ -144,7 +148,7 @@ public class CeCalculatorEnhanced {
 
 
 		if ( debug )
-			System.out.println("parameters: " + params);
+			LOGGER.info("parameters: " + params);
 
 		if ( params.getScoringStrategy() == CeParameters.ScoringStrategy.SEQUENCE_CONSERVATION){
 			if ( params.getSeqWeight() < 1)
@@ -755,8 +759,8 @@ public class CeCalculatorEnhanced {
 					}
 
 				if ( isPrint) {
-					System.out.println("fragment length: " + params.getWinSize());
-					System.out.println("ntraces : " + nTraces );
+					LOGGER.info("fragment length: " + params.getWinSize());
+					LOGGER.info("ntraces : " + nTraces );
 				}
 
 
@@ -786,8 +790,8 @@ public class CeCalculatorEnhanced {
 
 
 		if ( params.isShowAFPRanges()){
-			System.out.println("fragment length: " + params.getWinSize());
-			System.out.println("ntraces : " + nTraces );
+			LOGGER.info("fragment length: " + params.getWinSize());
+			LOGGER.info("ntraces : " + nTraces );
 
 		}
 
@@ -965,7 +969,7 @@ nBestTrace=nTrace;
 
 			rmsdNew = getRMSDForBestTrace(ir, strBuf1, strBuf2, bestTracesN,bestTraces1, bestTrace2,winSize,ca1,ca2);
 			if ( isPrint)
-				System.out.println(String.format("%d %d %d %.2f", ir, bestTracesN[ir], nBestTrace, rmsdNew));
+				LOGGER.info(String.format("%d %d %d %.2f", ir, bestTracesN[ir], nBestTrace, rmsdNew));
 
 			if(rmsd>rmsdNew) {
 				iBestTrace=ir;
@@ -1038,7 +1042,7 @@ nBestTrace=nTrace;
 		rmsd=calc_rmsd(strBuf1, strBuf2, strLen,true,showAlignmentSteps);
 
 		if ( isPrint)
-			System.out.println("got first rmsd: " + rmsd);
+			LOGGER.info("got first rmsd: " + rmsd);
 		boolean isCopied=false;
 
 		outer_loop:
@@ -1106,26 +1110,26 @@ nBestTrace=nTrace;
 		//if ( showAlignmentSteps)
 		rmsdNew=calc_rmsd(strBuf1, strBuf2, strLen,true, showAlignmentSteps);
 		if ( isPrint)
-			System.out.println("rmsdNew: " + rmsdNew + " rmsd " + rmsd);
+			LOGGER.info("rmsdNew: " + rmsdNew + " rmsd " + rmsd);
 		afpChain.setTotalRmsdIni(rmsdNew);
 		afpChain.setTotalLenIni(strBuf1.length);
 
 
 		nAtom = strLen;
 
-		System.out.println("zStrAlign: " + winSize + " strLen " + strLen  + " s/w " + (strLen/winSize) + " " + bestTraceScore + " " + nGaps);
+		LOGGER.info("zStrAlign: " + winSize + " strLen " + strLen  + " s/w " + (strLen/winSize) + " " + bestTraceScore + " " + nGaps);
 		z=zStrAlign(winSize, strLen/winSize, bestTraceScore, nGaps);
 
 		if(params.isShowAFPRanges()) {
-			System.out.println("win size: " + winSize + " strLen/winSize: " + strLen/winSize + " best trace score: " + String.format("%.2f",bestTraceScore) + " nr gaps: " + nGaps + " nr residues: " + nAtom);
+			LOGGER.info("win size: " + winSize + " strLen/winSize: " + strLen/winSize + " best trace score: " + String.format("%.2f",bestTraceScore) + " nr gaps: " + nGaps + " nr residues: " + nAtom);
 
-			System.out.println(String.format("size=%d rmsd=%.2f z=%.1f gaps=%d(%.1f%%) comb=%d",
+			LOGGER.info(String.format("size=%d rmsd=%.2f z=%.1f gaps=%d(%.1f%%) comb=%d",
 					nAtom, rmsd, z, nGaps, nGaps*100.0/nAtom,
 					nTraces));
 
-			System.out.println("Best Trace, before optimization");
+			LOGGER.info("Best Trace, before optimization");
 			for(int k=0; k<nBestTrace; k++)
-				System.out.println(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,
+				LOGGER.info(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,
 						bestTraceLen[k]));
 
 		}
@@ -1196,15 +1200,15 @@ nBestTrace=nTrace;
 		double gapsP = ( nGaps*100.0/nAtom) ;
 		if(isPrint) {
 			String msg = String.format("Alignment length = %d Rmsd = %.2fA Z-Score = %.1f Gaps = %d(%.1f%%)",nAtom,rmsd,z,nGaps, gapsP);
-			System.out.println(msg + " CPU = " + time_q);
+			LOGGER.info(msg + " CPU = " + time_q);
 		}
 
 		//      if ( params.isShowAFPRanges()){
 
 		// this is actually the final alignment...
-		System.out.println("Best Trace: (index1,index2,len)");
+		LOGGER.info("Best Trace: (index1,index2,len)");
 		for(int k=0; k<nBestTrace; k++)
-			System.out.println(
+			LOGGER.info(
 					String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1, bestTraceLen[k]));
 
 
@@ -1304,14 +1308,14 @@ nBestTrace=nTrace;
 
 
 		if ( isPrint){
-			System.out.println("rmsdNew after trace: " +rmsdNew);
+			LOGGER.info("rmsdNew after trace: " +rmsdNew);
 
 			for(int k=0; k<nBestTrace; k++)
-				System.out.println(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,8));
+				LOGGER.info(String.format("(%d,%d,%d) ", bestTrace1[k]+1, bestTrace2[k]+1,8));
 		}
 
 		if ( isPrint){
-			System.out.println("best traces: " + nBestTraces);
+			LOGGER.info("best traces: " + nBestTraces);
 		}
 
 
@@ -1364,7 +1368,7 @@ nBestTrace=nTrace;
 
 			counter++;
 			if ( debug)
-				System.out.println("nAtom: " + nAtom + " " + nAtomPrev + " " + rmsdLen + " " + isRmsdLenAssigned + " strLen:" + strLen + " nse1,nse2:" + nse1 + " " + nse2);
+				LOGGER.info("nAtom: " + nAtom + " " + nAtomPrev + " " + rmsdLen + " " + isRmsdLenAssigned + " strLen:" + strLen + " nse1,nse2:" + nse1 + " " + nse2);
 			nAtomPrev=nAtom;
 			oRmsdThr += distanceIncrement;
 
@@ -1408,12 +1412,12 @@ nBestTrace=nTrace;
 			double score = dpAlign( nse1, nse2, gapOpen , gapExtension , GLOBAL_ALIGN1, GLOBAL_ALIGN2);
 
 			if (debug) {
-				System.out.println("iter: "+ counter + "  score:"  + score + " " + " nAtomPrev: " + nAtomPrev + " nAtom:" + nAtom + " oRmsdThr: " + oRmsdThr);
+				LOGGER.info("iter: "+ counter + "  score:"  + score + " " + " nAtomPrev: " + nAtomPrev + " nAtom:" + nAtom + " oRmsdThr: " + oRmsdThr);
 
 				for (int i=0 ; i<alignmentPositionOrLength ; i++){
 					if ( align_se2[i] == 172 || align_se2[i] == 173) {
-						System.out.println("BREAK POINT IS ALIGNED!!!!");
-						System.out.println(align_se2[i-1] + " " + align_se2[i] + " " + align_se2[i+1]);
+						LOGGER.info("BREAK POINT IS ALIGNED!!!!");
+						LOGGER.info(align_se2[i-1] + " " + align_se2[i] + " " + align_se2[i+1]);
 					}
 				}
 			}
@@ -1438,9 +1442,8 @@ nBestTrace=nTrace;
 			for ( int i =0 ; i < strBuf1.length; i++){
 				if ( strBuf1[i] == null)
 					break;
-				System.out.print(strBuf1[i].getGroup().getChemComp().getOne_letter_code());
+				LOGGER.info(strBuf1[i].getGroup().getChemComp().getOne_letter_code());
 			}
-			System.out.println();
 
 			if(nAtom<4) continue;
 
@@ -1448,7 +1451,7 @@ nBestTrace=nTrace;
 			// here we don't store the rotation matrix for the user!
 			rmsd= calc_rmsd(strBuf1, strBuf2, nAtom,false, false);
 			if ( isPrint )
-				System.out.println("iter: " + counter + " nAtom " + nAtom + " rmsd: " + rmsd);
+				LOGGER.info("iter: " + counter + " nAtom " + nAtom + " rmsd: " + rmsd);
 			//afpChain.setTotalRmsdOpt(rmsd);
 			//System.out.println("rmsd: " + rmsd);
 
@@ -1798,7 +1801,7 @@ nBestTrace=nTrace;
 				for(k=i+1; k<nSeq1; k++) {
 					if(mat[k][j]-gapI-gapE*(k-i)>localMaxScore)
 					{
-						System.out.println("     gap1 " + alignmentPositionOrLength + " " + k + " " + j + " " + localMaxScore + "<" +(mat[k][j]-gapI-gapE*(k-i)));
+						LOGGER.info("     gap1 " + alignmentPositionOrLength + " " + k + " " + j + " " + localMaxScore + "<" +(mat[k][j]-gapI-gapE*(k-i)));
 						iMax=k; jMax=j;
 						localMaxScore=mat[k][j]-gapI-gapE*(k-i);
 					}
@@ -1806,7 +1809,7 @@ nBestTrace=nTrace;
 				for(k=j+1; k<nSeq2; k++) {
 					if(mat[i][k]-gapI-gapE*(k-j)>localMaxScore)
 					{
-						System.out.println("     gap2 " + alignmentPositionOrLength + " " + k + " " + i + " " + localMaxScore + "<"+ (mat[i][k]-gapI-gapE*(k-j)));
+						LOGGER.info("     gap2 " + alignmentPositionOrLength + " " + k + " " + i + " " + localMaxScore + "<"+ (mat[i][k]-gapI-gapE*(k-j)));
 						iMax=i; jMax=k;
 						localMaxScore=mat[i][k]-gapI-gapE*(k-j);
 					}
@@ -1818,18 +1821,18 @@ nBestTrace=nTrace;
 			if ( i != iMax || j != jMax ) {
 				int l1 = iMax - i;
 				int l2 = jMax - j ;
-				System.out.println(String.format("FOUND GAP AT: lcmp:%d l1: %d l2: %d | i:%d iMax: %d j:%d jMax:%d ",alignmentPositionOrLength, l1,l2, i, iMax , j, jMax));
+				LOGGER.info(String.format("FOUND GAP AT: lcmp:%d l1: %d l2: %d | i:%d iMax: %d j:%d jMax:%d ",alignmentPositionOrLength, l1,l2, i, iMax , j, jMax));
 				if ( l1 > 0) {
-					System.out.println(" -- G1 : " + alignmentPositionOrLength + " ->" + (alignmentPositionOrLength + l1) + " " );
+					LOGGER.info(" -- G1 : " + alignmentPositionOrLength + " ->" + (alignmentPositionOrLength + l1) + " " );
 					gapPosition = true;
 				}
 				if ( l2 > 0) {
-					System.out.println(" -- G2 : " + alignmentPositionOrLength + " ->" + (alignmentPositionOrLength + l2) +  " ");
+					LOGGER.info(" -- G2 : " + alignmentPositionOrLength + " ->" + (alignmentPositionOrLength + l2) +  " ");
 					gapPosition = true;
 				}
 				if ( prevGapEnd == alignmentPositionOrLength -1){
 					// double gap!
-					System.out.println( "  !! FOUND DOUBLE GAP AT: "+  alignmentPositionOrLength + " | "+ i+ " " + iMax + " " + j + " " + jMax + " " + String.format("%f", mat[i][j]) + " " +   getTraceBack(tracebackMatrix1,tracebackMatrix2,i,j));
+					LOGGER.info( "  !! FOUND DOUBLE GAP AT: "+  alignmentPositionOrLength + " | "+ i+ " " + iMax + " " + j + " " + jMax + " " + String.format("%f", mat[i][j]) + " " +   getTraceBack(tracebackMatrix1,tracebackMatrix2,i,j));
 					//doubleGap = true;
 
 					//										if ( i != iMax){
@@ -1853,7 +1856,7 @@ nBestTrace=nTrace;
 			//System.out.println(" iMax " + iMax + " jMax " +  jMax);
 			// set the gap positions:
 			//lcmp:53 i:41 j:173 imax:70 jmax:173
-			System.out.println(String.format("  lcmp:%d i:%d j:%d imax:%d jmax:%d score: %.2f",alignmentPositionOrLength,i,j, iMax, jMax, mat[iMax][jMax]));
+			LOGGER.info(String.format("  lcmp:%d i:%d j:%d imax:%d jmax:%d score: %.2f",alignmentPositionOrLength,i,j, iMax, jMax, mat[iMax][jMax]));
 
 
 			for(k=i; k<iMax; k++, i++) {
@@ -2038,7 +2041,7 @@ nBestTrace=nTrace;
 			long time_q=(timeEnd-timeStart);
 
 			String msg = String.format("size=0 time=%d comb=%d\n", (int)(time_q), nTraces);
-			System.out.println(msg);
+			LOGGER.info(msg);
 		}
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCalculatorEnhanced.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCalculatorEnhanced.java
@@ -147,8 +147,7 @@ public class CeCalculatorEnhanced {
 		dist2 = initIntraDistmatrix(ca2, nse2);
 
 
-		if ( debug )
-			LOGGER.info("parameters: " + params);
+		LOGGER.debug("parameters: " + params);
 
 		if ( params.getScoringStrategy() == CeParameters.ScoringStrategy.SEQUENCE_CONSERVATION){
 			if ( params.getSeqWeight() < 1)
@@ -1367,8 +1366,7 @@ nBestTrace=nTrace;
 				(isRmsdLenAssigned && rmsd<rmsdLen*1.1 && nAtomPrev!=nAtom)) && ( counter< maxNrIterations)) {
 
 			counter++;
-			if ( debug)
-				LOGGER.info("nAtom: " + nAtom + " " + nAtomPrev + " " + rmsdLen + " " + isRmsdLenAssigned + " strLen:" + strLen + " nse1,nse2:" + nse1 + " " + nse2);
+			LOGGER.debug("nAtom: " + nAtom + " " + nAtomPrev + " " + rmsdLen + " " + isRmsdLenAssigned + " strLen:" + strLen + " nse1,nse2:" + nse1 + " " + nse2);
 			nAtomPrev=nAtom;
 			oRmsdThr += distanceIncrement;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeSideChainMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeSideChainMain.java
@@ -22,9 +22,13 @@ package org.biojava.nbio.structure.align.ce;
 
 import org.biojava.nbio.structure.align.StructureAlignment;
 import org.biojava.nbio.structure.align.util.ConfigurationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class CeSideChainMain  extends CeMain implements StructureAlignment {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CeSideChainMain.class);
 
 	public static final String algorithmName = "jCE-sidechain";
 
@@ -63,7 +67,7 @@ public class CeSideChainMain  extends CeMain implements StructureAlignment {
 
 	@Override
 	public void setParameters(ConfigStrucAligParams params){
-		System.out.println("setting params : " + params);
+		LOGGER.info("setting params : " + params);
 		if (! (params instanceof CeParameters )){
 			throw new IllegalArgumentException("provided parameter object is not of type CeParameter");
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/GuiWrapper.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/GuiWrapper.java
@@ -26,6 +26,8 @@ import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.io.File;
@@ -40,6 +42,8 @@ import java.util.List;
  */
 
 public class GuiWrapper {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(GuiWrapper.class);
 
 	static final String guiPackage = "org.biojava.nbio.structure.gui";
 
@@ -218,7 +222,7 @@ public class GuiWrapper {
 		} catch (Exception e){
 			e.printStackTrace();
 
-			System.err.println("Probably structure-gui.jar is not in the classpath, can't show results...");
+			LOGGER.error("Probably structure-gui.jar is not in the classpath, can't show results...");
 		}
 
 		//DBResultTable table = new DBResultTable();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/OptimalCECPMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/OptimalCECPMain.java
@@ -612,9 +612,9 @@ public class OptimalCECPMain extends CeMain {
 			afpChain = cecp.align(ca1, ca2);
 			displayAlignment(afpChain,ca1,ca2);
 
-			LOGGER.info("Inspect additional alignments?");
+			System.out.println("Inspect additional alignments?");
 			Scanner scanner = new Scanner(System.in);
-			LOGGER.info("CP location [0,"+ca2.length+"): ");
+			System.out.println("CP location [0,"+ca2.length+"): ");
 			while(scanner.hasNext()) {
 				if(scanner.hasNextInt()) {
 					int cp = scanner.nextInt();
@@ -628,7 +628,7 @@ public class OptimalCECPMain extends CeMain {
 				} else {
 					//String next = scanner.nextLine();
 				}
-				LOGGER.info("CP location [0,"+ca2.length+"): ");
+				System.out.println("CP location [0,"+ca2.length+"): ");
 			}
 			scanner.close();
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/OptimalCECPMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/OptimalCECPMain.java
@@ -56,7 +56,6 @@ import java.util.Scanner;
  */
 public class OptimalCECPMain extends CeMain {
 	private static final Logger LOGGER = LoggerFactory.getLogger(OptimalCECPMain.class);
-	private static final boolean debug = true;
 
 
 	public static final String algorithmName = "jCE Optimal Circular Permutation";
@@ -485,15 +484,13 @@ public class OptimalCECPMain extends CeMain {
 		AFPChain unaligned = super.align(ca1, ca2, param);
 		AFPChain bestAlignment = unaligned;
 
-		if(debug) {
-			// print progress bar header
-			LOGGER.debug("|");
-			for(int cp=1;cp<ca2.length-1;cp++) {
-				LOGGER.debug("=");
-			}
-			LOGGER.debug("|");
-			LOGGER.debug(".");
+		// print progress bar header
+		LOGGER.debug("|");
+		for (int cp = 1; cp < ca2.length - 1; cp++) {
+			LOGGER.debug("=");
 		}
+		LOGGER.debug("|");
+		LOGGER.debug(".");
 
 		if(alignments != null) {
 			alignments[0] = unaligned;
@@ -507,7 +504,7 @@ public class OptimalCECPMain extends CeMain {
 			AFPChain currentAlignment = alignPermuted(ca1,ca2p,param,cp);
 
 			// increment progress bar
-			if(debug) System.out.print(".");
+			LOGGER.debug(".");
 
 			// fix up names, since cloning ca2 wipes it
 
@@ -525,12 +522,10 @@ public class OptimalCECPMain extends CeMain {
 				bestAlignment = currentAlignment;
 			}
 		}
-		if(debug) {
-			long elapsedTime = System.currentTimeMillis()-startTime;
-			LOGGER.debug("\n");
-			LOGGER.debug("%d alignments took %.4f s (%.1f ms avg)\n",
-					ca2.length, elapsedTime/1000., (double)elapsedTime/ca2.length);
-		}
+		long elapsedTime = System.currentTimeMillis() - startTime;
+		LOGGER.debug("\n");
+		LOGGER.debug("%d alignments took %.4f s (%.1f ms avg)\n",
+				ca2.length, elapsedTime / 1000., (double) elapsedTime / ca2.length);
 
 
 		return bestAlignment;
@@ -585,18 +580,18 @@ public class OptimalCECPMain extends CeMain {
 			// find optimal solution
 			AFPChain[] alignments = new AFPChain[ca2.length];
 			afpChain = ce.alignOptimal(ca1, ca2, params, alignments);
-			System.out.format("Optimal Score: %.2f\n", afpChain.getAlignScore());
+			LOGGER.info("Optimal Score: %.2f\n", afpChain.getAlignScore());
 
-			System.out.println("Pos\tScore\tTMScore\tLen\tRMSD\tBlocks");
+			LOGGER.info("Pos\tScore\tTMScore\tLen\tRMSD\tBlocks");
 			for(int i = 0; i< alignments.length; i++) {
 				double tm = AFPChainScorer.getTMScore(alignments[i], ca1, ca2);
-				System.out.format("%d\t%.2f\t%.2f\t%d\t%.2f\t%d\n",
+				LOGGER.info(String.format("%d\t%.2f\t%.2f\t%d\t%.2f\t%d\n",
 						i,
 						alignments[i].getAlignScore(),
 						tm,
 						alignments[i].getOptLength(),
 						alignments[i].getTotalRmsdOpt(),
-						alignments[i].getBlockNum()
+						alignments[i].getBlockNum())
 				);
 			}
 
@@ -617,9 +612,9 @@ public class OptimalCECPMain extends CeMain {
 			afpChain = cecp.align(ca1, ca2);
 			displayAlignment(afpChain,ca1,ca2);
 
-			System.out.println("Inspect additional alignments?");
+			LOGGER.info("Inspect additional alignments?");
 			Scanner scanner = new Scanner(System.in);
-			System.out.print("CP location [0,"+ca2.length+"): ");
+			LOGGER.info("CP location [0,"+ca2.length+"): ");
 			while(scanner.hasNext()) {
 				if(scanner.hasNextInt()) {
 					int cp = scanner.nextInt();
@@ -633,7 +628,7 @@ public class OptimalCECPMain extends CeMain {
 				} else {
 					//String next = scanner.nextLine();
 				}
-				System.out.print("CP location [0,"+ca2.length+"): ");
+				LOGGER.info("CP location [0,"+ca2.length+"): ");
 			}
 			scanner.close();
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/OptimalCECPMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/OptimalCECPMain.java
@@ -32,6 +32,8 @@ import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.util.AFPChainScorer;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -53,6 +55,7 @@ import java.util.Scanner;
  *
  */
 public class OptimalCECPMain extends CeMain {
+	private static final Logger LOGGER = LoggerFactory.getLogger(OptimalCECPMain.class);
 	private static final boolean debug = true;
 
 
@@ -484,12 +487,12 @@ public class OptimalCECPMain extends CeMain {
 
 		if(debug) {
 			// print progress bar header
-			System.out.print("|");
+			LOGGER.debug("|");
 			for(int cp=1;cp<ca2.length-1;cp++) {
-				System.out.print("=");
+				LOGGER.debug("=");
 			}
-			System.out.println("|");
-			System.out.print(".");
+			LOGGER.debug("|");
+			LOGGER.debug(".");
 		}
 
 		if(alignments != null) {
@@ -524,8 +527,8 @@ public class OptimalCECPMain extends CeMain {
 		}
 		if(debug) {
 			long elapsedTime = System.currentTimeMillis()-startTime;
-			System.out.println();
-			System.out.format("%d alignments took %.4f s (%.1f ms avg)\n",
+			LOGGER.debug("\n");
+			LOGGER.debug("%d alignments took %.4f s (%.1f ms avg)\n",
 					ca2.length, elapsedTime/1000., (double)elapsedTime/ca2.length);
 		}
 
@@ -657,9 +660,9 @@ public class OptimalCECPMain extends CeMain {
 		Atom[] ca1clone = StructureTools.cloneAtomArray(ca1);
 		Atom[] ca2clone = StructureTools.cloneAtomArray(ca2);
 		if (! GuiWrapper.isGuiModuleInstalled()) {
-			System.err.println("The biojava-structure-gui and/or JmolApplet modules are not installed. Please install!");
+			LOGGER.error("The biojava-structure-gui and/or JmolApplet modules are not installed. Please install!");
 			// display alignment in console
-			System.out.println(afpChain.toCE(ca1clone, ca2clone));
+			LOGGER.info(afpChain.toCE(ca1clone, ca2clone));
 		} else {
 			Object jmol = GuiWrapper.display(afpChain,ca1clone,ca2clone);
 			GuiWrapper.showAlignmentImage(afpChain, ca1clone,ca2clone,jmol);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/client/JFatCatClient.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/client/JFatCatClient.java
@@ -87,13 +87,13 @@ public class JFatCatClient {
 
 		String testServer = "http://source.rcsb.org/jfatcatserver/align/";
 
-		System.out.println(getAFPChainFromServer(testServer, FatCatRigid.algorithmName, name1, name2, ca1, ca2, timeout));
+		logger.info(getAFPChainFromServer(testServer, FatCatRigid.algorithmName, name1, name2, ca1, ca2, timeout).toString());
 
 		PdbPairsMessage msg = getPdbPairs(testServer, 1, "test");
 
-		System.out.println(msg);
+		logger.info(msg.toString());
 
-		System.out.println(getRepresentatives(FarmJobParameters.DEFAULT_SERVER_URL, 40));
+		logger.info(getRepresentatives(FarmJobParameters.DEFAULT_SERVER_URL, 40).toString());
 	}
 
 	public static boolean hasPrecalculatedResult(String serverLocation, String method, String name1, String name2 ){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPCalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPCalculator.java
@@ -45,9 +45,6 @@ public class AFPCalculator
 {
 	private static final Logger LOGGER = LoggerFactory.getLogger(AFPCalculator.class);
 
-	public static final boolean debug = FatCatAligner.debug;
-
-
 	public static final  void extractAFPChains(FatCatParameters params, AFPChain afpChain,Atom[] ca1,Atom[] ca2) throws StructureException {
 
 
@@ -55,8 +52,7 @@ public class AFPCalculator
 		List<AFP> afpSet = new ArrayList<AFP>();
 		afpChain.setAfpSet(afpSet);
 
-		if ( debug )
-			LOGGER.error("nr of atoms ca1: " + ca1.length + " ca2: " +  ca2.length);
+		LOGGER.debug("nr of atoms ca1: " + ca1.length + " ca2: " +  ca2.length);
 
 
 
@@ -133,11 +129,9 @@ public class AFPCalculator
 
 		int afpNum = afpSet.size();
 
-		if(debug) {
-			String msg = String.format("possible AFP-pairs %d, remain %d after filter 1 remove %d; filter 2 remove %d\n",
-					n0, afpNum, n1, n2);
-			LOGGER.debug(msg);
-		}
+		String msg = String.format("possible AFP-pairs %d, remain %d after filter 1 remove %d; filter 2 remove %d\n",
+				n0, afpNum, n1, n2);
+		LOGGER.debug(msg);
 
 
 	}
@@ -270,8 +264,7 @@ public class AFPCalculator
 
 		List<AFP> afpSet = afpChain.getAfpSet();
 
-		if ( debug)
-			LOGGER.debug("entering sortAfps");
+		LOGGER.debug("entering sortAfps");
 
 		int pro1Len = ca1.length;
 		int pro2Len = ca2.length;
@@ -322,9 +315,7 @@ public class AFPCalculator
 			}
 		}
 
-		if ( debug)
-			LOGGER.debug("done sortAfps");
-
+		LOGGER.debug("done sortAfps");
 
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPCalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPCalculator.java
@@ -30,6 +30,8 @@ import org.biojava.nbio.structure.*;
 import org.biojava.nbio.structure.align.model.AFP;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +43,8 @@ import java.util.List;
  */
 public class AFPCalculator
 {
+	private static final Logger LOGGER = LoggerFactory.getLogger(AFPCalculator.class);
+
 	public static final boolean debug = FatCatAligner.debug;
 
 
@@ -52,7 +56,7 @@ public class AFPCalculator
 		afpChain.setAfpSet(afpSet);
 
 		if ( debug )
-			System.err.println("nr of atoms ca1: " + ca1.length + " ca2: " +  ca2.length);
+			LOGGER.error("nr of atoms ca1: " + ca1.length + " ca2: " +  ca2.length);
 
 
 
@@ -132,7 +136,7 @@ public class AFPCalculator
 		if(debug) {
 			String msg = String.format("possible AFP-pairs %d, remain %d after filter 1 remove %d; filter 2 remove %d\n",
 					n0, afpNum, n1, n2);
-			System.err.println(msg);
+			LOGGER.debug(msg);
 		}
 
 
@@ -188,13 +192,13 @@ public class AFPCalculator
 			Atom[] catmp2 = getFragment(ca2, p2, fragLen,true); // clone the atoms for fragment 2 so we can manipulate them...
 
 			if ( catmp1 == null) {
-				System.err.println("could not get fragment for ca1 " + p1 + " " + fragLen );
+				LOGGER.error("could not get fragment for ca1 " + p1 + " " + fragLen );
 				return rmsd;
 
 			}
 
 			if ( catmp2 == null) {
-				System.err.println("could not get fragment for ca2 " + p2 + " " + fragLen );
+				LOGGER.error("could not get fragment for ca2 " + p2 + " " + fragLen );
 				return rmsd;
 
 			}
@@ -267,7 +271,7 @@ public class AFPCalculator
 		List<AFP> afpSet = afpChain.getAfpSet();
 
 		if ( debug)
-			System.err.println("entering sortAfps");
+			LOGGER.debug("entering sortAfps");
 
 		int pro1Len = ca1.length;
 		int pro2Len = ca2.length;
@@ -300,7 +304,7 @@ public class AFPCalculator
 					afpBefIndex[i][j]=b;
 					afpAftIndex[i][j]=b;
 					if(afpSet.get(b).getP1() != i)    {
-						System.err.println(String.format("Warning: wrong afp index %d %d\n", i, afpSet.get(b).getP1()));
+						LOGGER.error(String.format("Warning: wrong afp index %d %d\n", i, afpSet.get(b).getP1()));
 						return;
 					}
 				}
@@ -319,7 +323,7 @@ public class AFPCalculator
 		}
 
 		if ( debug)
-			System.err.println("done sortAfps");
+			LOGGER.debug("done sortAfps");
 
 
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPChainer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPChainer.java
@@ -47,8 +47,6 @@ import java.util.List;
 public class AFPChainer
 {
 	private static final Logger LOGGER = LoggerFactory.getLogger(AFPChainer.class);
-
-	public static final boolean debug = FatCatAligner.debug;
 	// private static final boolean showAlig = false;
 
 	/**
@@ -152,8 +150,7 @@ public class AFPChainer
 		}
 
 		int     currafp = maxafp;
-		if(debug)
-			LOGGER.debug(String.format("maximum score %f, %d\n", maxsco, twi[currafp]));
+		LOGGER.debug(String.format("maximum score %f, %d\n", maxsco, twi[currafp]));
 
 		//trace-back from maxafp (maxsco)
 
@@ -535,12 +532,10 @@ public class AFPChainer
 			LOGGER.error(String.format("AFPChainer Warning: fail in alignment score checking %.4f %.4f\n", alignScore, checkscore));
 		}
 
-		if ( debug )
-			LOGGER.debug("traceBack:" + afpChainLen + " " + afpChainList.length);
+		LOGGER.debug("traceBack:" + afpChainLen + " " + afpChainList.length);
 		double  rmsd = calAfpRmsd(afpChainLen, afpChainList,0, afpChain,ca1,ca2);
 		afpChain.setChainRmsd(rmsd);
-		if (debug )
-			LOGGER.debug("Chain RMSD: " + rmsd);
+		LOGGER.debug("Chain RMSD: " + rmsd);
 		int     b1 = 0;
 		int     bk = 0;
 		int     a, b;
@@ -568,8 +563,7 @@ public class AFPChainer
 			}
 
 			if(afpChainTwiBin[i] == 1)   {
-				if (debug)
-					LOGGER.debug(" ** calAfpTmsd : afpChainWtiBin == 1 : i: "+i+" i-b1: " + (i-b1) + " b1: " + b1 + " afpChainList.len: " + afpChainList.length);
+				LOGGER.debug(" ** calAfpTmsd : afpChainWtiBin == 1 : i: "+i+" i-b1: " + (i-b1) + " b1: " + b1 + " afpChainList.len: " + afpChainList.length);
 
 				//int len = afpChainList.length - b1 +1;
 				//int[] fakeList = new int[len];
@@ -578,8 +572,7 @@ public class AFPChainer
 				//   pos++;
 				//   fakeList[pos] = afpChainList[fPos];
 				//}
-				if (debug )
-					LOGGER.error("calculation calAfpRmsd " + i + " " + b1 + " " );
+				LOGGER.error("calculation calAfpRmsd " + i + " " + b1 + " " );
 
 
 				rmsd = calAfpRmsd(i - b1, afpChainList,b1, afpChain, ca1, ca2);
@@ -596,12 +589,10 @@ public class AFPChainer
 		afpChain.setBlock2Afp(block2Afp);
 		afpChain.setChainLen(chainLen);
 
-		if (debug)
-			LOGGER.debug("after loop over all afpChainList " + (i-b1) + " " + b1);
+		LOGGER.debug("after loop over all afpChainList " + (i-b1) + " " + b1);
 
 		rmsd = calAfpRmsd(i - b1, afpChainList, b1, afpChain,ca1,ca2);
-		if (debug)
-			LOGGER.debug("*** i:" + i + " b1: " + b1 + " i-b1 " + (i-b1));
+		LOGGER.debug("*** i:" + i + " b1: " + b1 + " i-b1 " + (i-b1));
 
 
 
@@ -615,8 +606,7 @@ public class AFPChainer
 		afpChain.setBlockRmsd(blockRmsd);
 		int blockNum = afpChain.getBlockNum();
 		blockNum = ++bk;
-		if ( debug)
-			LOGGER.error("AFPChainser setBlockNUm:" + blockNum);
+		LOGGER.error("AFPChainser setBlockNUm:" + blockNum);
 		afpChain.setBlockNum(blockNum);
 		afpChain.setAfpChainList(afpChainList);
 		afpChain.setAfpChainTwiList(afpChainTwiList);
@@ -640,8 +630,7 @@ public class AFPChainer
 	{
 
 
-		if (debug)
-			LOGGER.debug("XXX calling afp2res "+ afpn + " " + afpPositions.length);
+		LOGGER.debug("XXX calling afp2res "+ afpn + " " + afpPositions.length);
 
 		int focusResn = AFPTwister.afp2Res(afpChain,afpn, afpPositions, listStart);
 
@@ -649,8 +638,7 @@ public class AFPChainer
 		int[] focusRes1 = afpChain.getFocusRes1();
 		int[] focusRes2 = afpChain.getFocusRes2();
 
-		if (debug)
-			LOGGER.debug("XXX calculating calAfpRmsd: " + focusResn + " " + focusRes1.length + " " + focusRes2.length + " " + afpChain.getMinLen() + " " );
+		LOGGER.debug("XXX calculating calAfpRmsd: " + focusResn + " " + focusRes1.length + " " + focusRes2.length + " " + afpChain.getMinLen() + " " );
 		double rmsd = getRmsd(focusResn, focusRes1, focusRes2 , afpChain,ca1,  ca2);
 
 		return rmsd;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPChainer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPChainer.java
@@ -34,6 +34,8 @@ import org.biojava.nbio.structure.align.AFPTwister;
 import org.biojava.nbio.structure.align.model.AFP;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -44,6 +46,8 @@ import java.util.List;
  */
 public class AFPChainer
 {
+	private static final Logger LOGGER = LoggerFactory.getLogger(AFPChainer.class);
+
 	public static final boolean debug = FatCatAligner.debug;
 	// private static final boolean showAlig = false;
 
@@ -149,7 +153,7 @@ public class AFPChainer
 
 		int     currafp = maxafp;
 		if(debug)
-			System.out.println(String.format("maximum score %f, %d\n", maxsco, twi[currafp]));
+			LOGGER.debug(String.format("maximum score %f, %d\n", maxsco, twi[currafp]));
 
 		//trace-back from maxafp (maxsco)
 
@@ -517,7 +521,7 @@ public class AFPChainer
 		}
 
 		if(afpChainTwiNum != twist)     {
-			System.err.println(String.format("AFPChainer Warning: the twists number is not consistent %d %d\n", afpChainTwiNum, twist));
+			LOGGER.error(String.format("AFPChainer Warning: the twists number is not consistent %d %d\n", afpChainTwiNum, twist));
 		}
 
 		double alignScore = afpChain.getAlignScore();
@@ -528,15 +532,15 @@ public class AFPChainer
 			checkscore = checkscore + afpSet.get(afpChainList[i]).getScore() + afpChain.getConn();
 		}
 		if(Math.abs(checkscore - alignScore) > 1e-4)        {
-			System.err.println(String.format("AFPChainer Warning: fail in alignment score checking %.4f %.4f\n", alignScore, checkscore));
+			LOGGER.error(String.format("AFPChainer Warning: fail in alignment score checking %.4f %.4f\n", alignScore, checkscore));
 		}
 
 		if ( debug )
-			System.out.println("traceBack:" + afpChainLen + " " + afpChainList.length);
+			LOGGER.debug("traceBack:" + afpChainLen + " " + afpChainList.length);
 		double  rmsd = calAfpRmsd(afpChainLen, afpChainList,0, afpChain,ca1,ca2);
 		afpChain.setChainRmsd(rmsd);
 		if (debug )
-			System.out.println("Chain RMSD: " + rmsd);
+			LOGGER.debug("Chain RMSD: " + rmsd);
 		int     b1 = 0;
 		int     bk = 0;
 		int     a, b;
@@ -565,7 +569,7 @@ public class AFPChainer
 
 			if(afpChainTwiBin[i] == 1)   {
 				if (debug)
-					System.out.println(" ** calAfpTmsd : afpChainWtiBin == 1 : i: "+i+" i-b1: " + (i-b1) + " b1: " + b1 + " afpChainList.len: " + afpChainList.length);
+					LOGGER.debug(" ** calAfpTmsd : afpChainWtiBin == 1 : i: "+i+" i-b1: " + (i-b1) + " b1: " + b1 + " afpChainList.len: " + afpChainList.length);
 
 				//int len = afpChainList.length - b1 +1;
 				//int[] fakeList = new int[len];
@@ -575,7 +579,7 @@ public class AFPChainer
 				//   fakeList[pos] = afpChainList[fPos];
 				//}
 				if (debug )
-					System.err.println("calculation calAfpRmsd " + i + " " + b1 + " " );
+					LOGGER.error("calculation calAfpRmsd " + i + " " + b1 + " " );
 
 
 				rmsd = calAfpRmsd(i - b1, afpChainList,b1, afpChain, ca1, ca2);
@@ -593,11 +597,11 @@ public class AFPChainer
 		afpChain.setChainLen(chainLen);
 
 		if (debug)
-			System.out.println("after loop over all afpChainList " + (i-b1) + " " + b1);
+			LOGGER.debug("after loop over all afpChainList " + (i-b1) + " " + b1);
 
 		rmsd = calAfpRmsd(i - b1, afpChainList, b1, afpChain,ca1,ca2);
 		if (debug)
-			System.out.println("*** i:" + i + " b1: " + b1 + " i-b1 " + (i-b1));
+			LOGGER.debug("*** i:" + i + " b1: " + b1 + " i-b1 " + (i-b1));
 
 
 
@@ -612,7 +616,7 @@ public class AFPChainer
 		int blockNum = afpChain.getBlockNum();
 		blockNum = ++bk;
 		if ( debug)
-			System.err.println("AFPChainser setBlockNUm:" + blockNum);
+			LOGGER.error("AFPChainser setBlockNUm:" + blockNum);
 		afpChain.setBlockNum(blockNum);
 		afpChain.setAfpChainList(afpChainList);
 		afpChain.setAfpChainTwiList(afpChainTwiList);
@@ -637,7 +641,7 @@ public class AFPChainer
 
 
 		if (debug)
-			System.out.println("XXX calling afp2res "+ afpn + " " + afpPositions.length);
+			LOGGER.debug("XXX calling afp2res "+ afpn + " " + afpPositions.length);
 
 		int focusResn = AFPTwister.afp2Res(afpChain,afpn, afpPositions, listStart);
 
@@ -646,7 +650,7 @@ public class AFPChainer
 		int[] focusRes2 = afpChain.getFocusRes2();
 
 		if (debug)
-			System.out.println("XXX calculating calAfpRmsd: " + focusResn + " " + focusRes1.length + " " + focusRes2.length + " " + afpChain.getMinLen() + " " );
+			LOGGER.debug("XXX calculating calAfpRmsd: " + focusResn + " " + focusRes1.length + " " + focusRes2.length + " " + afpChain.getMinLen() + " " );
 		double rmsd = getRmsd(focusResn, focusRes1, focusRes2 , afpChain,ca1,  ca2);
 
 		return rmsd;
@@ -672,10 +676,10 @@ public class AFPChainer
 			tmp1[i] =       ca1[focusRes1[i]];
 			tmp2[i] = (Atom)ca2[focusRes2[i]].clone();
 			if (tmp1[i].getCoords() == null){
-				System.err.println("tmp1 got null: " +i + " pos: " + focusRes1[i]);
+				LOGGER.error("tmp1 got null: " +i + " pos: " + focusRes1[i]);
 			}
 			if (tmp2[i].getCoords() == null){
-				System.err.println("tmp1 got null: " +i + " pos: " + focusRes2[i]);
+				LOGGER.error("tmp1 got null: " +i + " pos: " + focusRes2[i]);
 			}
 			//XX
 			//tmp2[i].setParent((Group) ca2[focusRes2[i]].getParent().clone());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPOptimizer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPOptimizer.java
@@ -39,7 +39,6 @@ public class AFPOptimizer
 {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(AFPOptimizer.class);
-	public static final boolean debug = FatCatAligner.debug;
 
 	/**
 	 * optimize the alignment by dynamic programming
@@ -82,8 +81,7 @@ public class AFPOptimizer
 		int[] blockSize       = afpChain.getBlockSize();
 
 
-		if (debug)
-			LOGGER.debug("AFPOptimizer got blockNum: " +blockNum);
+		LOGGER.debug("AFPOptimizer got blockNum: " +blockNum);
 		//optimize each alignment defined by a block
 		b1 = b2 = e1 = e2 = optLength = 0;
 		for(bk = 0; bk < blockNum; bk ++)       {
@@ -117,12 +115,10 @@ public class AFPOptimizer
 				}
 			}
 			//optimize the align by dynamic programming & constraint the optimization region
-			if(debug) {
-				LOGGER.error(String.format("optimize block %d (%d afp), region %d-%d(len %d), %d-%d(len %d)\n",
-						bk, blockSize[bk], b1, e1, e1-b1, b2, e2, e2-b2));
+			LOGGER.error(String.format("optimize block %d (%d afp), region %d-%d(len %d), %d-%d(len %d)\n",
+					bk, blockSize[bk], b1, e1, e1 - b1, b2, e2, e2 - b2));
 
-				LOGGER.error(" initial alignment Length: " + iniLen );
-			}
+			LOGGER.error(" initial alignment Length: " + iniLen);
 
 			StructureAlignmentOptimizer opt = new StructureAlignmentOptimizer(b1,e1, ca1, b2,e2, ca2, iniLen, iniSet);
 			opt.runOptimization(maxi);
@@ -132,8 +128,7 @@ public class AFPOptimizer
 			// SALNOPT *opt = new SALNOPT(e1-b1, &pro1->caCod[3 * b1], e2-b2, &pro2->caCod[3 * b2], iniLen, iniSet, maxi);
 			// optRmsd[bk] = opt->OptimizeResult(&optLen[bk], optAln[bk]);
 
-			if(debug)
-				LOGGER.debug(String.format(" optimized len=%d, rmsd %f\n", optLen[bk], optRmsd[bk]));
+			LOGGER.debug(String.format(" optimized len=%d, rmsd %f\n", optLen[bk], optRmsd[bk]));
 
 			for(i = 0; i < optLen[bk]; i ++)        {
 				optAln[bk][0][i] += b1; //restore the position
@@ -145,7 +140,7 @@ public class AFPOptimizer
 		}
 
 		long optEnd = System.currentTimeMillis();
-		if(debug)       LOGGER.debug("complete AlignOpt " + (optEnd-optStart) +"\n");
+		LOGGER.debug("complete AlignOpt " + (optEnd-optStart) +"\n");
 
 		afpChain.setBlockNum(blockNum);
 		afpChain.setOptLength(optLength);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPOptimizer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPOptimizer.java
@@ -30,12 +30,15 @@ import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.align.model.AFP;
 import org.biojava.nbio.structure.align.model.AFPChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class AFPOptimizer
 {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(AFPOptimizer.class);
 	public static final boolean debug = FatCatAligner.debug;
 
 	/**
@@ -80,7 +83,7 @@ public class AFPOptimizer
 
 
 		if (debug)
-			System.out.println("AFPOptimizer got blockNum: " +blockNum);
+			LOGGER.debug("AFPOptimizer got blockNum: " +blockNum);
 		//optimize each alignment defined by a block
 		b1 = b2 = e1 = e2 = optLength = 0;
 		for(bk = 0; bk < blockNum; bk ++)       {
@@ -115,10 +118,10 @@ public class AFPOptimizer
 			}
 			//optimize the align by dynamic programming & constraint the optimization region
 			if(debug) {
-				System.err.println(String.format("optimize block %d (%d afp), region %d-%d(len %d), %d-%d(len %d)\n",
+				LOGGER.error(String.format("optimize block %d (%d afp), region %d-%d(len %d), %d-%d(len %d)\n",
 						bk, blockSize[bk], b1, e1, e1-b1, b2, e2, e2-b2));
 
-				System.err.println(" initial alignment Length: " + iniLen );
+				LOGGER.error(" initial alignment Length: " + iniLen );
 			}
 
 			StructureAlignmentOptimizer opt = new StructureAlignmentOptimizer(b1,e1, ca1, b2,e2, ca2, iniLen, iniSet);
@@ -130,7 +133,7 @@ public class AFPOptimizer
 			// optRmsd[bk] = opt->OptimizeResult(&optLen[bk], optAln[bk]);
 
 			if(debug)
-				System.out.println(String.format(" optimized len=%d, rmsd %f\n", optLen[bk], optRmsd[bk]));
+				LOGGER.debug(String.format(" optimized len=%d, rmsd %f\n", optLen[bk], optRmsd[bk]));
 
 			for(i = 0; i < optLen[bk]; i ++)        {
 				optAln[bk][0][i] += b1; //restore the position
@@ -142,7 +145,7 @@ public class AFPOptimizer
 		}
 
 		long optEnd = System.currentTimeMillis();
-		if(debug)       System.out.println("complete AlignOpt " + (optEnd-optStart) +"\n");
+		if(debug)       LOGGER.debug("complete AlignOpt " + (optEnd-optStart) +"\n");
 
 		afpChain.setBlockNum(blockNum);
 		afpChain.setOptLength(optLength);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPPostProcessor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPPostProcessor.java
@@ -43,8 +43,6 @@ public class AFPPostProcessor
 {
 	private static final Logger LOGGER = LoggerFactory.getLogger(AFPPostProcessor.class);
 
-	public static final boolean debug = FatCatAligner.debug;
-
 	public static void postProcess(FatCatParameters params, AFPChain afpChain,Atom[] ca1, Atom[] ca2){
 
 		int blockNum = afpChain.getBlockNum();
@@ -58,9 +56,7 @@ public class AFPPostProcessor
 		blockNum = afpChain.getBlockNum();
 		afpChain.setBlockNumSpt( blockNum);
 
-		if ( debug){
-			LOGGER.error("AFPPOstProcessor: postProcess blocknum = blocknumSpt:" + blockNum);
-		}
+		LOGGER.debug("AFPPOstProcessor: postProcess blocknum = blocknumSpt:" + blockNum);
 
 		//redo: merge blocks with similar transformations & remove small blocks
 		//if(blockNum >= 2)     ClustBlock();
@@ -85,8 +81,7 @@ public class AFPPostProcessor
 
 	private static void splitBlock(FatCatParameters params, AFPChain afpChain, Atom[] ca1, Atom[] ca2)
 	{
-		if ( debug)
-			LOGGER.error("AFPPostProcessor: splitBlock");
+		LOGGER.error("AFPPostProcessor: splitBlock");
 		int     i, a, bk, cut;
 		double  maxs, maxt;
 		int blockNum = afpChain.getBlockNum();
@@ -120,8 +115,7 @@ public class AFPPostProcessor
 
 				}
 			}
-			if(debug)
-				LOGGER.debug(String.format("block %d original size %d rmsd %.3f maxt %.2f cut at %d\n", bk, blockSize[bk], maxs, maxt, cut));
+			LOGGER.debug(String.format("block %d original size %d rmsd %.3f maxt %.2f cut at %d\n", bk, blockSize[bk], maxs, maxt, cut));
 			for(i = blockNum - 1; i > bk; i --)     {
 				block2Afp[i + 1] = block2Afp[i];
 				blockSize[i + 1] = blockSize[i];
@@ -131,8 +125,7 @@ public class AFPPostProcessor
 			blockSize[bk + 1] = blockSize[bk] - cut;
 			blockSize[bk] = cut;
 
-			if(debug)
-				LOGGER.debug(String.format("  split into %d and %d sizes\n", blockSize[bk], blockSize[bk + 1]));
+			LOGGER.debug(String.format("  split into %d and %d sizes\n", blockSize[bk], blockSize[bk + 1]));
 
 
 			int[] afpChainList = afpChain.getAfpChainList();
@@ -147,11 +140,9 @@ public class AFPPostProcessor
 			afpChain.setAfpChainList(afpChainList);
 		}
 		if(blockNum - blockNum0 > 0)    {
-			if(debug)
-				LOGGER.debug(String.format("Split %d times:\n", blockNum - blockNum0));
+			LOGGER.debug(String.format("Split %d times:\n", blockNum - blockNum0));
 			for(i = 0; i < blockNum; i ++)  {
-				if(debug)
-					LOGGER.debug(String.format("  block %d size %d from %d rmsd %.3f\n", i, blockSize[i], block2Afp[i], blockRmsd[i]));
+				LOGGER.debug(String.format("  block %d size %d from %d rmsd %.3f\n", i, blockSize[i], block2Afp[i], blockRmsd[i]));
 			}
 		}
 
@@ -219,14 +210,11 @@ public class AFPPostProcessor
 			} //delete a block
 		}
 		if(blockNumOld > blockNum)
-			if(debug)
-				LOGGER.debug(
-						String.format("Delete %d small blocks\n", blockNumOld - blockNum)
-				);
+			LOGGER.debug(
+					String.format("Delete %d small blocks\n", blockNumOld - blockNum)
+			);
 
-
-		if (debug)
-			LOGGER.debug("deleteBlock: end blockNum:"+ blockNum);
+		LOGGER.debug("deleteBlock: end blockNum:"+ blockNum);
 		afpChain.setBlock2Afp(block2Afp);
 		afpChain.setBlockSize(blockSize);
 		afpChain.setAfpChainList(afpChainList);
@@ -278,9 +266,8 @@ public class AFPPostProcessor
 			minb2 = minb1 + 1; //merge those most similar blocks
 			//maxrmsd = (blockRmsd[minb1] > blockRmsd[minb2])?blockRmsd[minb1]:blockRmsd[minb2];
 			if(minrmsd < badRmsd)   {
-				if(debug)
-					LOGGER.debug(String.format("merge block %d (rmsd %.3f) and %d (rmsd %.3f), total rmsd %.3f\n",
-							minb1, blockRmsd[minb1], minb2, blockRmsd[minb2], minrmsd));
+				LOGGER.debug(String.format("merge block %d (rmsd %.3f) and %d (rmsd %.3f), total rmsd %.3f\n",
+						minb1, blockRmsd[minb1], minb2, blockRmsd[minb2], minrmsd));
 				blockSize[minb1] += blockSize[minb2];
 				blockRmsd[minb1] = minrmsd;
 				for(i = minb2; i < blockNum - 1; i ++)  {
@@ -313,13 +300,10 @@ public class AFPPostProcessor
 		}
 
 		if(merge > 0)       {
-			if(debug)
-				LOGGER.debug(String.format("Merge %d blocks, remaining %d blocks\n", merge, blockNum));
+			LOGGER.debug(String.format("Merge %d blocks, remaining %d blocks\n", merge, blockNum));
 		}
-
-		if (debug){
-			LOGGER.debug("AFPPostProcessor: mergeBlock end blocknum:" + blockNum);
-		}
+		
+		LOGGER.debug("AFPPostProcessor: mergeBlock end blocknum:" + blockNum);
 		afpChain.setBlock2Afp(block2Afp);
 		afpChain.setBlockSize(blockSize);
 		afpChain.setBlockNum(blockNum);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPPostProcessor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPPostProcessor.java
@@ -29,6 +29,8 @@ package org.biojava.nbio.structure.align.fatcat.calc;
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.align.model.AFP;
 import org.biojava.nbio.structure.align.model.AFPChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -39,6 +41,7 @@ import java.util.List;
  */
 public class AFPPostProcessor
 {
+	private static final Logger LOGGER = LoggerFactory.getLogger(AFPPostProcessor.class);
 
 	public static final boolean debug = FatCatAligner.debug;
 
@@ -56,7 +59,7 @@ public class AFPPostProcessor
 		afpChain.setBlockNumSpt( blockNum);
 
 		if ( debug){
-			System.err.println("AFPPOstProcessor: postProcess blocknum = blocknumSpt:" + blockNum);
+			LOGGER.error("AFPPOstProcessor: postProcess blocknum = blocknumSpt:" + blockNum);
 		}
 
 		//redo: merge blocks with similar transformations & remove small blocks
@@ -83,7 +86,7 @@ public class AFPPostProcessor
 	private static void splitBlock(FatCatParameters params, AFPChain afpChain, Atom[] ca1, Atom[] ca2)
 	{
 		if ( debug)
-			System.err.println("AFPPostProcessor: splitBlock");
+			LOGGER.error("AFPPostProcessor: splitBlock");
 		int     i, a, bk, cut;
 		double  maxs, maxt;
 		int blockNum = afpChain.getBlockNum();
@@ -118,7 +121,7 @@ public class AFPPostProcessor
 				}
 			}
 			if(debug)
-				System.out.println(String.format("block %d original size %d rmsd %.3f maxt %.2f cut at %d\n", bk, blockSize[bk], maxs, maxt, cut));
+				LOGGER.debug(String.format("block %d original size %d rmsd %.3f maxt %.2f cut at %d\n", bk, blockSize[bk], maxs, maxt, cut));
 			for(i = blockNum - 1; i > bk; i --)     {
 				block2Afp[i + 1] = block2Afp[i];
 				blockSize[i + 1] = blockSize[i];
@@ -129,7 +132,7 @@ public class AFPPostProcessor
 			blockSize[bk] = cut;
 
 			if(debug)
-				System.out.println(String.format("  split into %d and %d sizes\n", blockSize[bk], blockSize[bk + 1]));
+				LOGGER.debug(String.format("  split into %d and %d sizes\n", blockSize[bk], blockSize[bk + 1]));
 
 
 			int[] afpChainList = afpChain.getAfpChainList();
@@ -145,10 +148,10 @@ public class AFPPostProcessor
 		}
 		if(blockNum - blockNum0 > 0)    {
 			if(debug)
-				System.out.println(String.format("Split %d times:\n", blockNum - blockNum0));
+				LOGGER.debug(String.format("Split %d times:\n", blockNum - blockNum0));
 			for(i = 0; i < blockNum; i ++)  {
 				if(debug)
-					System.out.println(String.format("  block %d size %d from %d rmsd %.3f\n", i, blockSize[i], block2Afp[i], blockRmsd[i]));
+					LOGGER.debug(String.format("  block %d size %d from %d rmsd %.3f\n", i, blockSize[i], block2Afp[i], blockRmsd[i]));
 			}
 		}
 
@@ -217,13 +220,13 @@ public class AFPPostProcessor
 		}
 		if(blockNumOld > blockNum)
 			if(debug)
-				System.out.println(
+				LOGGER.debug(
 						String.format("Delete %d small blocks\n", blockNumOld - blockNum)
 				);
 
 
 		if (debug)
-			System.err.println("deleteBlock: end blockNum:"+ blockNum);
+			LOGGER.debug("deleteBlock: end blockNum:"+ blockNum);
 		afpChain.setBlock2Afp(block2Afp);
 		afpChain.setBlockSize(blockSize);
 		afpChain.setAfpChainList(afpChainList);
@@ -276,7 +279,7 @@ public class AFPPostProcessor
 			//maxrmsd = (blockRmsd[minb1] > blockRmsd[minb2])?blockRmsd[minb1]:blockRmsd[minb2];
 			if(minrmsd < badRmsd)   {
 				if(debug)
-					System.out.println(String.format("merge block %d (rmsd %.3f) and %d (rmsd %.3f), total rmsd %.3f\n",
+					LOGGER.debug(String.format("merge block %d (rmsd %.3f) and %d (rmsd %.3f), total rmsd %.3f\n",
 							minb1, blockRmsd[minb1], minb2, blockRmsd[minb2], minrmsd));
 				blockSize[minb1] += blockSize[minb2];
 				blockRmsd[minb1] = minrmsd;
@@ -311,11 +314,11 @@ public class AFPPostProcessor
 
 		if(merge > 0)       {
 			if(debug)
-				System.out.println(String.format("Merge %d blocks, remaining %d blocks\n", merge, blockNum));
+				LOGGER.debug(String.format("Merge %d blocks, remaining %d blocks\n", merge, blockNum));
 		}
 
 		if (debug){
-			System.err.println("AFPPostProcessor: mergeBlock end blocknum:" + blockNum);
+			LOGGER.debug("AFPPostProcessor: mergeBlock end blocknum:" + blockNum);
 		}
 		afpChain.setBlock2Afp(block2Afp);
 		afpChain.setBlockSize(blockSize);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FCAlignHelper.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FCAlignHelper.java
@@ -26,8 +26,13 @@
 
 package org.biojava.nbio.structure.align.fatcat.calc;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class FCAlignHelper
 {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(FCAlignHelper.class);
 
 	int     M; //length of protein 1
 	int     N; //length of protein 2
@@ -251,11 +256,11 @@ public class FCAlignHelper
 	private void checkAlign(){
 
 		if(sapp[0] != 0)        {
-			System.err.println(String.format("warn: not a local-alignment result, first operation %d\n", sapp[0]));
+			LOGGER.error(String.format("warn: not a local-alignment result, first operation %d\n", sapp[0]));
 		}
 		double  sco = checkScore();
 		if(Math.abs(sco - alignScore) > 1e-3)       {
-			System.err.println(String.format("FCAlignHelper: warn: alignment scores are different %f(check) %f(align)\n", sco, alignScore));
+			LOGGER.error(String.format("FCAlignHelper: warn: alignment scores are different %f(check) %f(align)\n", sco, alignScore));
 		}
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FatCatAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FatCatAligner.java
@@ -50,7 +50,6 @@ public class FatCatAligner
 {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(FatCatAligner.class);
-	public static final boolean debug = false;
 	public static final boolean printTimeStamps = false;
 
 	AFPChain afpChain ;
@@ -142,17 +141,14 @@ public class FatCatAligner
 
 		List<AFP> afpSet = afpChain.getAfpSet();
 
-		if (debug)
-			LOGGER.info("entering chainAfp");
+		LOGGER.debug("entering chainAfp");
 		int afpNum = afpSet.size();
 
 		if ( afpNum < 1)
 			return new Group[0];
 
 		long bgtime = System.currentTimeMillis();
-		if(debug)    {
-			LOGGER.info(String.format("total AFP %d\n", afpNum));
-		}
+		LOGGER.debug(String.format("total AFP %d\n", afpNum));
 
 		//run AFP chaining
 
@@ -167,10 +163,7 @@ public class FatCatAligner
 		} //very short alignment
 
 		long chaintime = System.currentTimeMillis();
-		if(debug)    {
-
-			LOGGER.info("Afp chaining: time " + (chaintime-bgtime));
-		}
+		LOGGER.info("Afp chaining: time " + (chaintime-bgtime));
 
 		// do post processing
 
@@ -205,8 +198,6 @@ public class FatCatAligner
 		//if(maxTra == 0)       probability = sig.calSigRigid(pro1Len, pro2Len, alignScore, totalRmsdOpt, optLength);
 		//else  probability = sig.calSigFlexi(pro1Len, pro2Len, alignScore, totalRmsdOpt, optLength, blockNum - 1);
 
-		if(debug)    {
-
 			long nowtime = System.currentTimeMillis();
 			long diff = nowtime - chaintime;
 			LOGGER.info("Alignment optimization: time "+ diff);
@@ -215,7 +206,6 @@ public class FatCatAligner
 			LOGGER.info("opt length: " + afpChain.getOptLength());
 			LOGGER.info("opt rmsd:   "+ afpChain.getTotalRmsdOpt());
 
-		}
 		return twistedPDB;
 
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FatCatAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FatCatAligner.java
@@ -35,6 +35,8 @@ import org.biojava.nbio.structure.align.fatcat.FatCat;
 import org.biojava.nbio.structure.align.model.AFP;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.util.AFPAlignmentDisplay;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
@@ -47,6 +49,7 @@ import java.util.List;
 public class FatCatAligner
 {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(FatCatAligner.class);
 	public static final boolean debug = false;
 	public static final boolean printTimeStamps = false;
 
@@ -88,7 +91,7 @@ public class FatCatAligner
 		long cend = System.currentTimeMillis();
 
 		if (printTimeStamps)
-			System.out.println("calculation took:" + (cend - tstart) + " ms.");
+			LOGGER.info("calculation took:" + (cend - tstart) + " ms.");
 
 
 		AFPCalculator.sortAfps(afpChain,ca1,ca2);
@@ -97,7 +100,7 @@ public class FatCatAligner
 			long send = System.currentTimeMillis();
 
 
-			System.out.println("sorting  took:" + (send - cend) + " ms.");
+			LOGGER.info("sorting  took:" + (send - cend) + " ms.");
 		}
 
 		if ( doRigid)
@@ -111,7 +114,7 @@ public class FatCatAligner
 		long end = System.currentTimeMillis();
 		afpChain.setCalculationTime(end-tstart);
 		if ( printTimeStamps)
-			System.out.println("TOTAL calc time: " + (end -tstart) / 1000.0);
+			LOGGER.info("TOTAL calc time: " + (end -tstart) / 1000.0);
 
 	}
 
@@ -140,7 +143,7 @@ public class FatCatAligner
 		List<AFP> afpSet = afpChain.getAfpSet();
 
 		if (debug)
-			System.out.println("entering chainAfp");
+			LOGGER.info("entering chainAfp");
 		int afpNum = afpSet.size();
 
 		if ( afpNum < 1)
@@ -148,7 +151,7 @@ public class FatCatAligner
 
 		long bgtime = System.currentTimeMillis();
 		if(debug)    {
-			System.out.println(String.format("total AFP %d\n", afpNum));
+			LOGGER.info(String.format("total AFP %d\n", afpNum));
 		}
 
 		//run AFP chaining
@@ -166,7 +169,7 @@ public class FatCatAligner
 		long chaintime = System.currentTimeMillis();
 		if(debug)    {
 
-			System.out.println("Afp chaining: time " + (chaintime-bgtime));
+			LOGGER.info("Afp chaining: time " + (chaintime-bgtime));
 		}
 
 		// do post processing
@@ -206,11 +209,11 @@ public class FatCatAligner
 
 			long nowtime = System.currentTimeMillis();
 			long diff = nowtime - chaintime;
-			System.out.println("Alignment optimization: time "+ diff);
+			LOGGER.info("Alignment optimization: time "+ diff);
 
-			System.out.println("score:      " + afpChain.getAlignScore());
-			System.out.println("opt length: " + afpChain.getOptLength());
-			System.out.println("opt rmsd:   "+ afpChain.getTotalRmsdOpt());
+			LOGGER.info("score:      " + afpChain.getAlignScore());
+			LOGGER.info("opt length: " + afpChain.getOptLength());
+			LOGGER.info("opt rmsd:   "+ afpChain.getTotalRmsdOpt());
 
 		}
 		return twistedPDB;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/SigEva.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/SigEva.java
@@ -27,6 +27,8 @@
 package org.biojava.nbio.structure.align.fatcat.calc;
 
 import org.biojava.nbio.structure.align.model.AFPChain;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /* CDF: cumultive density function, SF: survial function for EVD distribution, Gumbel maximum function*/
@@ -45,7 +47,7 @@ import org.biojava.nbio.structure.align.model.AFPChain;
  */
 public class SigEva
 {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(SigEva.class);
 
 	double  mu;
 	double  beta;
@@ -116,7 +118,7 @@ public class SigEva
 			beta_b = -1.4017;
 		} //score * sqrt(optLen / RMSD), the new best parameters for flexible FATCAT, sparse-sampling=3, modified scoring 2
 		else    {
-			System.err.println("no corresponding parameter set found!");
+			LOGGER.error("no corresponding parameter set found!");
 		}
 
 		mu = beta = .0;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/StructureAlignmentOptimizer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/StructureAlignmentOptimizer.java
@@ -29,11 +29,14 @@ package org.biojava.nbio.structure.align.fatcat.calc;
 
 import org.biojava.nbio.structure.*;
 import org.biojava.nbio.structure.jama.Matrix;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class StructureAlignmentOptimizer
 {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(StructureAlignmentOptimizer.class);
 
 	//private static final boolean showAlig = false;
 
@@ -197,7 +200,7 @@ public class StructureAlignmentOptimizer
 	public void runOptimization(int maxi) throws StructureException{
 		superimposeBySet();
 		if ( debug)
-			System.err.println("   initial rmsd " + rmsd);
+			LOGGER.debug("   initial rmsd " + rmsd);
 
 //      if (showAlig)
 //         showCurrentAlignment(equLen, equSet, "after initial superimposeBySet Len:" +equLen + " rmsd:" +rmsd);
@@ -302,7 +305,7 @@ public class StructureAlignmentOptimizer
 	{
 		long optStart = System.currentTimeMillis();
 		if ( debug)
-			System.out.println("Optimizing up to " + maxi + " iterations.. ");
+			LOGGER.debug("Optimizing up to " + maxi + " iterations.. ");
 		boolean ifstop = true;;
 		int     i, alnLen;
 		alnLen = 0;
@@ -333,10 +336,10 @@ public class StructureAlignmentOptimizer
 
 		if  (debug){
 			if(i < maxi)    {
-				System.out.println(String.format("   optimize converged at %d iterations\n", i));
+				LOGGER.debug(String.format("   optimize converged at %d iterations\n", i));
 			}
-			else    System.out.println("   optimize stop without convergence\n");
-			System.out.println("optimization time: " + (System.currentTimeMillis() - optStart) + " ms.");
+			else    LOGGER.debug("   optimize stop without convergence\n");
+			LOGGER.debug("optimization time: " + (System.currentTimeMillis() - optStart) + " ms.");
 		}
 
 //      if (showAlig)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/StructureAlignmentOptimizer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/StructureAlignmentOptimizer.java
@@ -66,8 +66,6 @@ public class StructureAlignmentOptimizer
 
 	double rmsd;
 
-	private static final boolean debug = FatCatAligner.debug;
-
 	/**
 	 * optimize the structural alignment by update the equivalent residues
 	 * and then run dynamic programming
@@ -199,8 +197,7 @@ public class StructureAlignmentOptimizer
 	 */
 	public void runOptimization(int maxi) throws StructureException{
 		superimposeBySet();
-		if ( debug)
-			LOGGER.debug("   initial rmsd " + rmsd);
+		LOGGER.debug("   initial rmsd " + rmsd);
 
 //      if (showAlig)
 //         showCurrentAlignment(equLen, equSet, "after initial superimposeBySet Len:" +equLen + " rmsd:" +rmsd);
@@ -304,8 +301,7 @@ public class StructureAlignmentOptimizer
 	private void optimize(int maxi) throws StructureException
 	{
 		long optStart = System.currentTimeMillis();
-		if ( debug)
-			LOGGER.debug("Optimizing up to " + maxi + " iterations.. ");
+		LOGGER.debug("Optimizing up to " + maxi + " iterations.. ");
 		boolean ifstop = true;;
 		int     i, alnLen;
 		alnLen = 0;
@@ -334,13 +330,10 @@ public class StructureAlignmentOptimizer
 //               showCurrentAlignment(alnLen, alnList,  "optimizing alignment - after " + i + " iterations alnLen:" + alnLen + " rmsd " + rmsd);
 		}
 
-		if  (debug){
-			if(i < maxi)    {
-				LOGGER.debug(String.format("   optimize converged at %d iterations\n", i));
-			}
-			else    LOGGER.debug("   optimize stop without convergence\n");
-			LOGGER.debug("optimization time: " + (System.currentTimeMillis() - optStart) + " ms.");
-		}
+		if (i < maxi) {
+			LOGGER.debug(String.format("   optimize converged at %d iterations\n", i));
+		} else LOGGER.debug("   optimize stop without convergence\n");
+		LOGGER.debug("optimization time: " + (System.currentTimeMillis() - optStart) + " ms.");
 
 //      if (showAlig)
 //         showCurrentAlignment(alnLen, alnList,  "optimizing alignment - after " + i + " iterations alnLen:" + alnLen + " rmsd " + rmsd);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/helper/AlignTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/helper/AlignTools.java
@@ -26,8 +26,12 @@ import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.AtomImpl;
 import org.biojava.nbio.structure.Calc;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AlignTools {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(AlignTools.class);
 
 	/** get a subset of Atoms based by their positions
 	 *
@@ -101,7 +105,7 @@ public class AlignTools {
 		Atom center = new AtomImpl();
 
 		if ( pos+fragmentLength > ca.length) {
-			System.err.println("pos ("+pos+"), fragL ("+fragmentLength +") > ca.length"+ca.length);
+			LOGGER.info("pos ("+pos+"), fragL ("+fragmentLength +") > ca.length"+ca.length);
 			return center;
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/helper/JointFragments.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/helper/JointFragments.java
@@ -22,6 +22,9 @@
  */
 package org.biojava.nbio.structure.align.helper;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -35,6 +38,7 @@ import java.util.List;
  */
 public class JointFragments {
 
+		private static final Logger LOGGER = LoggerFactory.getLogger(JointFragments.class);
 
 		double rms;
 
@@ -81,7 +85,7 @@ public class JointFragments {
 				while (iter.hasNext()){
 					int[] kno = iter.next();
 					if ((kno[0] == e[0]) && ( kno[1] == e[1])){
-						System.err.println("already known index pair, not adding a 2nd time." + e[0] + " " + e[1]);
+						LOGGER.warn("already known index pair, not adding a 2nd time." + e[0] + " " + e[1]);
 						return;
 					}
 				}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/AlignmentProgressListener.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/AlignmentProgressListener.java
@@ -23,6 +23,8 @@ import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.Calc;
 import org.biojava.nbio.structure.align.helper.JointFragments;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
 import java.awt.event.WindowAdapter;
@@ -37,6 +39,7 @@ import java.util.List;
  */
 public class AlignmentProgressListener
 {
+	private static final Logger LOGGER = LoggerFactory.getLogger(AlignmentProgressListener.class);
 
 	String n1;
 	String n2;
@@ -60,7 +63,7 @@ public class AlignmentProgressListener
 	}
 
 	public void calculatedFragmentPairs(List<FragmentPair> fragments){
-		System.out.println("got: " + fragments.size() + " fragments");
+		LOGGER.info("got: " + fragments.size() + " fragments");
 
 		String title = "Initial FragmentPairs for:" +  n1 + "("+l1+")"+ " vs. " + n2 + " ("+l2+")";
 		// ScaleableMatrixPanel panel = new ScaleableMatrixPanel();
@@ -120,7 +123,7 @@ public class AlignmentProgressListener
 
 
 	public void jointFragments(JointFragments[] fragments){
-		System.out.println("numberof Joint fragments: " + fragments.length);
+		LOGGER.info("numberof Joint fragments: " + fragments.length);
 
 		String title = "JointFragment for:" +  n1 + "("+l1+")"+ " vs. " + n2 + " ("+l2+")";
 		// ScaleableMatrixPanel panel = new ScaleableMatrixPanel();
@@ -156,7 +159,7 @@ public class AlignmentProgressListener
 
 
 		for (JointFragments f : fragments){
-			System.out.println(f);
+			LOGGER.info(f.toString());
 		}
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/Gotoh.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/Gotoh.java
@@ -26,6 +26,8 @@ package org.biojava.nbio.structure.align.pairwise;
 import org.biojava.nbio.structure.align.helper.AligMatEl;
 import org.biojava.nbio.structure.align.helper.GapArray;
 import org.biojava.nbio.structure.align.helper.IndexPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +39,8 @@ import java.util.List;
  * @version %I% %G%
  */
 public class Gotoh {
+	private static final Logger LOGGER = LoggerFactory.getLogger(Gotoh.class);
+
 	public static int ALIGFACTOR = 1000; // constant to shift floats to ints
 
 	Alignable a;
@@ -129,7 +133,7 @@ public class Gotoh {
 
 				if (currentGap.getValue() > currentCell.getValue()){
 					if ( currentGap.getIndex() >= rowDim)
-						System.err.println("col gap at" + rowCounter + " " + colCounter + " to " + currentGap.getIndex());
+						LOGGER.warn("col gap at" + rowCounter + " " + colCounter + " to " + currentGap.getIndex());
 					currentCell.setValue( currentGap.getValue());
 					currentCell.setRow((short)currentGap.getIndex());
 					currentCell.setCol((short)colCounter);
@@ -153,7 +157,7 @@ public class Gotoh {
 
 				if ( currentGap.getValue() > currentCell.getValue() ) {
 					if ( currentGap.getIndex() >= colDim)
-						System.err.println("row gap at" + rowCounter + " " + colCounter + " to " + currentGap.getIndex());
+						LOGGER.warn("row gap at" + rowCounter + " " + colCounter + " to " + currentGap.getIndex());
 					currentCell.setValue(currentGap.getValue());
 					currentCell.setRow((short)rowCounter);
 					currentCell.setCol((short)currentGap.getIndex());
@@ -240,19 +244,19 @@ public class Gotoh {
 
 					e.printStackTrace();
 					for (int f=0; f< n;f++){
-						System.out.println(backId[f]);
+						LOGGER.info(backId[f].toString());
 					}
 
 				}
 
 				if ( el == null)
-					System.out.println("el = null! x:"+ x + " y " + y);
+					LOGGER.info("el = null! x:"+ x + " y " + y);
 				backId[n] = el;
 			} catch (Exception e){
 				e.printStackTrace();
-				System.out.println("x " + x);
-				System.out.println("y " + y);
-				System.out.println(backId[n-2]);
+				LOGGER.error("x " + x);
+				LOGGER.error("y " + y);
+				LOGGER.error(backId[n-2].toString());
 				System.exit(0);
 			}
 			// get diagonal indeces into path

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
@@ -321,9 +321,7 @@ public class AlignmentTools {
 		double bestMetric = Double.POSITIVE_INFINITY; //lower is better
 		boolean foundSymmetry = false;
 
-		if(debug) {
-			logger.trace("Symm\tPos\tDelta");
-		}
+		logger.trace("Symm\tPos\tDelta");
 
 		for(int n=1;n<=maxSymmetry;n++) {
 			int deltasSq = 0;
@@ -341,9 +339,7 @@ public class AlignmentTools {
 					deltasSq += delta*delta;
 					numDeltas++;
 
-					if(debug) {
-						logger.debug("%d\t%d\t%d\n",n,preimage.get(i),delta);
-					}
+					logger.debug("%d\t%d\t%d\n",n,preimage.get(i),delta);
 				}
 
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/CliTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/CliTools.java
@@ -34,6 +34,9 @@
 
 package org.biojava.nbio.structure.align.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.beans.BeanInfo;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
@@ -49,6 +52,9 @@ import java.util.*;
  */
 
 public class CliTools {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CliTools.class);
+
 	private CliTools() {
 	}
 
@@ -266,7 +272,7 @@ public class CliTools {
 						}
 
 					} else {
-						System.err.println("Unsupported optionType for " + arg + " propType:" + propType);
+						LOGGER.warn("Unsupported optionType for " + arg + " propType:" + propType);
 						System.exit(1);
 					}
 				}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/ResourceManager.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/ResourceManager.java
@@ -22,6 +22,9 @@
  */
 package org.biojava.nbio.structure.align.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
@@ -38,6 +41,8 @@ import java.util.ResourceBundle;
  * @version %I% %G%
  */
 public class ResourceManager {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(ResourceManager.class);
 
 	private String BUNDLE_NAME ;
 
@@ -66,7 +71,7 @@ public class ResourceManager {
 		try {
 			return RESOURCE_BUNDLE.getString(key);
 		} catch (MissingResourceException e) {
-			System.err.println(e.getMessage());
+			LOGGER.error(e.getMessage());
 			return '!' + key + '!';
 		}
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/SynchronizedOutFile.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/SynchronizedOutFile.java
@@ -21,10 +21,14 @@
 package org.biojava.nbio.structure.align.util;
 
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.*;
 import java.util.zip.GZIPOutputStream;
 
 public class SynchronizedOutFile {
+	private static final Logger LOGGER = LoggerFactory.getLogger(SynchronizedOutFile.class);
 
 	File file;
 
@@ -48,7 +52,7 @@ public class SynchronizedOutFile {
 			throw new FileNotFoundException("please provide a file and not a directory");
 
 		if ( ! f.exists()){
-			System.out.println("creating output file: " + f.getAbsolutePath());
+			LOGGER.info("creating output file: " + f.getAbsolutePath());
 			f.createNewFile();
 		}
 		file = f;
@@ -113,7 +117,7 @@ public class SynchronizedOutFile {
 			}
 
 		} catch (Exception x) {
-			System.err.println(x);
+			LOGGER.error(x.getMessage());
 		} finally {
 			if (out != null) {
 				out.flush();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainFlipper.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainFlipper.java
@@ -29,9 +29,12 @@ import org.biojava.nbio.structure.Calc;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.jama.Matrix;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class AFPChainFlipper {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(AFPChainFlipper.class);
 
 	/** Flip the position of name1 and name2 (as well as all underlying data) in an AFPChain.
 	 * This is a utility function for AFPChainXMLParser.
@@ -70,7 +73,7 @@ public class AFPChainFlipper {
 		String[][][] pdbAlnO         = o.getPdbAln();
 
 		if ( ( optAlnO == null) && ( pdbAlnO == null) ){
-			System.err.println("Can't get either optAln or pdbAln data from original AFPChain. Not enough information to recreate alignment!");
+			LOGGER.error("Can't get either optAln or pdbAln data from original AFPChain. Not enough information to recreate alignment!");
 		}
 
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/HasResultXMLConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/HasResultXMLConverter.java
@@ -25,6 +25,8 @@
 package org.biojava.nbio.structure.align.xml;
 
 import org.biojava.nbio.core.util.PrettyXMLWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -43,7 +45,7 @@ import java.io.StringWriter;
 public class HasResultXMLConverter
 {
 
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(HasResultXMLConverter.class);
 
 
 	/** return flag if the server has a result
@@ -103,9 +105,9 @@ public class HasResultXMLConverter
 		}
 		catch (SAXParseException err)
 		{
-			System.out.println ("** Parsing error" + ", line "
+			LOGGER.error ("** Parsing error" + ", line "
 					+ err.getLineNumber () + ", uri " + err.getSystemId ());
-			System.out.println(" " + err.getMessage ());
+			LOGGER.error(" " + err.getMessage ());
 		}
 		catch (SAXException e)
 		{

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/PositionInQueueXMLConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/PositionInQueueXMLConverter.java
@@ -25,6 +25,8 @@
 package org.biojava.nbio.structure.align.xml;
 
 import org.biojava.nbio.core.util.PrettyXMLWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -42,6 +44,7 @@ import java.io.StringWriter;
 
 public class PositionInQueueXMLConverter
 {
+	private static final Logger LOGGER = LoggerFactory.getLogger(PositionInQueueXMLConverter.class);
 
 	public String toXML(int position) throws IOException{
 		StringWriter swriter = new StringWriter();
@@ -97,9 +100,9 @@ public class PositionInQueueXMLConverter
 		}
 		catch (SAXParseException err)
 		{
-			System.out.println ("** Parsing error" + ", line "
+			LOGGER.error ("** Parsing error" + ", line "
 					+ err.getLineNumber () + ", uri " + err.getSystemId ());
-			System.out.println(" " + err.getMessage ());
+			LOGGER.error(" " + err.getMessage ());
 		}
 		catch (SAXException e)
 		{

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cath/CathInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cath/CathInstallation.java
@@ -26,6 +26,8 @@ package org.biojava.nbio.structure.cath;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.io.util.FileDownloadUtils;
 import org.biojava.nbio.core.util.InputStreamProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.URL;
@@ -40,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author Daniel Asarnow
  */
 public class CathInstallation implements CathDatabase{
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(CathInstallation.class);
 	public static final String DEFAULT_VERSION = CathFactory.DEFAULT_VERSION;
 
 	String cathVersion;
@@ -653,7 +655,7 @@ public class CathInstallation implements CathDatabase{
 			disp = disp / 1024.0;
 		}
 		long timeE = System.currentTimeMillis();
-		System.out.println("downloaded " + String.format("%.1f",disp) + unit  + " in " + (timeE - timeS)/1000 + " sec.");
+		LOGGER.info("downloaded " + String.format("%.1f",disp) + unit  + " in " + (timeE - timeS)/1000 + " sec.");
 	}
 
 	private boolean domainDescriptionFileAvailable(){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/PDBDomainProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/PDBDomainProvider.java
@@ -21,6 +21,8 @@
 package org.biojava.nbio.structure.domain;
 
 import org.biojava.nbio.structure.align.util.URLConnectionTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -43,6 +45,9 @@ import java.util.TreeSet;
  *
  */
 public class PDBDomainProvider implements DomainProvider{
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PDBDomainProvider.class);
+
 	public static final String DEFAULT_PDB_HOST = "http://www.rcsb.org";
 	public static final String DEFAULT_PDB_API_URL = DEFAULT_PDB_HOST + "/pdb/rest/";
 
@@ -154,13 +159,13 @@ public class PDBDomainProvider implements DomainProvider{
 
 		SortedSet<String> domains = dom.getDomainNames(name);
 
-		System.out.println("Domains for "+name+":");
+		LOGGER.info("Domains for "+name+":");
 		for(String s : domains) {
-			System.out.println(s);
+			LOGGER.info(s);
 		}
 
 		SortedSet<String> reprs = dom.getRepresentativeDomains();
-		System.out.format("%nFound %d clusters.%n",reprs.size());
+		LOGGER.info(String.format("%nFound %d clusters.%n",reprs.size()));
 
 		try {
 			File outfile  = new File("/Users/blivens/Downloads/representativeDomainsJava.xml");

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/RemoteDomainProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/RemoteDomainProvider.java
@@ -193,9 +193,9 @@ public class RemoteDomainProvider extends SerializableCache<String,SortedSet<Str
 	public static void main(String[] args) throws IOException, StructureException{
 		String name ="3KIH.A";
 		RemoteDomainProvider me = new RemoteDomainProvider(true);
-		System.out.println(me.getDomainNames(name));
+		logger.info(me.getDomainNames(name).toString());
 		StructureName n = new StructureName(name);
-		System.out.println(n);
+		logger.info(n.toString());
 		//System.out.println(new  AtomCache().getStructure(name));
 		me.flushCache();
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/RemotePDPProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/RemotePDPProvider.java
@@ -67,11 +67,11 @@ public class RemotePDPProvider extends SerializableCache<String,SortedSet<String
 
 		//System.out.println(scop.getByCategory(ScopCategory.Superfamily));
 		SortedSet<String> pdpdomains = me.getPDPDomainNamesForPDB("4HHB");
-		System.out.println(pdpdomains);
+		logger.info(pdpdomains.toString());
 
 		AtomCache cache = new AtomCache();
 		Structure s = me.getDomain(pdpdomains.first(), cache);
-		System.out.println(s);
+		logger.info(s.toString());
 
 		me.flushCache();
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/ClusterDomains.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/ClusterDomains.java
@@ -20,6 +20,9 @@
  */
 package org.biojava.nbio.structure.domain.pdp;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +30,7 @@ import java.util.List;
 
 public class ClusterDomains {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(ClusterDomains.class);
 
 	static private boolean verbose = CutDomain.verbose;
 
@@ -66,7 +70,7 @@ public class ClusterDomains {
 					Domain d1 = domains.get(i);
 					Domain d2 = domains.get(j);
 					long total_contacts = getTotalContacts(domains,pdpDistMatrix,d1,d2);
-					System.out.println(" pos: d1:" + i + " vs d2:" +j + " d1:" + d1.getSegmentAtPos(0).getFrom() + "-" + d1.getSegmentAtPos(0).getTo() + " " +  d2.getSegmentAtPos(0).getFrom() + "-" + d2.getSegmentAtPos(0).getTo() + " " + total_contacts);
+					LOGGER.info(" pos: d1:" + i + " vs d2:" +j + " d1:" + d1.getSegmentAtPos(0).getFrom() + "-" + d1.getSegmentAtPos(0).getTo() + " " +  d2.getSegmentAtPos(0).getFrom() + "-" + d2.getSegmentAtPos(0).getTo() + " " + total_contacts);
 					int size1dom1=domains.get(i).size;
 					int size2dom2=domains.get(j).size;
 					double minDomSize=Math.min(size1dom1,size2dom2);
@@ -99,9 +103,9 @@ public class ClusterDomains {
 					 */
 
 					double S_value= total_contacts/(double)total_max_contacts;
-					if(verbose) System.out.println(String.format(" size1=%d size2=%d minDomSize=%5.2f maxDomSize=%5.2f total_contacts = %d ", size1,size2,minDomSize,maxDomSize,total_contacts));
-					if(verbose) System.out.println(String.format(" total_contacts = %d total_max_contacts = %d", total_contacts, total_max_contacts));
-					if(verbose) System.out.println(String.format(" maximum_value = %f S_value = %f\n",maximum_value, S_value));
+					if(verbose) LOGGER.info(String.format(" size1=%d size2=%d minDomSize=%5.2f maxDomSize=%5.2f total_contacts = %d ", size1,size2,minDomSize,maxDomSize,total_contacts));
+					if(verbose) LOGGER.info(String.format(" total_contacts = %d total_max_contacts = %d", total_contacts, total_max_contacts));
+					if(verbose) LOGGER.info(String.format(" maximum_value = %f S_value = %f\n",maximum_value, S_value));
 
 					if (S_value > maximum_value) {
 						maximum_value = S_value;
@@ -124,18 +128,18 @@ public class ClusterDomains {
 			}
 
 			if ( verbose) {
-				System.out.println("Check for combining: " + maximum_value  + " 1 :" + PDPParameters.CUT_OFF_VALUE1);
-				System.out.println("                     " + maximum_valuem + " 1M:" + PDPParameters.CUT_OFF_VALUE1M );
-				System.out.println("                     " + maximum_values + " 1S:" + PDPParameters.CUT_OFF_VALUE1S);
+				LOGGER.info("Check for combining: " + maximum_value  + " 1 :" + PDPParameters.CUT_OFF_VALUE1);
+				LOGGER.info("                     " + maximum_valuem + " 1M:" + PDPParameters.CUT_OFF_VALUE1M );
+				LOGGER.info("                     " + maximum_values + " 1S:" + PDPParameters.CUT_OFF_VALUE1S);
 			}
 
 			if (maximum_value > PDPParameters.CUT_OFF_VALUE1) {
 				/*
 			avd=(domains.get(Si).avd+domains.get(Sj).avd)/2;
 				 */
-				if(verbose) System.out.println(" Criteria 1 matched");
-				if(verbose) System.out.println(String.format(" maximum_value = %f", maximum_value));
-				if(verbose) System.out.println(String.format(" Si = %d Sj = %d ", Si, Sj));
+				if(verbose) LOGGER.info(" Criteria 1 matched");
+				if(verbose) LOGGER.info(String.format(" maximum_value = %f", maximum_value));
+				if(verbose) LOGGER.info(String.format(" Si = %d Sj = %d ", Si, Sj));
 				domains = combine(domains,Si, Sj, maximum_value);
 				maximum_value = PDPParameters.CUT_OFF_VALUE1-.1;
 				maximum_values = PDPParameters.CUT_OFF_VALUE1S-.1;
@@ -144,16 +148,16 @@ public class ClusterDomains {
 			domains.get(Si).avd=domcont(domains.get(Si));
 			domains.get(Sj).avd=domcont(domains.get(Sj));
 				 */
-				if(verbose) System.out.println(String.format(" Listing the domains after combining..."));
+				if(verbose) LOGGER.info(String.format(" Listing the domains after combining..."));
 				if(verbose) listdomains (domains);
 			}
 			else if (maximum_valuem > PDPParameters.CUT_OFF_VALUE1M) {
 				/*
 			avd=(domains[Sim].avd+domains[Sjm].avd)/2;
 				 */
-				if(verbose) System.out.println(" Criteria 2 matched");
-				if(verbose) System.out.println(String.format(" maximum_values = %f", maximum_valuem));
-				if(verbose) System.out.println(String.format(" Sim = %d Sjm = %d", Sim, Sjm));
+				if(verbose) LOGGER.info(" Criteria 2 matched");
+				if(verbose) LOGGER.info(String.format(" maximum_values = %f", maximum_valuem));
+				if(verbose) LOGGER.info(String.format(" Sim = %d Sjm = %d", Sim, Sjm));
 				domains = combine(domains, Sim, Sjm, maximum_valuem);
 				maximum_value =  PDPParameters.CUT_OFF_VALUE1-.1;
 				maximum_values = PDPParameters.CUT_OFF_VALUE1S-.1;
@@ -162,16 +166,16 @@ public class ClusterDomains {
 			domains[Sim].avd=domcont(domains[Sim]);
 			domains[Sjm].avd=domcont(domains[Sjm]);
 				 */
-				if(verbose) System.out.println(String.format(" Listing the domains after combining..."));
+				if(verbose) LOGGER.info(String.format(" Listing the domains after combining..."));
 				if(verbose) listdomains (domains);
 			}
 			else if (maximum_values > PDPParameters.CUT_OFF_VALUE1S) {
 				/*
 			avd=(domains[Sis].avd+domains[Sjs].avd)/2;
 				 */
-				if(verbose) System.out.println(" Criteria 3 matched");
-				if(verbose) System.out.println(String.format(" maximum_values = %f", maximum_values));
-				if(verbose) System.out.println(String.format(" Sis = %d Sjs = %d", Sis, Sjs));
+				if(verbose) LOGGER.info(" Criteria 3 matched");
+				if(verbose) LOGGER.info(String.format(" maximum_values = %f", maximum_values));
+				if(verbose) LOGGER.info(String.format(" Sis = %d Sjs = %d", Sis, Sjs));
 				domains = combine(domains, Sis, Sjs, maximum_values);
 				maximum_value = PDPParameters.CUT_OFF_VALUE1-.1;
 				maximum_values = PDPParameters.CUT_OFF_VALUE1S-.1;
@@ -180,11 +184,11 @@ public class ClusterDomains {
 			domains[Sis].avd=domcont(domains[Sis]);
 			domains[Sjs].avd=domcont(domains[Sjs]);
 				 */
-				if(verbose) System.out.println(String.format(" Listing the domains after combining..."));
+				if(verbose) LOGGER.info(String.format(" Listing the domains after combining..."));
 				if(verbose) listdomains(domains);
 			}
 			else {
-				if(verbose) System.out.println(String.format(" Maximum value is less than cut off value. (max:" + maximum_value+")" ));
+				if(verbose) LOGGER.info(String.format(" Maximum value is less than cut off value. (max:" + maximum_value+")" ));
 				maximum_value = -1.0;
 				maximum_values = -1.0;
 				maximum_valuem = -1.0;
@@ -192,7 +196,7 @@ public class ClusterDomains {
 			}
 		} while ( maximum_value > 0.0||maximum_values>0.0||maximum_valuem>0.0);
 
-		if(verbose) System.out.println(String.format(" The domains are:"));
+		if(verbose) LOGGER.info(String.format(" The domains are:"));
 		if(verbose) listdomains(domains);
 		return domains;
 	}
@@ -224,7 +228,7 @@ public class ClusterDomains {
 	private static List<Domain> combine(List<Domain> domains,int Si, int Sj, double maximum_value) {
 
 		if ( verbose)
-			System.out.println("  +++  combining domains " + Si + " " + Sj);
+			LOGGER.info("  +++  combining domains " + Si + " " + Sj);
 
 		List<Domain> newdoms = new ArrayList<Domain>();
 
@@ -273,11 +277,11 @@ public class ClusterDomains {
 		int i = -1;
 		for ( Domain dom : domains){
 			i++;
-			System.out.println("DOMAIN:" + i + " size:" + dom.size + " " +  dom.score);
+			LOGGER.info("DOMAIN:" + i + " size:" + dom.size + " " +  dom.score);
 			List<Segment> segments = dom.getSegments();
 
 			for ( Segment s : segments){
-				System.out.println("   Segment: " + s);
+				LOGGER.info("   Segment: " + s);
 
 			}
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/Cut.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/Cut.java
@@ -21,11 +21,13 @@
 package org.biojava.nbio.structure.domain.pdp;
 
 import org.biojava.nbio.structure.Atom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 public class Cut {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(Cut.class);
 	static boolean verbose = CutDomain.verbose;
 
 	public int cut( Atom[] ca, Domain dom, CutValues val, int[][] dist, PDPDistanceMatrix pdpMatrix) {
@@ -62,7 +64,7 @@ public class Cut {
 		java.util.Collections.sort(segments, new SegmentComparator());
 
 		if ( verbose)
-			System.out.println("  ---  Cut.cut " + dom + " ");
+			LOGGER.info("  ---  Cut.cut " + dom + " ");
 		average_density = 0.0;
 		size0=0;
 		for(iseg=0;iseg<dom.nseg;iseg++) {
@@ -167,11 +169,11 @@ public class Cut {
 			}
 		}
 		average_density/=size0;
-		if(verbose) System.out.println(String.format("  --- Trying to cut domain of size %d having %d segments and  average cont_density %f\n",dom.size,dom.nseg,average_density));
+		if(verbose) LOGGER.info(String.format("  --- Trying to cut domain of size %d having %d segments and  average cont_density %f\n",dom.size,dom.nseg,average_density));
 
 		if ( verbose )
 			for(kseg=0;kseg<dom.nseg;kseg++)
-				System.out.println(String.format("	--- segment %d from %d to %d",kseg,dom.getSegmentAtPos(kseg).getFrom(),dom.getSegmentAtPos(kseg).getTo()) + " av density: " + average_density);
+				LOGGER.info(String.format("	--- segment %d from %d to %d",kseg,dom.getSegmentAtPos(kseg).getFrom(),dom.getSegmentAtPos(kseg).getTo()) + " av density: " + average_density);
 
 
 		if(val.first_cut) {
@@ -180,7 +182,7 @@ public class Cut {
 			printf("%d	%s	%d	%d	%d	%d	%f\n",k,protein.res[k].type,k-from,to-k,contacts[k],max_contacts[k],contact_density[k]);
 			 */
 			val.AD = average_density;
-			if(verbose)	System.out.println(String.format("  --- AD=%f", average_density));
+			if(verbose)	LOGGER.info(String.format("  --- AD=%f", average_density));
 			/*
 			 */
 		}
@@ -188,14 +190,14 @@ public class Cut {
 
 		val.s_min/=val.AD;
 
-		if(verbose) System.out.println(String.format("  --- after single cut: s_min = %f site_min = %d",val.s_min,site_min));
+		if(verbose) LOGGER.info(String.format("  --- after single cut: s_min = %f site_min = %d",val.s_min,site_min));
 
 		///
 		k=0;
 
 		/* check double cuts */
 		if ( verbose )
-		System.out.println("  --- checking double cuts up to: " + nclose);
+		LOGGER.info("  --- checking double cuts up to: " + nclose);
 		nc=0;
 		for(l=0;l<nclose;l++) {
 
@@ -391,7 +393,7 @@ public class Cut {
 		}
 		val.first_cut=false;
 		if(verbose)
-			System.out.println(String.format("  --- E ... at the end of cut: s_min %f CUTOFF %f site_min %d *site2 %d",val.s_min,PDPParameters.CUT_OFF_VALUE,site_min,val.site2));
+			LOGGER.info(String.format("  --- E ... at the end of cut: s_min %f CUTOFF %f site_min %d *site2 %d",val.s_min,PDPParameters.CUT_OFF_VALUE,site_min,val.site2));
 		if(val.s_min> PDPParameters.CUT_OFF_VALUE) return -1;
 
 		return(site_min);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/CutDomain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/CutDomain.java
@@ -21,12 +21,16 @@
 package org.biojava.nbio.structure.domain.pdp;
 
 import org.biojava.nbio.structure.Atom;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
 
 public class CutDomain {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CutDomain.class);
 
 	int ndom;
 
@@ -51,7 +55,7 @@ public class CutDomain {
 	public  void cutDomain(Domain dom, CutSites cut_sites, PDPDistanceMatrix pdpMatrix){
 
 		if ( verbose )
-		System.out.println("  B ... beginning of cutDomain " +dom + " cutsites: " + cut_sites );
+			LOGGER.info("  B ... beginning of cutDomain " +dom + " cutsites: " + cut_sites );
 
 		/* recursive function to cut input domain into two domains */
 
@@ -71,7 +75,7 @@ public class CutDomain {
 
 		site = cut.cut(ca,dom,val, dist, pdpMatrix);
 		if ( verbose )
-		System.out.println("  S ... site " + dom + " : site: " + site + " val : " + val);
+			LOGGER.info("  S ... site " + dom + " : site: " + site + " val : " + val);
 
 		if(site<0) {
 
@@ -85,7 +89,7 @@ public class CutDomain {
 		}
 
 		if(verbose)
-			System.out.println(String.format("   C ... Cutting at position(s): %d %d %f\n",site,val.site2,dom.score));
+			LOGGER.info(String.format("   C ... Cutting at position(s): %d %d %f\n",site,val.site2,dom.score));
 
 		cut_sites.cut_sites[cut_sites.ncuts++] = site;
 
@@ -172,19 +176,19 @@ public class CutDomain {
 			}
 		}
 		if(verbose)
-			System.out.println(String.format("  CUTR dom1 ...  nseg %d",dom1.nseg));
+			LOGGER.info(String.format("  CUTR dom1 ...  nseg %d",dom1.nseg));
 
 		if ( verbose)
 		for(i=0;i<dom1.nseg;i++)
-			System.out.println(String.format("	F ... from %d to %d",dom1.getSegmentAtPos(i).getFrom(),dom1.getSegmentAtPos(i).getTo()));
+			LOGGER.info(String.format("	F ... from %d to %d",dom1.getSegmentAtPos(i).getFrom(),dom1.getSegmentAtPos(i).getTo()));
 
 		cutDomain(dom1, cut_sites, pdpMatrix);
 
 		if(verbose)
-			System.out.println(String.format("  C ... cutr dom2: nseg %d",dom2.nseg));
+			LOGGER.info(String.format("  C ... cutr dom2: nseg %d",dom2.nseg));
 		if(verbose)
 			for(i=0;i<dom2.nseg;i++)
-			 System.out.println(String.format("	F ... from %d to %d",dom2.getSegmentAtPos(i).getFrom(),dom2.getSegmentAtPos(i).getTo()));
+				LOGGER.info(String.format("	F ... from %d to %d",dom2.getSegmentAtPos(i).getFrom(),dom2.getSegmentAtPos(i).getTo()));
 
 		cutDomain(dom2, cut_sites, pdpMatrix);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/GetDistanceMatrix.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/GetDistanceMatrix.java
@@ -21,10 +21,13 @@
 package org.biojava.nbio.structure.domain.pdp;
 
 import org.biojava.nbio.structure.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class GetDistanceMatrix {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(GetDistanceMatrix.class);
 
 	/** A set of Calpha atoms that are representing the protein
 	 *
@@ -39,7 +42,7 @@ public class GetDistanceMatrix {
 		int[] jclose= new int[protein.length*protein.length];
 
 		if(protein.length >= PDPParameters.MAXLEN) {
-			System.err.println(String.format("%d protein.len > MAXLEN %d\n",protein.length,PDPParameters.MAXLEN));
+			LOGGER.warn(String.format("%d protein.len > MAXLEN %d\n",protein.length,PDPParameters.MAXLEN));
 			return null;
 		}
 		for(i=0;i<protein.length;i++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
@@ -765,7 +765,7 @@ v1.4 - added seqid_range and headers (develop101)
 
 	public static void main(String[] args) {
 		if( args.length!= 1) {
-			System.out.println("usage: ecod_domains.txt");
+			logger.info("usage: ecod_domains.txt");
 			System.exit(1); return;
 		}
 
@@ -776,14 +776,14 @@ v1.4 - added seqid_range and headers (develop101)
 
 			List<EcodDomain> domains = parser.getDomains();
 
-			System.out.format("Found %d ECOD domains.%n",domains.size());
+			logger.info("Found %d ECOD domains.%n",domains.size());
 
-			System.out.println("First 10 domains:");
+			logger.info("First 10 domains:");
 			int i = 0;
 			for(EcodDomain d: domains) {
 				if( i>10) break;
 
-				System.out.println(d.getDomainId());
+				logger.info(d.getDomainId());
 				i++;
 			}
 		} catch (IOException e) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FastaAFPChainConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FastaAFPChainConverter.java
@@ -396,7 +396,7 @@ public class FastaAFPChainConverter {
 	 */
 	public static void main(String[] args) throws StructureException, IOException {
 		if (args.length != 3) {
-			System.err.println("Usage: FastaAFPChainConverter fasta-file structure-1-name structure-2-name");
+			logger.info("Usage: FastaAFPChainConverter fasta-file structure-1-name structure-2-name");
 			return;
 		}
 		File fasta = new File(args[0]);
@@ -406,7 +406,7 @@ public class FastaAFPChainConverter {
 		if (structure2 == null) throw new IllegalArgumentException("No structure for " + args[2] + " was found");
 		AFPChain afpChain = fastaFileToAfpChain(fasta, structure1, structure2);
 		String xml = AFPChainXMLConverter.toXML(afpChain);
-		System.out.println(xml);
+		logger.info(xml);
 	}
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -482,7 +482,7 @@ public class FileConvert {
 		/*xmlns="http://www.sanger.ac.uk/xml/das/2004/06/17/dasalignment.xsd" xmlns:align="http://www.sanger.ac.uk/xml/das/2004/06/17/alignment.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema-instance" xsd:schemaLocation="http://www.sanger.ac.uk/xml/das/2004/06/17/dasalignment.xsd http://www.sanger.ac.uk/xml/das//2004/06/17/dasalignment.xsd"*/
 
 		if ( structure == null){
-			System.err.println("can not convert structure null");
+			logger.error("can not convert structure null");
 			return;
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/MMCIFFileReader.java
@@ -26,6 +26,8 @@ import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.io.mmcif.MMcifParser;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifConsumer;
 import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -51,7 +53,7 @@ public static void main(String[] args) throws Exception {
  */
 public class MMCIFFileReader extends LocalPDBDirectory {
 
-	//private static final Logger logger = LoggerFactory.getLogger(MMCIFFileReader.class);
+	private static final Logger logger = LoggerFactory.getLogger(MMCIFFileReader.class);
 
 	public static final String[] MMCIF_SPLIT_DIR    = new String[]{"data","structures","divided" ,"mmCIF"};
 	public static final String[] MMCIF_OBSOLETE_DIR = new String[]{"data","structures","obsolete","mmCIF"};
@@ -66,8 +68,8 @@ public class MMCIFFileReader extends LocalPDBDirectory {
 
 
 		Structure struc = reader.getStructureById("1m4x");
-		System.out.println(struc);
-		System.out.println(struc.toPDB());
+		logger.info(struc.toString());
+		logger.info(struc.toPDB());
 
 
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileReader.java
@@ -29,6 +29,9 @@ import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -96,7 +99,7 @@ import java.util.List;
  */
 public class PDBFileReader extends LocalPDBDirectory {
 
-	//private static final Logger logger = LoggerFactory.getLogger(PDBFileReader.class);
+	private static final Logger logger = LoggerFactory.getLogger(PDBFileReader.class);
 
 	// a list of big pdb files for testing
 	//  "1htq",
@@ -144,22 +147,22 @@ public class PDBFileReader extends LocalPDBDirectory {
 		try{
 
 			Structure struc = pdbreader.getStructureById("193D");
-			System.out.println(struc);
+			logger.info(struc.toString());
 
 			List<EntityInfo>	compounds = struc.getEntityInfos();
 			for (EntityInfo comp : compounds  ){
 				List<Chain> chains = comp.getChains();
-				System.out.print(">Chains :" );
+				logger.info(">Chains :" );
 				for (Chain c : chains){
-					System.out.print(c.getId() + " " );
+					logger.info(c.getId() + " " );
 				}
-				System.out.println();
+				logger.info("\n");
 				if ( chains.size() > 0)	{
-					System.out.println(chains.get(0).getAtomSequence());
-					System.out.println(chains.get(0).getSeqResSequence());
-					
+					logger.info(chains.get(0).getAtomSequence());
+					logger.info(chains.get(0).getSeqResSequence());
 
-					System.out.println(" ");
+
+					logger.info(" ");
 				}
 			}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
@@ -105,7 +105,7 @@ System.out.println(s.toPDB());
  */
 public class SimpleMMcifParser implements MMcifParser {
 
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(SimpleMMcifParser.class);
 
 	/**
 	 * The header appearing at the beginning of a mmCIF file.
@@ -168,14 +168,14 @@ public class SimpleMMcifParser implements MMcifParser {
 		//String file = "/Users/andreas/WORK/PDB/MMCIF/1gav.mmcif";
 		//String file = "/Users/andreas/WORK/PDB/MMCIF/100d.cif";
 		//String file = "/Users/andreas/WORK/PDB/MMCIF/1a4a.mmcif";
-		System.out.println("parsing " + file);
+		LOGGER.info("parsing " + file);
 
 		StructureIOFile pdbreader = new MMCIFFileReader();
 		try {
 			Structure s = pdbreader.getStructure(file);
-			System.out.println(s);
+			LOGGER.info(s.toString());
 			// convert it to a PDB file...
-			System.out.println(s.toPDB());
+			LOGGER.info(s.toPDB());
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/PdbxStructAssemblyGenXMLContainer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/PdbxStructAssemblyGenXMLContainer.java
@@ -20,6 +20,9 @@
  */
 package org.biojava.nbio.structure.io.mmcif.model;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
@@ -32,6 +35,8 @@ import java.util.List;
 
 @XmlRootElement(name="PdbxStructAssemblyGenXMLContainer")
 public class PdbxStructAssemblyGenXMLContainer {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PdbxStructAssemblyGenXMLContainer.class);
 
 	private List<PdbxStructAssemblyGen> data ;
 
@@ -56,7 +61,7 @@ public class PdbxStructAssemblyGenXMLContainer {
 
 	public  String toXML(){
 
-		System.out.println("converting to XML: " + data);
+		LOGGER.info("converting to XML: " + data);
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureWriter.java
@@ -17,6 +17,8 @@ import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.biojava.nbio.structure.quaternary.BioAssemblyInfo;
 import org.rcsb.mmtf.api.StructureAdapterInterface;
 import org.rcsb.mmtf.dataholders.MmtfStructure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class to take Biojava structure data and covert to the DataApi for encoding. 
@@ -26,6 +28,7 @@ import org.rcsb.mmtf.dataholders.MmtfStructure;
  */
 public class MmtfStructureWriter {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(MmtfStructureWriter.class);
 
 	private StructureAdapterInterface mmtfDecoderInterface;
 
@@ -161,7 +164,7 @@ public class MmtfStructureWriter {
 			List<Chain> entityChains = entityInfo.getChains();
 			if (entityChains.isEmpty()){
 				// Error mapping chain to entity
-				System.err.println("ERROR MAPPING CHAIN TO ENTITY: "+description);
+				LOGGER.error("ERROR MAPPING CHAIN TO ENTITY: "+description);
 				continue;
 			}
 			int[] chainIndices = new int[entityChains.size()];

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfUtils.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfUtils.java
@@ -42,6 +42,8 @@ import org.biojava.nbio.structure.xtal.CrystalCell;
 import org.biojava.nbio.structure.xtal.SpaceGroup;
 import org.rcsb.mmtf.dataholders.DsspType;
 import org.rcsb.mmtf.utils.CodecUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A utils class of functions needed for Biojava to read and write to mmtf.
@@ -49,6 +51,9 @@ import org.rcsb.mmtf.utils.CodecUtils;
  *
  */
 public class MmtfUtils {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(MmtfUtils.class);
+
 	/**
 	 * Set up the configuration parameters for BioJava.
 	 */
@@ -145,7 +150,7 @@ public class MmtfUtils {
 			catch(FileNotFoundException enew){
 			}
 			catch(Exception bige){
-				System.out.println(bige);
+				LOGGER.error(bige.getMessage());
 			}
 		}
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
@@ -52,13 +52,13 @@ public class SiftsMappingProvider {
 			List<SiftsEntity> entities = getSiftsMapping("1gc1");
 
 			for (SiftsEntity e : entities){
-				System.out.println(e.getEntityId() + " " +e.getType());
+				logger.info(e.getEntityId() + " " +e.getType());
 
 				for ( SiftsSegment seg: e.getSegments()) {
-					System.out.println(" Segment: " + seg.getSegId() + " " + seg.getStart() + " " + seg.getEnd()) ;
+					logger.info(" Segment: " + seg.getSegId() + " " + seg.getStart() + " " + seg.getEnd()) ;
 
 					for ( SiftsResidue res: seg.getResidues() ) {
-						System.out.println("  " + res);
+						logger.info("  " + res);
 					}
 				}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsXMLParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsXMLParser.java
@@ -24,6 +24,8 @@
  */
 package org.biojava.nbio.structure.io.sifts;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -39,6 +41,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class SiftsXMLParser {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SiftsXMLParser.class);
 
 	Document dom;
 	List<SiftsEntity> entities;
@@ -146,7 +150,7 @@ public class SiftsXMLParser {
 			SiftsSegment seg = new SiftsSegment(segId,start,end);
 
 			if ( debug )
-				System.out.println("parsed " + seg);
+				LOGGER.info("parsed " + seg);
 
 			// get nodelist of segments...
 			NodeList nl = el.getElementsByTagName("listResidue");

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsXMLParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsXMLParser.java
@@ -47,7 +47,6 @@ public class SiftsXMLParser {
 	Document dom;
 	List<SiftsEntity> entities;
 
-	static boolean debug = false;
 	public SiftsXMLParser(){
 		entities = new ArrayList<SiftsEntity>();
 	}
@@ -149,8 +148,7 @@ public class SiftsXMLParser {
 			String end = el.getAttribute("end");
 			SiftsSegment seg = new SiftsSegment(segId,start,end);
 
-			if ( debug )
-				LOGGER.info("parsed " + seg);
+			LOGGER.debug("parsed " + seg);
 
 			// get nodelist of segments...
 			NodeList nl = el.getElementsByTagName("listResidue");

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/util/FileDownloadUtils.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/util/FileDownloadUtils.java
@@ -244,15 +244,15 @@ public class FileDownloadUtils {
 	public static void main(String[] args) {
 		String url;
 		url = "http://scop.mrc-lmb.cam.ac.uk/scop/parse/";
-		System.out.format("%s\t%s%n", ping(url, 200), url);
+		logger.info(String.format("%s\t%s%n", ping(url, 200), url));
 		url = "http://scop.mrc-lmb.cam.ac.uk/scop/parse/foo";
-		System.out.format("%s\t%s%n", ping(url, 200), url);
+		logger.info(String.format("%s\t%s%n", ping(url, 200), url));
 		url = "http://scopzzz.mrc-lmb.cam.ac.uk/scop/parse/";
-		System.out.format("%s\t%s%n", ping(url, 200), url);
+		logger.info(String.format("%s\t%s%n", ping(url, 200), url));
 		url = "scop.mrc-lmb.cam.ac.uk";
-		System.out.format("%s\t%s%n", ping(url, 200), url);
+		logger.info(String.format("%s\t%s%n", ping(url, 200), url));
 		url = "http://scop.mrc-lmb.cam.ac.uk";
-		System.out.format("%s\t%s%n", ping(url, 200), url);
+		logger.info(String.format("%s\t%s%n", ping(url, 200), url));
 	}
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/rcsb/GetRepresentatives.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/rcsb/GetRepresentatives.java
@@ -24,6 +24,8 @@ import org.biojava.nbio.structure.align.client.JFatCatClient;
 import org.biojava.nbio.structure.align.client.StructureName;
 import org.biojava.nbio.structure.align.util.URLConnectionTools;
 import org.biojava.nbio.structure.align.xml.RepresentativeXMLConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -38,6 +40,8 @@ import java.util.TreeSet;
  * TODO Move this to {@link Representatives}.
  */
 public class GetRepresentatives {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(GetRepresentatives.class);
 
 	private static String clusterUrl = "http://www.rcsb.org/pdb/rest/representatives?cluster=";
 	private static String allUrl = "http://www.rcsb.org/pdb/rest/getCurrent/";
@@ -57,7 +61,7 @@ public class GetRepresentatives {
 		SortedSet<StructureName> representatives = new TreeSet<StructureName>();
 
 		if (!seqIdentities.contains(sequenceIdentity)) {
-			System.err.println("Error: representative chains are not available for %sequence identity: "
+			LOGGER.error("Error: representative chains are not available for %sequence identity: "
 							+ sequenceIdentity);
 			return representatives;
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/rcsb/PdbIdLists.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/rcsb/PdbIdLists.java
@@ -20,6 +20,9 @@
  */
 package org.biojava.nbio.structure.rcsb;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
@@ -33,6 +36,8 @@ import java.util.*;
  *  @since 4.2.0
  */
 public class PdbIdLists {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PdbIdLists.class);
 
 	/** get the list of current PDB IDs
 	 *

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/rcsb/PdbIdLists.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/rcsb/PdbIdLists.java
@@ -284,13 +284,13 @@ public class PdbIdLists {
 
 	public static void main(String[] args){
 		try {
-			System.out.println("Current PDB status: " + getCurrentPDBIds().size());
-			System.out.println("Virus structures: " + getAllViruses().size());
-			System.out.println("NMR structures: " + getNMRStructures().size());
-			System.out.println("Gag-polyproteins: " + getGagPolyproteins().size());
-			System.out.println("Transmembrane proteins: " + getTransmembraneProteins().size());
-			System.out.println("Nucleotide: " + getNucleotides().size());
-			System.out.println("Ribosomes: " + getRibosomes().size());
+			LOGGER.info("Current PDB status: " + getCurrentPDBIds().size());
+			LOGGER.info("Virus structures: " + getAllViruses().size());
+			LOGGER.info("NMR structures: " + getNMRStructures().size());
+			LOGGER.info("Gag-polyproteins: " + getGagPolyproteins().size());
+			LOGGER.info("Transmembrane proteins: " + getTransmembraneProteins().size());
+			LOGGER.info("Nucleotide: " + getNucleotides().size());
+			LOGGER.info("Ribosomes: " + getRibosomes().size());
 		} catch ( Exception e){
 			e.printStackTrace();
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/RemoteScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/RemoteScopInstallation.java
@@ -30,6 +30,8 @@ import org.biojava.nbio.structure.scop.server.ScopDescriptions;
 import org.biojava.nbio.structure.scop.server.ScopDomains;
 import org.biojava.nbio.structure.scop.server.ScopNodes;
 import org.biojava.nbio.structure.scop.server.XMLUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,6 +46,8 @@ import java.util.List;
  */
 public class RemoteScopInstallation implements ScopDatabase {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteScopInstallation.class);
+
 	public static final String DEFAULT_SERVER = "http://source.rcsb.org/jfatcatserver/domains/";
 
 	String server = DEFAULT_SERVER;
@@ -57,7 +61,7 @@ public class RemoteScopInstallation implements ScopDatabase {
 
 		//System.out.println(scop.getByCategory(ScopCategory.Superfamily));
 
-		System.out.println(scop.getDomainsForPDB("4HHB"));
+		LOGGER.info(scop.getDomainsForPDB("4HHB").toString());
 	}
 
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/axis/HelixAxisAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/axis/HelixAxisAligner.java
@@ -26,12 +26,16 @@ import org.biojava.nbio.structure.symmetry.core.QuatSymmetryResults;
 import org.biojava.nbio.structure.symmetry.core.Subunits;
 import org.biojava.nbio.structure.symmetry.geometry.MomentsOfInertia;
 import org.biojava.nbio.structure.symmetry.geometry.SuperPosition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.vecmath.*;
 
 import java.util.*;
 
 public class HelixAxisAligner extends AxisAligner {
+	private static final Logger LOGGER = LoggerFactory.getLogger(HelixAxisAligner.class);
+
 	private static final Vector3d Y_AXIS = new Vector3d(0,1,0);
 	private static final Vector3d Z_AXIS = new Vector3d(0,0,1);
 
@@ -485,7 +489,7 @@ public class HelixAxisAligner extends AxisAligner {
 		ref[0] = new Point3d(referenceVectors[0]);
 		ref[1] = new Point3d(referenceVectors[1]);
 		if (SuperPosition.rmsd(axes, ref) > 0.1) {
-			System.out.println("Warning: AxisTransformation: axes alignment is off. RMSD: " + SuperPosition.rmsd(axes, ref));
+			LOGGER.warn("Warning: AxisTransformation: axes alignment is off. RMSD: " + SuperPosition.rmsd(axes, ref));
 		}
 
 		return m2;
@@ -605,7 +609,7 @@ public class HelixAxisAligner extends AxisAligner {
 		referenceVector = getReferenceAxisCylic();
 
 		if (referenceVector == null) {
-			System.err.println("Warning: no reference vector found. Using y-axis.");
+			LOGGER.error("Warning: no reference vector found. Using y-axis.");
 			referenceVector = new Vector3d(Y_AXIS);
 		}
 		// make sure reference vector is perpendicular principal roation vector
@@ -621,7 +625,7 @@ public class HelixAxisAligner extends AxisAligner {
 			vector2.negate();
 		}
 		if (Math.abs(dot) < 0.00001) {
-			System.out.println("HelixAxisAligner: Warning: reference axis parallel");
+			LOGGER.warn("HelixAxisAligner: Warning: reference axis parallel");
 		}
 		vector2.cross(vector1, vector2);
 //		System.out.println("Intermed. refVector: " + vector2);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/axis/RotationAxisAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/axis/RotationAxisAligner.java
@@ -26,12 +26,16 @@ import org.biojava.nbio.structure.symmetry.core.RotationGroup;
 import org.biojava.nbio.structure.symmetry.core.Subunits;
 import org.biojava.nbio.structure.symmetry.geometry.MomentsOfInertia;
 import org.biojava.nbio.structure.symmetry.geometry.SuperPosition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.vecmath.*;
 
 import java.util.*;
 
 public class RotationAxisAligner extends AxisAligner{
+	private static final Logger LOGGER = LoggerFactory.getLogger(RotationAxisAligner.class);
+
 	private static final Vector3d X_AXIS = new Vector3d(1,0,0);
 	private static final Vector3d Y_AXIS = new Vector3d(0,1,0);
 	private static final Vector3d Z_AXIS = new Vector3d(0,0,1);
@@ -325,7 +329,7 @@ public class RotationAxisAligner extends AxisAligner{
 		}
 		Collections.reverse(orbit.subList(1,  orbit.size()));
 		if (orbit.get(1) != index2) {
-			System.err.println("Warning: alignWithReferenceAxis failed");
+			LOGGER.error("Warning: alignWithReferenceAxis failed");
 		}
 //		System.out.println("Orbit2: " + orbit);
 		return orbit;
@@ -464,7 +468,7 @@ public class RotationAxisAligner extends AxisAligner{
 		ref[0] = new Point3d(referenceVectors[0]);
 		ref[1] = new Point3d(referenceVectors[1]);
 		if (SuperPosition.rmsd(axes, ref) > 0.1) {
-			System.out.println("Warning: AxisTransformation: axes alignment is off. RMSD: " + SuperPosition.rmsd(axes, ref));
+			LOGGER.info("Warning: AxisTransformation: axes alignment is off. RMSD: " + SuperPosition.rmsd(axes, ref));
 		}
 
 		return m2;
@@ -637,7 +641,7 @@ public class RotationAxisAligner extends AxisAligner{
 			int index = p0.indexOf(current);
 			int next = p1.get(index);
 			if (!orbit.contains(next)) {
-				System.err.println("deconvolute: inconsistency in permuation. Returning original order");
+				LOGGER.warn("deconvolute: inconsistency in permuation. Returning original order");
 				return orbit;
 			}
 			inRotationOrder.add(next);
@@ -680,7 +684,7 @@ public class RotationAxisAligner extends AxisAligner{
 		}
 
 		if (referenceVector == null) {
-			System.err.println("Warning: no reference vector found. Using y-axis.");
+			LOGGER.warn("Warning: no reference vector found. Using y-axis.");
 			referenceVector = new Vector3d(Y_AXIS);
 		}
 		// make sure reference vector is perpendicular principal roation vector

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixExtender.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixExtender.java
@@ -21,6 +21,8 @@
 package org.biojava.nbio.structure.symmetry.core;
 
 import org.biojava.nbio.structure.symmetry.geometry.SuperPosition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.vecmath.Matrix4d;
 import javax.vecmath.Point3d;
@@ -29,6 +31,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class HelixExtender {
+	private static final Logger LOGGER = LoggerFactory.getLogger(HelixExtender.class);
+
 	private Subunits subunits = null;
 	private Helix helix = null;
 
@@ -49,7 +53,7 @@ public class HelixExtender {
 				indices.add(line.get(line.size()-1));
 			}
 		}
-		System.out.println("Extending subunits: " + indices);
+		LOGGER.info("Extending subunits: " + indices);
 
 		List<Point3d> points = new ArrayList<Point3d>();
 		Matrix4d transformation = helix.getTransformation();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixSolver.java
@@ -39,10 +39,7 @@ import java.util.Map.Entry;
  *
  */
 public class HelixSolver {
-
-	private static final Logger logger = LoggerFactory
-			.getLogger(HelixSolver.class);
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(HelixSolver.class);
 	private Subunits subunits = null;
 	private int fold = 1;
 	private HelixLayers helixLayers = new HelixLayers();
@@ -86,7 +83,7 @@ public class HelixSolver {
 
 		for (Entry<Integer[], Integer> entry : interactionMap.entrySet()) {
 			Integer[] pair = entry.getKey();
-			logger.debug("HelixSolver: pair: " + Arrays.toString(pair));
+			LOGGER.debug("HelixSolver: pair: " + Arrays.toString(pair));
 			
 			int contacts = entry.getValue();
 			Point3d[] h1 = null;
@@ -105,7 +102,7 @@ public class HelixSolver {
 					repeatUnitCenters.get(pair[1]));
 			double angle = getAngle(transformation);
 
-			logger.debug(
+			LOGGER.debug(
 					"Original rmsd: {}, Original rise {}, Original angle: {}",
 					rmsd, rise, Math.toDegrees(angle));
 
@@ -127,8 +124,7 @@ public class HelixSolver {
 				continue;
 			}
 			permutations.add(permutation);
-			logger.debug("Permutation: " + permutation);
-			
+            LOGGER.debug("Permutation: " + permutation);
 
 			// keep track of which subunits are permuted
 			Set<Integer> permSet = new HashSet<Integer>();
@@ -149,13 +145,13 @@ public class HelixSolver {
 
 			// a helix a repeat unit cannot map onto itself
 			if (!valid) {
-				logger.debug("Invalid mapping");
+				LOGGER.debug("Invalid mapping");
 				continue;
 			}
 
 			// all subunits must be involved in a permutation
 			if (permSet.size() != subunits.getSubunitCount()) {
-				logger.debug("Not all subunits involved in permutation");
+				LOGGER.debug("Not all subunits involved in permutation");
 				continue;
 			}
 
@@ -190,8 +186,8 @@ public class HelixSolver {
 				rise = getRise(transformation, repeatUnitCenters.get(pair[0]),
 						repeatUnitCenters.get(pair[1]));
 				angle = getAngle(transformation);
-
-				logger.debug("Subunit rmsd: {}, Subunit rise: {}, Subunit angle: {}", subunitRmsd, rise, Math.toDegrees(angle));
+                
+				LOGGER.debug("Subunit rmsd: {}, Subunit rise: {}, Subunit angle: {}", subunitRmsd, rise, Math.toDegrees(angle));
 
 				if (subunitRmsd > parameters.getRmsdThreshold()) {
 					continue;
@@ -238,11 +234,11 @@ public class HelixSolver {
 			rise = getRise(transformation, repeatUnitCenters.get(pair[0]),
 					repeatUnitCenters.get(pair[1]));
 			angle = getAngle(transformation);
-
-			logger.debug("Trace rmsd: " + traceRmsd);
-			logger.debug("Trace rise: " + rise);
-			logger.debug("Trace angle: " + Math.toDegrees(angle));
-			logger.debug("Permutation: " + permutation);
+            
+			LOGGER.debug("Trace rmsd: " + traceRmsd);
+            LOGGER.debug("Trace rise: " + rise);
+            LOGGER.debug("Trace angle: " + Math.toDegrees(angle));
+            LOGGER.debug("Permutation: " + permutation);
 
 			if (traceRmsd > parameters.getRmsdThreshold()) {
 				continue;
@@ -281,7 +277,7 @@ public class HelixSolver {
 			helix.setFold(fold);
 			helix.setContacts(contacts);
 			helix.setRepeatUnits(unit.getRepeatUnitIndices());
-			logger.debug("Layerlines: " + helix.getLayerLines());
+			LOGGER.debug("Layerlines: " + helix.getLayerLines());
 			
 			for (List<Integer> line : helix.getLayerLines()) {
 				maxLayerLineLength = Math.max(maxLayerLineLength, line.size());
@@ -329,7 +325,7 @@ public class HelixSolver {
 				}
 			}
 		}
-		System.out.println("SelfLimiting helix: " + overlap1 + ", " + overlap2);
+		LOGGER.info("SelfLimiting helix: " + overlap1 + ", " + overlap2);
 	}
 
 	private boolean preCheck() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/geometry/SuperPositionQCP.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/geometry/SuperPositionQCP.java
@@ -21,6 +21,9 @@
 
 package org.biojava.nbio.structure.symmetry.geometry;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.vecmath.Matrix3d;
 import javax.vecmath.Matrix4d;
 import javax.vecmath.Point3d;
@@ -32,6 +35,8 @@ import javax.vecmath.Vector3d;
  * @author Peter
  */
 public final class SuperPositionQCP {
+	private static final Logger LOGGER = LoggerFactory.getLogger(SuperPositionQCP.class);
+
 	double evecprec = 1d-6;
 	double evalprec = 1d-11;
 
@@ -290,7 +295,7 @@ public final class SuperPositionQCP {
 
 
 		if (i == 50)
-			System.err.println("More than %d iterations needed!" + i);
+			LOGGER.warn("More than %d iterations needed!" + i);
 
 		/* the fabs() is to guard against extremely small, but *negative* numbers due to floating point error */
 		rmsd = Math.sqrt(Math.abs(2.0 * (e0 - mxEigenV)/len));
@@ -378,7 +383,7 @@ public final class SuperPositionQCP {
 		q3 /= normq;
 		q4 /= normq;
 
-		System.out.println("q: " + q1 + " " + q2 + " " + q3 + " " + q4);
+		LOGGER.info("q: " + q1 + " " + q2 + " " + q3 + " " + q4);
 
 		double a2 = q1 * q1;
 		double x2 = q2 * q2;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/SequenceFunctionRefiner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/SequenceFunctionRefiner.java
@@ -35,6 +35,8 @@ import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.multiple.MultipleAlignment;
 import org.biojava.nbio.structure.align.util.AlignmentTools;
 import org.biojava.nbio.structure.symmetry.utils.SymmetryTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Creates a refined alignment with the CE-Symm alternative self-alignment.
@@ -47,6 +49,8 @@ import org.biojava.nbio.structure.symmetry.utils.SymmetryTools;
  *
  */
 public class SequenceFunctionRefiner implements SymmetryRefiner {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(SequenceFunctionRefiner.class);
 
 	@Override
 	public MultipleAlignment refine(AFPChain selfAlignment, Atom[] atoms,
@@ -182,11 +186,11 @@ public class SequenceFunctionRefiner implements SymmetryRefiner {
 
 			Map<Integer, Double> virginScores = initializeScores(alignment, null, k);
 			if (scores.size() != virginScores.size()) {
-				System.out.println("Size missmatch");
+				LOGGER.info("Size missmatch");
 			} else {
 				for (Integer key : scores.keySet()) {
 					if (!virginScores.containsKey(key) || !scores.get(key).equals(virginScores.get(key))) {
-						System.out.format("Mismatch %d -> %f/%f%n", key, scores.get(key), virginScores.get(key));
+						LOGGER.info(String.format("Mismatch %d -> %f/%f%n", key, scores.get(key), virginScores.get(key)));
 					}
 				}
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/BlastClustReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/BlastClustReader.java
@@ -20,6 +20,9 @@
  */
 package org.biojava.nbio.structure.symmetry.utils;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +33,8 @@ import java.util.*;
 
 
 public class BlastClustReader implements Serializable {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(BlastClustReader.class);
 
 	private static final long serialVersionUID = 1L;
 
@@ -138,7 +143,7 @@ public class BlastClustReader implements Serializable {
 		}
 
 		if (!seqIdentities.contains(sequenceIdentity)) {
-			System.err.println("Error: representative chains are not available for %sequence identity: "
+			LOGGER.error("Error: representative chains are not available for %sequence identity: "
 					+ sequenceIdentity);
 			return;
 		}

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxHelper.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxHelper.java
@@ -22,6 +22,8 @@ package org.biojava.nbio.survival.cox;
 
 
 import org.biojava.nbio.survival.data.WorkSheet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 
@@ -33,6 +35,8 @@ import java.util.ArrayList;
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class CoxHelper {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoxHelper.class);
 
 	/**
 	 *
@@ -162,8 +166,7 @@ public class CoxHelper {
 
 			  //  ci.dump();
 
-				System.out.println(ci);
-				System.out.println();
+				LOGGER.info(ci.toString());
 
 				CoxCC.process(ci);
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxInfo.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxInfo.java
@@ -23,6 +23,8 @@ package org.biojava.nbio.survival.cox;
 import org.biojava.nbio.survival.cox.stats.ChiSq;
 import org.biojava.nbio.survival.kaplanmeier.figure.ExpressionFigure;
 import org.biojava.nbio.survival.kaplanmeier.figure.KaplanMeierFigure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -36,6 +38,7 @@ import java.util.LinkedHashMap;
  */
 public class CoxInfo {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoxInfo.class);
 	private WaldTestInfo waldTestInfo = null;
 	String message = "";
 	Integer maxIterations = null;
@@ -357,60 +360,60 @@ public class CoxInfo {
 		//       Collections.sort(orderedSurvivalInfoList,sicSort);
 
 
-		System.out.println();
-		System.out.println("$coef");
+		LOGGER.info("\n");
+		LOGGER.info("$coef");
 		for (CoxCoefficient coe : coefficientsList.values()) {
-			System.out.print(coe.getCoeff() + " ");
+			LOGGER.info(coe.getCoeff() + " ");
 		}
-		System.out.println();
-		System.out.println("$means");
+		LOGGER.info("\n");
+		LOGGER.info("$means");
 
 		for (CoxCoefficient coe : coefficientsList.values()) {
-			System.out.print(coe.getMean() + " ");
+			LOGGER.info(coe.getMean() + " ");
 		}
-		System.out.println();
-		System.out.println("$u");
+		LOGGER.info("\n");
+		LOGGER.info("$u");
 
 		for (double d : u) {
-			System.out.print(d + " ");
+			LOGGER.info(d + " ");
 		}
 
-		System.out.println();
-		System.out.println("$imat");
+		LOGGER.info("\n");
+		LOGGER.info("$imat");
 		for (int i = 0; i < imat.length; i++) {
 			for (int j = 0; j < imat[0].length; j++) {
-				System.out.print(imat[i][j] + " ");
+				LOGGER.info(imat[i][j] + " ");
 			}
-			System.out.println();
+			LOGGER.info("\n");
 		}
 
 		if (this.naive_imat != null) {
-			System.out.println("$naive_imat");
+			LOGGER.info("$naive_imat");
 			for (int i = 0; i < naive_imat.length; i++) {
 				for (int j = 0; j < naive_imat[0].length; j++) {
-					System.out.print(naive_imat[i][j] + " ");
+					LOGGER.info(naive_imat[i][j] + " ");
 				}
-				System.out.println();
+				LOGGER.info("\n");
 			}
 		}
 
-		System.out.println();
-		System.out.println("$loglik");
+		LOGGER.info("\n");
+		LOGGER.info("$loglik");
 
-		System.out.println(loglikInit + " " + loglikFinal);
+		LOGGER.info(loglikInit + " " + loglikFinal);
 
-		System.out.println();
-		System.out.println("$sctest");
+		LOGGER.info("\n");
+		LOGGER.info("$sctest");
 
-		System.out.println(this.scoreLogrankTest);
+		LOGGER.info(String.valueOf(this.scoreLogrankTest));
 
-		System.out.println("$iter");
-		System.out.println(this.iterations);
+		LOGGER.info("$iter");
+		LOGGER.info(String.valueOf(this.iterations));
 
-		System.out.println("$flag");
-		System.out.println(flag);
+		LOGGER.info("$flag");
+		LOGGER.info(String.valueOf(flag));
 
-		System.out.println();
+		LOGGER.info("\n");
 //        if (false) {
 //            System.out.println("ID      LP       Score      Residuals");
 //            for (SurvivalInfo si : orderedSurvivalInfoList) {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxR.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxR.java
@@ -24,6 +24,8 @@ import org.biojava.nbio.survival.cox.matrix.Matrix;
 import org.biojava.nbio.survival.cox.stats.ChiSq;
 import org.biojava.nbio.survival.cox.stats.Cholesky2;
 import org.biojava.nbio.survival.data.WorkSheet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -109,6 +111,8 @@ import java.util.Collections;
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class CoxR {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoxR.class);
 
 	/**
 	 *
@@ -986,7 +990,7 @@ public class CoxR {
 				//       variables.add("TREAT:AGE");
 			  //  ArrayList<Integer> cluster = new ArrayList<Integer>();
 				CoxInfo ci = cox.process(variables, survivalInfoList, false, true,false, false);
-				System.out.println(ci);
+				LOGGER.info(ci.toString());
 			} catch (Exception e) {
 				e.printStackTrace();
 			}

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvivalInfoHelper.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvivalInfoHelper.java
@@ -20,6 +20,9 @@
  */
 package org.biojava.nbio.survival.cox;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,7 +33,7 @@ import java.util.LinkedHashMap;
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class SurvivalInfoHelper {
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(SurvivalInfoHelper.class);
 	/**
 	 * For each analysis this allows outputing of the data used in the calculations to a printstream/file. This then
 	 * allows the file to be loaded into R and calculations can be verified.
@@ -199,7 +202,7 @@ public class SurvivalInfoHelper {
 			}
 		}
 		Collections.sort(validLabels);
-		System.out.println("Valid Lables:" + validLabels);
+		LOGGER.info("Valid Lables:" + validLabels);
 		for (SurvivalInfo si : survivalInfoList) {
 			Double value = si.getContinuousVariable(variable);
 			if (value == null) {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/matrix/StdArrayIO.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/matrix/StdArrayIO.java
@@ -91,7 +91,7 @@ public class StdArrayIO {
 		LOGGER.info(String.valueOf(N));
 		for (int i = 0; i < N; i++) {
 		 //   System.out.printf("%9.5f ", a[i]);
-			System.out.print(a[i] + " ");
+			LOGGER.info(a[i] + " ");
 		}
 		LOGGER.info("\n");
 	}
@@ -110,7 +110,7 @@ public class StdArrayIO {
 		for (int i = 0; i < M; i++) {
 			for (int j = 0; j < N; j++) {
 	//            System.out.printf("%9.5f ", a[i][j]);
-				System.out.print(a[i][j] + " ");
+				LOGGER.info(a[i][j] + " ");
 			}
 			LOGGER.info("\n");
 		}
@@ -127,7 +127,7 @@ public class StdArrayIO {
 		int N = a.length;
 		LOGGER.info(String.valueOf(N));
 		for (int i = 0; i < N; i++) {
-			System.out.printf("%9d ", a[i]);
+			LOGGER.info("%9d ", a[i]);
 		}
 		LOGGER.info("\n");
 	}
@@ -162,8 +162,8 @@ public class StdArrayIO {
 		int N = a.length;
 		LOGGER.info(String.valueOf(N));
 		for (int i = 0; i < N; i++) {
-			if (a[i]) System.out.print("1 ");
-			else      System.out.print("0 ");
+			if (a[i]) LOGGER.info("1 ");
+			else      LOGGER.info("0 ");
 		}
 		LOGGER.info("\n");
 	}

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/matrix/StdArrayIO.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/matrix/StdArrayIO.java
@@ -65,6 +65,9 @@ package org.biojava.nbio.survival.cox.matrix;
  *************************************************************************/
 
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  *  <i>Standard array IO</i>. This class provides methods for reading
  *  in 1D and 2D arrays from standard input and printing out to
@@ -77,7 +80,7 @@ package org.biojava.nbio.survival.cox.matrix;
  */
 public class StdArrayIO {
 
-
+	private static final Logger LOGGER = LoggerFactory.getLogger(StdArrayIO.class);
 
 	/**
 	 * Print an array of doubles to standard output.
@@ -85,12 +88,12 @@ public class StdArrayIO {
 	 */
 	public static void print(double[] a) {
 		int N = a.length;
-		System.out.println(N);
+		LOGGER.info(String.valueOf(N));
 		for (int i = 0; i < N; i++) {
 		 //   System.out.printf("%9.5f ", a[i]);
 			System.out.print(a[i] + " ");
 		}
-		System.out.println();
+		LOGGER.info("\n");
 	}
 
 
@@ -103,13 +106,13 @@ public class StdArrayIO {
 	public static void print(double[][] a) {
 		int M = a.length;
 		int N = a[0].length;
-		System.out.println(M + "x" + N);
+		LOGGER.info(M + "x" + N);
 		for (int i = 0; i < M; i++) {
 			for (int j = 0; j < N; j++) {
 	//            System.out.printf("%9.5f ", a[i][j]);
 				System.out.print(a[i][j] + " ");
 			}
-			System.out.println();
+			LOGGER.info("\n");
 		}
 	}
 
@@ -122,11 +125,11 @@ public class StdArrayIO {
 	 */
 	public static void print(int[] a) {
 		int N = a.length;
-		System.out.println(N);
+		LOGGER.info(String.valueOf(N));
 		for (int i = 0; i < N; i++) {
 			System.out.printf("%9d ", a[i]);
 		}
-		System.out.println();
+		LOGGER.info("\n");
 	}
 
 
@@ -139,12 +142,12 @@ public class StdArrayIO {
 	public static void print(int[][] a) {
 		int M = a.length;
 		int N = a[0].length;
-		System.out.println(M + " " + N);
+		LOGGER.info(M + " " + N);
 		for (int i = 0; i < M; i++) {
 			for (int j = 0; j < N; j++) {
-				System.out.printf("%9d ", a[i][j]);
+				LOGGER.info(String.format("%9d ", a[i][j]));
 			}
-			System.out.println();
+			LOGGER.info("\n");
 		}
 	}
 
@@ -157,12 +160,12 @@ public class StdArrayIO {
 	 */
 	public static void print(boolean[] a) {
 		int N = a.length;
-		System.out.println(N);
+		LOGGER.info(String.valueOf(N));
 		for (int i = 0; i < N; i++) {
 			if (a[i]) System.out.print("1 ");
 			else      System.out.print("0 ");
 		}
-		System.out.println();
+		LOGGER.info("\n");
 	}
 
 
@@ -174,13 +177,13 @@ public class StdArrayIO {
 	public static void print(boolean[][] a) {
 		int M = a.length;
 		int N = a[0].length;
-		System.out.println(M + " " + N);
+		LOGGER.info(M + " " + N);
 		for (int i = 0; i < M; i++) {
 			for (int j = 0; j < N; j++) {
-				if (a[i][j]) System.out.print("1 ");
-				else         System.out.print("0 ");
+				if (a[i][j]) LOGGER.info("1 ");
+				else         LOGGER.info("0 ");
 			}
-			System.out.println();
+			LOGGER.info("\n");
 		}
 	}
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/data/WorkSheet.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/data/WorkSheet.java
@@ -20,6 +20,9 @@
  */
 package org.biojava.nbio.survival.data;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.*;
 import java.util.*;
 
@@ -30,6 +33,8 @@ import java.util.*;
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class WorkSheet {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(WorkSheet.class);
 
 	private LinkedHashMap<String, HeaderInfo> columnLookup = new LinkedHashMap<String, HeaderInfo>();
 	private LinkedHashMap<String, HeaderInfo> rowLookup = new LinkedHashMap<String, HeaderInfo>();
@@ -102,7 +107,7 @@ public class WorkSheet {
 				data[row][col] = new CompactCharSequence(value);
 				values[row][col] = null;
 			}
-			System.out.println("Row " + row + " " + Runtime.getRuntime().totalMemory());
+			LOGGER.info("Row " + row + " " + Runtime.getRuntime().totalMemory());
 
 		}
 		values = null;

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/hmmer/RemoteHmmerScan.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/hmmer/RemoteHmmerScan.java
@@ -23,6 +23,8 @@ package org.biojava.nbio.ws.hmmer;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 import org.biojava.nbio.core.sequence.ProteinSequence;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -37,6 +39,8 @@ import java.util.TreeSet;
  * @since 3.0.3
  */
 public class RemoteHmmerScan implements HmmerScan {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(RemoteHmmerScan.class);
 
 	public static String HMMER_SERVICE = "http://www.ebi.ac.uk/Tools/hmmer/search/hmmscan";
 
@@ -104,8 +108,8 @@ public class RemoteHmmerScan implements HmmerScan {
 
 		int responseCode = connection.getResponseCode();
 		if ( responseCode == 500){
-			System.err.println("something went wrong!" + serviceLocation);
-			System.err.println(connection.getResponseMessage());
+			LOGGER.error("something went wrong!" + serviceLocation);
+			LOGGER.error(connection.getResponseMessage());
 		}
 
 		HttpURLConnection connection2 = (HttpURLConnection) respUrl.openConnection();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S106 - Standard outputs should not be used directly to log anything

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S106

Please let me know if you have any questions.

M-Ezzat