### PR TITLE
Refactored getChain to getChainByIndex

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureTest.java
@@ -108,12 +108,12 @@ public class StructureTest {
 
 		// since biojava 5.0, we have 4 chains here: 1 protein, 2 non-poly (ligands), 1 water
 		
-		Chain c = structure.getChain(0);
+		Chain c = structure.getChainByIndex(0);
 		assertEquals("did not find the expected 58 amino acids!",58,c.getAtomGroups(GroupType.AMINOACID).size());
 
 		assertEquals(0 , c.getAtomGroups(GroupType.HETATM).size());
 
-		Chain c4 = structure.getChain(3);
+		Chain c4 = structure.getChainByIndex(3);
 
 		// The fourth chain in the file contains 63 molecules of deutarated
 		assertEquals(63, c4.getAtomGroups(GroupType.HETATM).size());
@@ -221,7 +221,7 @@ public class StructureTest {
 	@Test
 	public void testCreateVirtualCBAtom(){
 
-		Group g1 = structure.getChain(0).getAtomGroup(11);
+		Group g1 = structure.getChainByIndex(0).getAtomGroup(11);
 
 		if ( g1.getPDBName().equals("GLY")){
 			if ( g1 instanceof AminoAcid){
@@ -240,11 +240,11 @@ public class StructureTest {
 	@Test
 	public void testMutation() throws Exception {
 
-		Group g1 = (Group)structure.getChain(0).getAtomGroup(21).clone();
+		Group g1 = (Group)structure.getChainByIndex(0).getAtomGroup(21).clone();
 		assertTrue(g1 != null);
 
 
-		Group g2 = (Group)structure.getChain(0).getAtomGroup(53).clone();
+		Group g2 = (Group)structure.getChainByIndex(0).getAtomGroup(53).clone();
 		assertTrue(g2 != null);
 
 

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -56,7 +56,7 @@ public class StructureToolsTest extends TestCase {
 		assertEquals("structure does not contain one chain ", 1 ,structure.size());
 
 		// since biojava 5, chains contain either only polymers or only nonpolymers: here we get the first protein chain with 58 residues
-		Chain chain = structure.getChain(0);
+		Chain chain = structure.getChainByIndex(0);
 		assertEquals("Wrong number of residues.",58,chain.getAtomLength());
 
 		inStream.close();
@@ -104,12 +104,12 @@ public class StructureToolsTest extends TestCase {
 
 		Structure hivA = cache.getStructure("1hiv.A");
 		Atom[] caSa = StructureTools.getRepresentativeAtomArray(hivA);
-		Atom[] caCa = StructureTools.getRepresentativeAtomArray(hivA.getChain(0));
+		Atom[] caCa = StructureTools.getRepresentativeAtomArray(hivA.getChainByIndex(0));
 		assertEquals("did not find the same number of Atoms from structure and from chain..",
 				caSa.length,caCa.length);
 		Structure hivB = cache.getStructure("1hiv.B");
 		Atom[] caSb = StructureTools.getRepresentativeAtomArray(hivB);
-		Atom[] caCb = StructureTools.getRepresentativeAtomArray(hivB.getChain(0));
+		Atom[] caCb = StructureTools.getRepresentativeAtomArray(hivB.getChainByIndex(0));
 		assertEquals("did not find the same number of Atoms from structure and from chain..",
 				caSb.length,caCb.length);
 		//Both chains have to be the same size (A and B)
@@ -137,7 +137,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 5, chain.getAtomLength() );
 
@@ -146,7 +146,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		// since biojava 5, chains contain either only polymers or only nonpolymers: here we get the first protein chain with 408 residues
 		assertEquals("Did not find the expected number of residues in "+range, 408, chain.getAtomLength() );
@@ -157,7 +157,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		// since biojava 5, chains contain either only polymers or only nonpolymers: here we get the first protein chain with 408 residues
 		assertEquals("Did not find the expected number of residues in "+range, 408, chain.getAtomLength() );
@@ -168,10 +168,10 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 2, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 		assertEquals("Did not find the expected number of residues in first chain of "+range, 5, chain.getAtomLength() );
 
-		chain = substr.getChain(1);
+		chain = substr.getChainByIndex(1);
 		assertEquals("Did not find the expected number of residues in second chain of "+range, 5, chain.getAtomLength() );
 
 		// combined ranges
@@ -180,10 +180,10 @@ public class StructureToolsTest extends TestCase {
 		assertEquals("Wrong number of chains in "+range, 2, substr.size());
 
 		// since biojava 5, chains contain either only polymers or only nonpolymers: here we get the first protein chain with 408 residues
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 		assertEquals("Did not find the expected number of residues in first chain of "+range, 408, chain.getAtomLength() );
 
-		chain = substr.getChain(1);
+		chain = substr.getChainByIndex(1);
 		assertEquals("Did not find the expected number of residues in second chain of "+range, 5, chain.getAtomLength() );
 
 		// parentheses
@@ -191,14 +191,14 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 		assertEquals("Did not find the expected number of residues in "+range, 5, chain.getAtomLength() );
 
 		// single residue
 		range = "A:3";
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 		assertEquals("Did not find the expected number of residues in "+range, 1, chain.getAtomLength() );
 
 		// Special '-' case
@@ -212,7 +212,7 @@ public class StructureToolsTest extends TestCase {
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
 		// since biojava 5, chains contain either only polymers or only nonpolymers: here we get the first protein chain with 58 residues
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 		assertEquals("Did not find the expected number of residues in first chain of "+range, 58, chain.getAtomLength() );
 
 		// Test single-chain syntax in a multi-chain structure. Should give chain A.
@@ -221,7 +221,7 @@ public class StructureToolsTest extends TestCase {
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
 		// since biojava 5, chains contain either only polymers or only nonpolymers: here we get the first protein chain with 408 residues
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 		assertEquals("Chain _ not converted to chain A.","A",chain.getChainID());
 		assertEquals("Did not find the expected number of residues in first chain of "+range, 408, chain.getAtomLength() );
 
@@ -336,7 +336,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		// Note residue 0 is missing from 1lnl
 		assertEquals("Did not find the expected number of residues in "+range, 10, chain.getAtomLength() );
@@ -346,7 +346,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 3, chain.getAtomLength() );
 
@@ -355,7 +355,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 4, chain.getAtomLength() );
 
@@ -364,7 +364,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 6, chain.getAtomLength() );
 
@@ -374,10 +374,10 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure2, range);
 		assertEquals("Wrong number of chains in "+range, 2, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 		assertEquals("Did not find the expected number of residues in first chain of "+range, 5, chain.getAtomLength() );
 
-		chain = substr.getChain(1);
+		chain = substr.getChainByIndex(1);
 		assertEquals("Did not find the expected number of residues in second chain of "+range, 5, chain.getAtomLength() );
 
 	}
@@ -397,7 +397,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 4, chain.getAtomLength() );
 
@@ -407,7 +407,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 3, chain.getAtomLength() );
 
@@ -416,7 +416,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 3, chain.getAtomLength() );
 
@@ -425,7 +425,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 12, chain.getAtomLength() );
 
@@ -434,7 +434,7 @@ public class StructureToolsTest extends TestCase {
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
-		chain = substr.getChain(0);
+		chain = substr.getChainByIndex(0);
 
 		assertEquals("Did not find the expected number of residues in "+range, 8, chain.getAtomLength() );
 	}

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/Test1a4w.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/Test1a4w.java
@@ -106,8 +106,8 @@ public class Test1a4w extends TestCase{
 		assertEquals(structure.getPDBHeader().toPDB().toLowerCase(),structure2.getPDBHeader().toPDB().toLowerCase());
 
 		for ( int i = 0 ; i < 3 ; i++){
-			Chain c1 = structure.getChain(i);
-			Chain c2 = structure.getChain(i);
+			Chain c1 = structure.getChainByIndex(i);
+			Chain c2 = structure.getChainByIndex(i);
 			testEqualChains(c1, c2);
 		}
 	}
@@ -159,7 +159,7 @@ public class Test1a4w extends TestCase{
 
 		assertEquals(3, s.getPolyChains().size());
 
-		Chain c2 = s.getChain(1);
+		Chain c2 = s.getChainByIndex(1);
 		assertEquals("H", c2.getName());
 
 		
@@ -194,7 +194,7 @@ public class Test1a4w extends TestCase{
 	}
 
 	public void testLigandLoading(){
-		Chain c2 = structure.getChain(1);
+		Chain c2 = structure.getChainByIndex(1);
 		assertEquals("H", c2.getName());
 
 		
@@ -227,7 +227,7 @@ public class Test1a4w extends TestCase{
 		//			for (Chain chain : s.getChains()) {
 		//				System.out.println("Chain: " + chain.getChainID());
 		//			}
-		Chain c2 = s.getChain(1);
+		Chain c2 = s.getChainByIndex(1);
 		assertEquals("H", c2.getName());
 
 		//			if (s == null) {

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestSeqResParsing.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestSeqResParsing.java
@@ -54,7 +54,7 @@ public class TestSeqResParsing {
 		s = StructureIO.getStructure(pdbID);
 		assertNotNull(s);
 		assertTrue(s.getChains().size() > 0);
-		Chain c = s.getChain(0);
+		Chain c = s.getChainByIndex(0);
 
 		assertTrue(c.getSeqResGroups().size() > 2);
 

--- a/biojava-structure/src/main/java/demo/DemoContacts.java
+++ b/biojava-structure/src/main/java/demo/DemoContacts.java
@@ -84,7 +84,7 @@ public class DemoContacts {
 		System.out.println("Total number of residue contacts: "+groupContacts.size());
 
 
-		contacts = StructureTools.getAtomsInContact(structure.getChain(0),structure.getChain(1),5.5, false);
+		contacts = StructureTools.getAtomsInContact(structure.getChainByIndex(0),structure.getChainByIndex(1),5.5, false);
 
 		System.out.println("Contacting residues between 2 first chains (all non-H non-hetatoms)");
 

--- a/biojava-structure/src/main/java/demo/DemoLoadStructure.java
+++ b/biojava-structure/src/main/java/demo/DemoLoadStructure.java
@@ -58,7 +58,7 @@ public class DemoLoadStructure
 			System.out.println(StructureTools.getNrAtoms(s1));
 
 
-			Chain chain1 = s1.getChain(0);
+			Chain chain1 = s1.getChainByIndex(0);
 
 			System.out.println("First chain: " + chain1);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
@@ -395,19 +395,19 @@ public interface Structure extends Cloneable {
 	/**
 	 * Retrieve a chain by its index within the Structure .
 	 *
-	 * @param pos  an int for the position in the List of Chains.
+	 * @param chainIndex the index of the desired chain in the structure
 	 * @return a Chain object
 	 */
-	Chain getChain(int pos);
+	Chain getChainByIndex(int chainIndex);
 
 	/**
 	 * Retrieve a chain by its indices within the Structure and model.
 	 *
-	 * @param pos      an int
-	 * @param modelnr  an int
+	 * @param chainIndex the index of the desired chain in the structure
+	 * @param modelnr the model the desired chain is in
 	 * @return a Chain object
 	 */
-	Chain getChain( int modelnr, int pos);
+	Chain getChainByIndex(int modelnr, int chainIndex);
 
 	/**
 	 * Request a particular chain from a structure.

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -150,7 +150,7 @@ public class StructureImpl implements Structure, Serializable {
 
 			for (int j=0;j<size(i);j++){
 
-				Chain cloned_chain  = (Chain) getChain(i,j).clone();
+				Chain cloned_chain  = (Chain) getChainByIndex(i,j).clone();
 
 				// setting the parent: can only be done from the parent
 				cloned_chain.setStructure(n);
@@ -338,17 +338,17 @@ public class StructureImpl implements Structure, Serializable {
 
 	/** {@inheritDoc} */
 	@Override
-	public Chain getChain(int number) {
+	public Chain getChainByIndex(int number) {
 
 		int modelnr = 0 ;
 
-		return getChain(modelnr,number);
+		return getChainByIndex(modelnr,number);
 	}
 
 
 	/** {@inheritDoc} */
 	@Override
-	public Chain getChain(int modelnr,int number) {
+	public Chain getChainByIndex(int modelnr,int number) {
 
 		Model model = models.get(modelnr);
 
@@ -434,7 +434,7 @@ public class StructureImpl implements Structure, Serializable {
 
 			for (int j=0;j<size(i);j++){
 
-				Chain cha = getChain(i,j);
+				Chain cha = getChainByIndex(i,j);
 				List<Group> agr = cha.getAtomGroups(GroupType.AMINOACID);
 				List<Group> hgr = cha.getAtomGroups(GroupType.HETATM);
 				List<Group> ngr = cha.getAtomGroups(GroupType.NUCLEOTIDE);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1141,7 +1141,7 @@ public class StructureTools {
 		}
 		Chain c = null;
 
-		c = s.getChain(0, chainNr);
+		c = s.getChainByIndex(0, chainNr);
 
 		newStructure.addChain(c);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -213,7 +213,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 					Chain chain;
 					if(chainId.equals("_") ) {
 						// Handle special case of "_" chain for single-chain proteins
-						chain = s.getChain(modelNr,0);
+						chain = s.getChainByIndex(modelNr,0);
 						if(pdbresnum1 != null)
 							pdbresnum1.setChainName(chain.getName());
 						if(pdbresnum2 != null)
@@ -234,7 +234,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 							try {
 								int chainNum = Integer.parseInt(chainId);
 								try {
-									chain = s.getChain(modelNr, chainNum);
+									chain = s.getChainByIndex(modelNr, chainNum);
 									logger.warn("No chain found for {}. Interpretting it as an index, using chain {} instead",chainId,chain.getChainID());
 								} catch(Exception e2) { //we don't care what gets thrown here -sbliven
 									throw e; // Nope, not an index. Throw the original exception

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -509,7 +509,7 @@ public class FileConvert {
 
 			// do for all chains:
 			for (int chainnr = 0;chainnr<structure.size(modelnr);chainnr++){
-				Chain chain = structure.getChain(modelnr,chainnr);
+				Chain chain = structure.getChainByIndex(modelnr,chainnr);
 				xw.openTag("chain");
 				xw.attribute("id",chain.getId());
 				xw.attribute("SwissprotId",chain.getSwissprotId() );

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
@@ -604,7 +604,7 @@ public class SymmetryTools {
 
 		for (int i = 0; i < result.getMultipleAlignment().size(); i++) {
 			Structure newStr = new StructureImpl();
-			Chain newCh = divided.getChain(i);
+			Chain newCh = divided.getChainByIndex(i);
 			newStr.addChain(newCh);
 			Atom[] repeat = StructureTools.getRepresentativeAtomArray(newCh);
 			atomArrays.add(repeat);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/Test4hhb.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/Test4hhb.java
@@ -94,8 +94,8 @@ public class Test4hhb {
 		assertEquals(structure.getPDBHeader().toPDB().toLowerCase(),structure2.getPDBHeader().toPDB().toLowerCase());
 
 		for ( int i = 0 ; i < 4 ; i++){
-			Chain c1 = structure.getChain(i);
-			Chain c2 = structure.getChain(i);
+			Chain c1 = structure.getChainByIndex(i);
+			Chain c2 = structure.getChainByIndex(i);
 			testEqualChains(c1, c2);
 		}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAltLocs.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAltLocs.java
@@ -157,7 +157,7 @@ public class TestAltLocs {
 		AtomCache cache = new AtomCache();
 		Structure structure = cache.getStructure("1JXX");
 
-		Chain chain = structure.getChain(0); // 1JXX example
+		Chain chain = structure.getChainByIndex(0); // 1JXX example
 
 		Group g = chain.getAtomGroups().get(1); // 1JXX  THR A   2
 		ensureAllAtomsSameAltCode(g, g);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/align/util/AtomCacheTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/align/util/AtomCacheTest.java
@@ -273,14 +273,14 @@ public class AtomCacheTest {
 		full = id.loadStructure(cache);
 		assertEquals("Wrong number of models in full "+name,1,full.nrModels());
 		assertEquals("Wrong number of chains in full "+name,1,full.getChains().size());
-		chain = full.getChain(0);
+		chain = full.getChainByIndex(0);
 		seqres = chain.getSeqResGroups();
 		assertEquals("Wrong seqres length in full "+name,46,seqres.size());
 		
 		reduced = id.reduce(full);
 		assertEquals("Wrong number of models in reduced "+name,1,reduced.nrModels());
 		assertEquals("Wrong number of chains in reduced "+name,1,reduced.getChains().size());
-		chain = reduced.getChain(0);
+		chain = reduced.getChainByIndex(0);
 		seqres = chain.getSeqResGroups();
 		assertEquals("Wrong seqres length in reduced "+name,46,seqres.size());
 
@@ -291,14 +291,14 @@ public class AtomCacheTest {
 		full = id.loadStructure(cache);
 		assertEquals("Wrong number of models in full "+name,1,full.nrModels());
 		assertEquals("Wrong number of chains in full "+name,1,full.getChains().size());
-		chain = full.getChain(0);
+		chain = full.getChainByIndex(0);
 		seqres = chain.getSeqResGroups();
 		assertEquals("Wrong seqres length in full "+name,46,seqres.size());
 		
 		reduced = id.reduce(full);
 		assertEquals("Wrong number of models in reduced "+name,1,reduced.nrModels());
 		assertEquals("Wrong number of chains in reduced "+name,1,reduced.getChains().size());
-		chain = reduced.getChain(0);
+		chain = reduced.getChainByIndex(0);
 		seqres = chain.getSeqResGroups();
 		assertEquals("Wrong seqres length in reduced "+name,46,seqres.size());
 
@@ -309,7 +309,7 @@ public class AtomCacheTest {
 		full = id.loadStructure(cache);
 		assertEquals("Wrong number of models in full "+name,1,full.nrModels());
 		assertEquals("Wrong number of chains in full "+name,1,full.getChains().size());
-		chain = full.getChain(0);
+		chain = full.getChainByIndex(0);
 		seqres = chain.getSeqResGroups();
 		assertEquals("Wrong seqres length in full "+name,46,seqres.size());
 		assertEquals("Wrong SeqNum at first group in full",1,(int)chain.getAtomGroup(0).getResidueNumber().getSeqNum());
@@ -317,7 +317,7 @@ public class AtomCacheTest {
 		reduced = id.reduce(full);
 		assertEquals("Wrong number of models in reduced "+name,1,reduced.nrModels());
 		assertEquals("Wrong number of chains in reduced "+name,1,reduced.getChains().size());
-		chain = reduced.getChain(0);
+		chain = reduced.getChainByIndex(0);
 		seqres = chain.getSeqResGroups();
 		assertEquals("Wrong seqres length in reduced "+name,46,seqres.size());
 		

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/StructureSequenceMatcherTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/StructureSequenceMatcherTest.java
@@ -121,7 +121,7 @@ public class StructureSequenceMatcherTest extends TestCase {
 		assertEquals("Wrong number of groups", 10, StructureTools.getNrGroups(result));
 		assertEquals("Wrong number of chains", 1, result.getChains().size());
 		int i = 0;
-		for (Group group : result.getChain(0).getAtomGroups()) {
+		for (Group group : result.getChainByIndex(0).getAtomGroups()) {
 			assertTrue("Contains non-amino acid group", group instanceof AminoAcid);
 			AminoAcid aa = (AminoAcid) group;
 			char c = StructureTools.get1LetterCodeAmino(aa.getPDBName());

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestDifficultMmCIFFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestDifficultMmCIFFiles.java
@@ -172,7 +172,7 @@ public class TestDifficultMmCIFFiles {
 		cache.setUseMmCif(true);
 
 		Structure s = cache.getStructure("2PTC");
-		Chain c = s.getChain(0);
+		Chain c = s.getChainByIndex(0);
 		System.out.println(c);
 		assertEquals("Wrong first chain",c.getName(),"E");
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestChemCompProvider.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestChemCompProvider.java
@@ -138,7 +138,7 @@ public class TestChemCompProvider {
 		pdbreader.setFileParsingParameters(params);
 
 		Structure s = pdbreader.getStructure(testPDB);
-		assertEquals(3, s.getChain(0).getAtomGroups().size());
+		assertEquals(3, s.getChainByIndex(0).getAtomGroups().size());
 		// Not wanted here for testing, but useful for cleaning up downloaded .cif.gz files.
 		// ZipChemCompProvider.purgeTempFiles(pdbdir.toString());
 	}


### PR DESCRIPTION
Refactored getChain(int chainIndex) and getChain(int modelNr, int chainIndex) to getChainByIndex().

This avoids ambiguity around whether the input can by a char (implicitally converted to an int).