### PR TITLE
squid:S2131 - Primitives should not be boxed just for String conversion

### DIFF
--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptideProperties.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptideProperties.java
@@ -460,7 +460,7 @@ public class PeptideProperties {
 	 * @return the composition of specified amino acid in the sequence
 	 */
 	public static final double getEnrichment(String sequence, char aminoAcidCode){
-		return getEnrichment(sequence, aminoAcidCode + "");
+		return getEnrichment(sequence, aminoAcidCode);
 	}
 
 	/**

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptidePropertiesImpl.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptidePropertiesImpl.java
@@ -75,7 +75,7 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 		AminoAcidCompoundSet aaSet = new AminoAcidCompoundSet();
 		char[] seq = getSequence(sequence.toString(), true);//ignore case
 		for(char aa:seq){
-			AminoAcidCompound c = aaSet.getCompoundForString(aa + "");
+			AminoAcidCompound c = aaSet.getCompoundForString(String.valueOf(aa));
 			if(Constraints.aa2MolecularWeight.containsKey(c)){
 				value += Constraints.aa2MolecularWeight.get(c);
 			}
@@ -263,7 +263,7 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 		AminoAcidCompoundSet aaSet = new AminoAcidCompoundSet();
 		char[] seq = this.getSequence(sequence.toString(), true);
 		for(char aa:seq){
-			AminoAcidCompound c = aaSet.getCompoundForString(aa + "");
+			AminoAcidCompound c = aaSet.getCompoundForString(String.valueOf(aa));
 			if(Constraints.aa2Hydrophathicity.containsKey(c)){
 				total += Constraints.aa2Hydrophathicity.get(c);
 				validLength++;
@@ -477,13 +477,13 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 		AminoAcidCompoundSet aaSet = new AminoAcidCompoundSet();
 
 		double nTerminalCharge = 0.0;
-		AminoAcidCompound nTermCompound = aaSet.getCompoundForString(nTerminalChar + "");
+		AminoAcidCompound nTermCompound = aaSet.getCompoundForString(String.valueOf(nTerminalChar));
 		if(Constraints.aa2NTerminalPka.containsKey(nTermCompound)){
 			nTerminalCharge = this.getPosCharge(Constraints.aa2NTerminalPka.get(nTermCompound), ph);
 		}
 
 		double cTerminalCharge = 0.0;
-		AminoAcidCompound cTermCompound = aaSet.getCompoundForString(cTerminalChar + "");
+		AminoAcidCompound cTermCompound = aaSet.getCompoundForString(String.valueOf(cTerminalChar));
 		if(Constraints.aa2CTerminalPka.containsKey(cTermCompound)){
 			cTerminalCharge = this.getNegCharge(Constraints.aa2CTerminalPka.get(cTermCompound), ph);
 		}
@@ -548,7 +548,7 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 		double counter = 0.0;
 		char[] seq = this.getSequence(sequence.getSequenceAsString(), true);
 		for(char aa:seq){
-			if(aminoAcidCode.getShortName().equals(aa + "")){
+			if(aminoAcidCode.getShortName().equals(String.valueOf(aa))){
 				counter++;
 			}
 		}
@@ -566,7 +566,7 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 		char[] seq = this.getSequence(sequence.toString(), true);
 		for(char aa:seq){
 			if(PeptideProperties.standardAASet.contains(aa)){
-				AminoAcidCompound compound = aaSet.getCompoundForString(aa + "");
+				AminoAcidCompound compound = aaSet.getCompoundForString(String.valueOf(aa));
 				aa2Composition.put(compound, aa2Composition.get(compound) + 1.0);
 				validLength++;
 			}

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/profeat/convertor/Convertor.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/profeat/convertor/Convertor.java
@@ -81,7 +81,7 @@ public abstract class Convertor {
 		String convertedSequence = "";
 		String uppercaseSequence = sequence.getSequenceAsString().toUpperCase();
 		for(int x = 0; x < uppercaseSequence.length(); x++){
-			convertedSequence += convert(uppercaseSequence.charAt(x));
+			convertedSequence += String.valueOf(convert(uppercaseSequence.charAt(x)));
 		}
 		return convertedSequence;
 	}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/alignment/SimpleProfile.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/alignment/SimpleProfile.java
@@ -567,8 +567,8 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 	private boolean isSimilar(char c1, char c2) {
 		AminoAcidCompoundSet set = AminoAcidCompoundSet.getAminoAcidCompoundSet();
 
-		AminoAcidCompound aa1 = set.getCompoundForString(""+c1);
-		AminoAcidCompound aa2 = set.getCompoundForString(""+c2);
+		AminoAcidCompound aa1 = set.getCompoundForString(String.valueOf(c1));
+		AminoAcidCompound aa2 = set.getCompoundForString(String.valueOf(c2));
 
 		short val = matrix.getValue(aa1,aa2);
 		return val > 0;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/AAIndexFileParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/AAIndexFileParser.java
@@ -185,14 +185,14 @@ public class AAIndexFileParser {
 		AminoAcidCompoundSet compoundSet = AminoAcidCompoundSet.getAminoAcidCompoundSet();
 		for ( int i = 0 ; i < currentRows.length() ; i ++){
 			char c = currentRows.charAt(i);
-			AminoAcidCompound aa = compoundSet.getCompoundForString(c+"");
+			AminoAcidCompound aa = compoundSet.getCompoundForString(String.valueOf(c));
 
 			rows.add(aa);
 		}
 
 		for ( int i = 0 ; i < currentCols.length() ; i ++){
 			char c = currentRows.charAt(i);
-			AminoAcidCompound aa = compoundSet.getCompoundForString(c+"");
+			AminoAcidCompound aa = compoundSet.getCompoundForString(String.valueOf(c));
 
 			cols.add(aa);
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/CDSSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/CDSSequence.java
@@ -94,7 +94,7 @@ public class CDSSequence extends DNASequence {
 			StringBuilder b = new StringBuilder(getLength());
 			CompoundSet<NucleotideCompound> compoundSet = this.getCompoundSet();
 			for (int i = 0; i < sequence.length(); i++) {
-				String nucleotide = sequence.charAt(i) + "";
+				String nucleotide = String.valueOf(sequence.charAt(i));
 				NucleotideCompound nucleotideCompound = compoundSet.getCompoundForString(nucleotide);
 				b.append(nucleotideCompound.getComplement().getShortName());
 			}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/GeneSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/GeneSequence.java
@@ -298,7 +298,7 @@ public class GeneSequence extends DNASequence {
 			StringBuilder b = new StringBuilder(getLength());
 			CompoundSet<NucleotideCompound> compoundSet = this.getCompoundSet();
 			for (int i = 0; i < sequence.length(); i++) {
-				String nucleotide = sequence.charAt(i) + "";
+				String nucleotide = String.valueOf(sequence.charAt(i));
 				NucleotideCompound nucleotideCompound = compoundSet.getCompoundForString(nucleotide);
 				b.append(nucleotideCompound.getComplement().getShortName());
 			}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaGeneWriter.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaGeneWriter.java
@@ -110,7 +110,7 @@ public class FastaGeneWriter {
 						for (int i = featureBioBegin; i <= featureBioEnd; i++) {
 							char ch = sb.charAt(i);
 							//probably not the fastest but the safest way if language is not standard ASCII
-							String temp = ch + "";
+							String temp = String.valueOf(ch);
 							ch = temp.toUpperCase().charAt(0);
 							sb.setCharAt(i, ch);
 						}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/util/IOUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/util/IOUtils.java
@@ -276,7 +276,7 @@ public class IOUtils {
 	 * @return formatted String
 	 */
 	public static String getPDBCharacter(boolean web, char c1, char c2, boolean similar, char c) {
-		String s = c + "";
+		String s = String.valueOf(c);
 		return getPDBString(web, c1, c2, similar, s, s, s, s);
 	}
 

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/Feature.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/Feature.java
@@ -212,7 +212,7 @@ public class Feature implements FeatureI {
 		   String[] data = attribute.split(splitData);
 		   String value = "";
 		   if(data.length >= 2 && data[1].indexOf('"') != -1){ // an attibute field could be empty
-			   value = data[1].replaceAll('"' + "","").trim();
+			   value = data[1].replaceAll("\"","").trim();
 		   }else if(data.length >= 2){
 			   value = data[1].trim();
 		   }

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/io/ModifiedCompoundXMLConverter.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/io/ModifiedCompoundXMLConverter.java
@@ -74,13 +74,13 @@ public class ModifiedCompoundXMLConverter {
 			for ( StructureAtomLinkage link: linkages){
 				pos ++;
 				xml.openTag("linkage");
-				xml.attribute("pos", pos+"");
-				xml.attribute("total", linkages.size()+"");
+				xml.attribute("pos", String.valueOf(pos));
+				xml.attribute("total", String.valueOf(linkages.size()));
 				StructureAtom atom1 = link.getAtom1();
 				StructureAtom atom2 = link.getAtom2();
 				double distance = link.getDistance();
 
-				xml.attribute("distance", distance+"");
+				xml.attribute("distance", String.valueOf(distance));
 				xml.openTag("atom1");
 				StructureAtomXMLConverter.toXML(atom1,xml);
 				xml.closeTag("atom1");

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/GUIAlignmentProgressListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/GUIAlignmentProgressListener.java
@@ -122,7 +122,7 @@ public class GUIAlignmentProgressListener extends JPanel implements AlignmentPro
 		int v = progressBar.getValue();
 
 		progressBar.setValue(v+1);
-		progressBar.setString(v+"");
+		progressBar.setString(String.valueOf(v));
 		synchronized(this){notifyAll();}
 
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/AligPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/AligPanel.java
@@ -282,7 +282,7 @@ public void paintComponent(Graphics g){
 							int block = 0;
 							char s = symb[i];
 							try {
-								block = Integer.parseInt(s+"") - 1;
+								block = Integer.parseInt(String.valueOf(s)) - 1;
 								bg  = ColorUtils.getIntermediate(ColorUtils.orange, end1, blockNum, block);
 								bg2   = ColorUtils.getIntermediate(ColorUtils.cyan, end2, blockNum, block);
 								//bg = ColorUtils.rotateHue(ColorUtils.orange,  (1.0f  / 24.0f) * block  );
@@ -347,8 +347,8 @@ public void paintComponent(Graphics g){
 
 			// draw the AA sequence
 			g2D.setColor(Color.black);
-			g2D.drawString(c1+"",xpos1,ypos1);
-			g2D.drawString(c2+"" ,xpos2,ypos2);
+			g2D.drawString(String.valueOf(c1), xpos1, ypos1);
+			g2D.drawString(String.valueOf(c2), xpos2, ypos2);
 
 
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/MultipleAligPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/MultipleAligPanel.java
@@ -286,7 +286,7 @@ implements AlignmentPositionListener, WindowListener {
 
 				// draw the AA sequence
 				g2D.setColor(Color.black);
-				g2D.drawString(c+"",points.get(str).x,points.get(str).y);
+				g2D.drawString(String.valueOf(c), points.get(str).x, points.get(str).y);
 			}
 		}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/SequenceScalePanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/SequenceScalePanel.java
@@ -317,7 +317,7 @@ extends JPanel{
 					g2D.fillRect(xpos, y+2, aminosize, y+lineH);
 					g2D.setColor(SCALE_COLOR);
 					if ( scale < SEQUENCE_SHOW)
-						g2D.drawString(""+(i+1),xpos,y+DEFAULT_Y_STEP);
+						g2D.drawString(String.valueOf(i+1), xpos, y+DEFAULT_Y_STEP);
 				}
 
 			}else if  ( ((i+1)%50) == 0 ) {
@@ -326,7 +326,7 @@ extends JPanel{
 					g2D.fillRect(xpos,y+2, aminosize, y+lineH);
 					g2D.setColor(SCALE_COLOR);
 					if ( scale < SEQUENCE_SHOW)
-						g2D.drawString(""+(i+1),xpos,y+DEFAULT_Y_STEP);
+						g2D.drawString(String.valueOf(i+1), xpos, y+DEFAULT_Y_STEP);
 
 				}
 
@@ -336,7 +336,7 @@ extends JPanel{
 					g2D.fillRect(xpos, y+2, aminosize, y+lineH);
 					g2D.setColor(SCALE_COLOR);
 					if ( scale < SEQUENCE_SHOW)
-						g2D.drawString(""+(i+1),xpos,y+DEFAULT_Y_STEP);
+						g2D.drawString(String.valueOf(i+1), xpos, y+DEFAULT_Y_STEP);
 
 				}
 			}
@@ -347,7 +347,7 @@ extends JPanel{
 		if ( endpos >= length-1) {
 
 			int endPanel = coordManager.getPanelPos(endpos);
-			g2D.drawString(""+length,endPanel+10,y+DEFAULT_Y_STEP);
+			g2D.drawString(String.valueOf(length), endPanel+10,y+DEFAULT_Y_STEP);
 		}
 
 		return y ;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1928,7 +1928,7 @@ public class StructureTools {
 
 	private static String replaceFirstChar(String name, char c, char d) {
 		if(name.charAt(0)==c){
-			return name.replaceFirst(""+c, ""+d);
+			return name.replaceFirst(String.valueOf(c), String.valueOf(d));
 		}
 		return name;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/BioJavaStructureAlignment.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/BioJavaStructureAlignment.java
@@ -74,7 +74,7 @@ implements StructureAlignment  {
 
 	@Override
 	public String getVersion() {
-		return versionNr+"";
+		return String.valueOf(versionNr);
 	}
 
 	public String printHelp() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AfpChainWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AfpChainWriter.java
@@ -285,7 +285,7 @@ public class AfpChainWriter
 					int block = -1 ;
 					if ( cl != ' ') {
 						try {
-							block = Integer.parseInt(cl+"");
+							block = Integer.parseInt(String.valueOf(cl));
 						} catch (Exception e){
 							//
 						}
@@ -1117,7 +1117,7 @@ public class AfpChainWriter
 
 			String origString = "orig";
 			if ( blockNr > 0)
-				origString = (blockNr)+"";
+				origString = String.valueOf(blockNr);
 
 
 			txt.append(String.format("     X"+(blockNr+1)+" = (%9.6f)*X"+ origString +" + (%9.6f)*Y"+ origString +" + (%9.6f)*Z"+ origString +" + (%12.6f)",m.get(0,0),m.get(1,0), m.get(2,0), shift.getX()));

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/mc/MultipleMcOptimizer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/mc/MultipleMcOptimizer.java
@@ -843,7 +843,7 @@ public class MultipleMcOptimizer implements Callable<MultipleAlignment> {
 		writer.append("Step,Length,RMSD,Score\n");
 
 		for (int i = 0; i < lengthHistory.size(); i++) {
-			writer.append("" + (i * 100));
+			writer.append(String.valueOf(i * 100));
 			writer.append("," + lengthHistory.get(i));
 			writer.append("," + rmsdHistory.get(i));
 			writer.append("," + scoreHistory.get(i) + "\n");

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentTools.java
@@ -212,9 +212,8 @@ public class MultipleAlignmentTools {
 										.set(str,
 												alnSequences
 														.get(str)
-														.concat(""
-																+ Character
-																		.toLowerCase(aa)));
+														.concat(String.valueOf(Character
+																		.toLowerCase(aa))) );
 								previousPos[str]++;
 							} else {
 								// Insert a gap otherwise
@@ -229,7 +228,7 @@ public class MultipleAlignmentTools {
 							alnSequences.set(
 									str,
 									alnSequences.get(str).concat(
-											"" + provisionalChar[str]));
+											String.valueOf(provisionalChar[str])));
 
 							if (provisionalChar[str] != '-') {
 								if (alignment.getBlocks().get(b).getAlignRes()
@@ -281,7 +280,7 @@ public class MultipleAlignmentTools {
 						alnSequences.set(
 								str,
 								alnSequences.get(str).concat(
-										"" + provisionalChar[str]));
+										String.valueOf(provisionalChar[str])) );
 					}
 					mapSeqToStruct.add(-1); // unaligned position
 				}
@@ -413,7 +412,7 @@ public class MultipleAlignmentTools {
 										alnSequences.set(
 												s2,
 												alnSequences.get(s2).concat(
-														"" + aa));
+														String.valueOf(aa)) );
 									} else {
 										alnSequences.set(s2,
 												alnSequences.get(s2)
@@ -429,7 +428,7 @@ public class MultipleAlignmentTools {
 							alnSequences.set(
 									str,
 									alnSequences.get(str).concat(
-											"" + provisionalChar[str]));
+											String.valueOf(provisionalChar[str])) );
 							if (provisionalChar[str] != '-') {
 								previousPos[str] = alignment.getBlocks().get(b)
 										.getAlignRes().get(str).get(pos);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentWriter.java
@@ -103,7 +103,7 @@ public class MultipleAlignmentWriter {
 			int blockNr = MultipleAlignmentTools.getBlockForSequencePosition(
 					alignment, mapSeqToStruct, pos);
 			if (blockNr != -1) {
-				blockNumbers = blockNumbers.concat("" + (blockNr + 1));
+				blockNumbers = blockNumbers.concat(String.valueOf(blockNr + 1));
 			} else
 				blockNumbers = blockNumbers.concat(" ");
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLConverter.java
@@ -130,7 +130,7 @@ public class AFPChainXMLConverter {
 			String pdbres2 = spl2[1];
 
 			xml.openTag("eqr");
-			xml.attribute("eqrNr",eqrNr+"");
+			xml.attribute("eqrNr", String.valueOf(eqrNr));
 			xml.attribute("pdbres1",pdbres1);
 			xml.attribute("chain1", chain1);
 			xml.attribute("pdbres2",pdbres2);
@@ -155,7 +155,7 @@ public class AFPChainXMLConverter {
 			int pos1 = optAln[bk][0][pos];
 			int pos2 = optAln[bk][1][pos];
 			xml.openTag("eqr");
-			xml.attribute("eqrNr",pos+"");
+			xml.attribute("eqrNr", String.valueOf(pos));
 			xml.attribute("pdbres1",ca1[pos1].getGroup().getResidueNumber().toString());
 			xml.attribute("chain1", ca1[pos1].getGroup().getChain().getName());
 			xml.attribute("pdbres2",ca2[pos2].getGroup().getResidueNumber().toString());
@@ -185,11 +185,11 @@ public class AFPChainXMLConverter {
 		double[]blockScore = afpChain.getBlockScore();
 		double[] blockRmsd = afpChain.getBlockRmsd();
 
-		xml.attribute("blockNr",bk+"");
-		xml.attribute("blockSize", blockSize[bk]+"");
+		xml.attribute("blockNr", String.valueOf(bk));
+		xml.attribute("blockSize", String.valueOf(blockSize[bk]));
 		xml.attribute("blockScore", String.format("%5.2f",blockScore[bk]).trim());
 		xml.attribute("blockRmsd", String.format("%5.2f",blockRmsd[bk]).trim());
-		xml.attribute("blockGap", blockGap[bk]+"");
+		xml.attribute("blockGap", String.valueOf(blockGap[bk]));
 
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/HasResultXMLConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/HasResultXMLConverter.java
@@ -58,7 +58,7 @@ public class HasResultXMLConverter
 		PrettyXMLWriter xml = new PrettyXMLWriter(writer);
 
 		xml.openTag("alignment");
-		xml.attribute("hasResult", hasResult+"");
+		xml.attribute("hasResult", String.valueOf(hasResult));
 		xml.closeTag("alignment");
 		xml.close();
 		return swriter.toString();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/PositionInQueueXMLConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/PositionInQueueXMLConverter.java
@@ -50,7 +50,7 @@ public class PositionInQueueXMLConverter
 		PrettyXMLWriter xml = new PrettyXMLWriter(writer);
 
 		xml.openTag("queue");
-		xml.attribute("position", position+"");
+		xml.attribute("position", String.valueOf(position));
 		xml.closeTag("queue");
 		xml.close();
 		return swriter.toString();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/ResidueIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/ResidueIdentifier.java
@@ -91,7 +91,7 @@ class ResidueIdentifier implements Serializable {
 
 	@Override
 	public String toString() {
-		return ""+ seqResIndex;
+		return String.valueOf(seqResIndex);
 	}
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -203,7 +203,7 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 		atomsInGroup = new ArrayList<Atom>();
 		// Set the CC -> empty but not null
 		ChemComp chemComp = new ChemComp();
-		chemComp.setOne_letter_code("" + singleLetterCode);
+		chemComp.setOne_letter_code(String.valueOf(singleLetterCode));
 		ResidueType residueType = ResidueType.getResidueTypeFromString(chemCompType);
 		chemComp.setResidueType(residueType);
 		chemComp.setPolymerType(residueType.polymerType);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
@@ -532,7 +532,7 @@ public class SymmetryTools {
 				Group g = (Group) repeat[k].getGroup().clone();
 				newCh.addGroup(g);
 			}
-			newCh.setName(chainID + "");
+			newCh.setName(String.valueOf(chainID));
 			chainID++;
 			symm.addChain(newCh);
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvivalInfo.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvivalInfo.java
@@ -92,7 +92,7 @@ public class SurvivalInfo implements Comparable<SurvivalInfo> {
 		status = e;
 
 		data.put(variable, d);
-		originalMetaData.put(variable, d + "");
+		originalMetaData.put(variable, String.valueOf(d));
 	}
 
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/data/WorkSheet.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/data/WorkSheet.java
@@ -1035,10 +1035,10 @@ public class WorkSheet {
 		while (picked.size() < number) {
 			double v = Math.random();
 			int index = (int) (v * columns.size());
-			if (picked.containsKey(index + "")) {
+			if (picked.containsKey(String.valueOf(index))) {
 				continue;
 			}
-			picked.put(index + "", index + "");
+			picked.put(String.valueOf(index), String.valueOf(index));
 			randomColumns.add(columns.get(index));
 		}
 		return randomColumns;
@@ -1267,7 +1267,7 @@ public class WorkSheet {
 		String line = br.readLine();
 		int numcolumns = -1;
 		while (line != null) {
-			String[] d = line.split(delimiter + "");
+			String[] d = line.split(String.valueOf(delimiter));
 			if (numcolumns == -1) {
 				numcolumns = d.length;
 			}
@@ -1314,7 +1314,7 @@ public class WorkSheet {
 		String line = br.readLine();
 		int numcolumns = -1;
 		while (line != null) {
-			String[] d = line.split(delimiter + "");
+			String[] d = line.split(String.valueOf(delimiter));
 			if (numcolumns == -1) {
 				numcolumns = d.length;
 			}

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/NumbersAtRiskPanel.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/NumbersAtRiskPanel.java
@@ -117,7 +117,7 @@ public class NumbersAtRiskPanel extends JPanel {
 				if(value == null){
 					nrisk = "";
 				}else{
-					nrisk = value.intValue() + "";
+					nrisk = String.valueOf(value.intValue());
 				}
 				if(time == 0.0){
 					 g2.drawString(nrisk , xvalue, row);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2131 - Primitives should not be boxed just for "String" conversion

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2131

Please let me know if you have any questions.

M-Ezzat