### PR TITLE
squid:S2130 - Parsing should be used to convert Strings to primitives

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
@@ -228,7 +228,7 @@ public class InsdcParser <S extends AbstractSequence<C>, C extends Compound>{
 
 				String accession = m.group(1);
 				Strand s = versus == 1 ? Strand.POSITIVE : Strand.NEGATIVE;
-				int start = new Integer(m.group(3));
+				int start = Integer.parseInt(m.group(3));
 				int end = m.group(6) == null ? start : new Integer(m.group(6));
 
 				if (featureGlobalStart > start) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLParser.java
@@ -260,31 +260,31 @@ public class AFPChainXMLParser
 				if ( version != null)
 					a.setVersion(version);
 
-				a.setAlnLength(	new Integer(getAttribute(rootElement,"alnLength")).intValue());
-				a.setBlockNum(		new Integer(getAttribute(rootElement,"blockNum")).intValue());
-				a.setGapLen(		new Integer(getAttribute(rootElement,"gapLen")).intValue());
-				a.setOptLength(	new Integer(getAttribute(rootElement,"optLength")).intValue());
-				a.setTotalLenIni(	new Integer(getAttribute(rootElement,"totalLenIni")).intValue());
-				a.setBlockNum(		new Integer(getAttribute(rootElement,"blockNum")).intValue());
+				a.setAlnLength(	Integer.parseInt(getAttribute(rootElement,"alnLength")));
+				a.setBlockNum(		Integer.parseInt(getAttribute(rootElement,"blockNum")));
+				a.setGapLen(		Integer.parseInt(getAttribute(rootElement,"gapLen")));
+				a.setOptLength(	Integer.parseInt(getAttribute(rootElement,"optLength")));
+				a.setTotalLenIni(	Integer.parseInt(getAttribute(rootElement,"totalLenIni")));
+				a.setBlockNum(		Integer.parseInt(getAttribute(rootElement,"blockNum")));
 
 				if ( a.getAlgorithmName().equals(CeCPMain.algorithmName)){
 						 a.setSequentialAlignment(a.getBlockNum() == 1);
 					 }
 
-				a.setAlignScore(new Double(getAttribute(rootElement,"alignScore")).doubleValue());
-				a.setChainRmsd(new Double(getAttribute(rootElement,"chainRmsd")).doubleValue());
-				Double identity = new Double(getAttribute(rootElement,"identity")).doubleValue();
+				a.setAlignScore(Double.parseDouble(getAttribute(rootElement,"alignScore")));
+				a.setChainRmsd(Double.parseDouble(getAttribute(rootElement,"chainRmsd")));
+				Double identity = Double.parseDouble(getAttribute(rootElement,"identity"));
 				a.setIdentity(identity);
 
-				a.setNormAlignScore(new Double(getAttribute(rootElement,"normAlignScore")).doubleValue());
-				a.setProbability(new Double(getAttribute(rootElement,"probability")).doubleValue());
-				a.setSimilarity(new Double(getAttribute(rootElement,"similarity")).doubleValue());
-				a.setTotalRmsdIni(new Double(getAttribute(rootElement,"totalRmsdIni")).doubleValue());
-				a.setTotalRmsdOpt(new Double(getAttribute(rootElement,"totalRmsdOpt")).doubleValue());
-				a.setAlignScoreUpdate(new Double(getAttribute(rootElement,"alignScoreUpdate")).doubleValue());
-				int ca1Length = new Integer(getAttribute(rootElement,"ca1Length")).intValue();
+				a.setNormAlignScore(Double.parseDouble(getAttribute(rootElement,"normAlignScore")));
+				a.setProbability(Double.parseDouble(getAttribute(rootElement,"probability")));
+				a.setSimilarity(Double.parseDouble(getAttribute(rootElement,"similarity")));
+				a.setTotalRmsdIni(Double.parseDouble(getAttribute(rootElement,"totalRmsdIni")));
+				a.setTotalRmsdOpt(Double.parseDouble(getAttribute(rootElement,"totalRmsdOpt")));
+				a.setAlignScoreUpdate(Double.parseDouble(getAttribute(rootElement,"alignScoreUpdate")));
+				int ca1Length = Integer.parseInt(getAttribute(rootElement,"ca1Length"));
 				a.setCa1Length(ca1Length);
-				int ca2Length = new Integer(getAttribute(rootElement,"ca2Length")).intValue();
+				int ca2Length = Integer.parseInt(getAttribute(rootElement,"ca2Length"));
 				a.setCa2Length(ca2Length);
 
 				String tmScoreS = getAttribute(rootElement,"tmScore");
@@ -315,7 +315,7 @@ public class AFPChainXMLParser
 				Atom[] blockShiftVector = new Atom[a.getBlockNum()];
 				a.setBlockShiftVector(blockShiftVector);
 
-				int afpNum = new Integer(getAttribute(rootElement,"afpNum")).intValue();
+				int afpNum = Integer.parseInt(getAttribute(rootElement,"afpNum"));
 				List<AFP> afpSet = new ArrayList<AFP>();
 				for (int afp=0;afp<afpNum;afp++){
 					afpSet.add( new AFP());
@@ -398,18 +398,18 @@ public class AFPChainXMLParser
 		Matrix[] ms     = a.getBlockRotationMatrix();
 		Atom[] shifts = a.getBlockShiftVector();
 
-		int blockNr = new Integer( map.getNamedItem("blockNr").getTextContent()).intValue();
+		int blockNr = Integer.parseInt( map.getNamedItem("blockNr").getTextContent());
 
-		int thisBlockGap = new Integer(map.getNamedItem("blockGap").getTextContent()).intValue();
+		int thisBlockGap = Integer.parseInt(map.getNamedItem("blockGap").getTextContent());
 		blockGap[blockNr] = thisBlockGap;
 
-		int thisBlockSize = new Integer(map.getNamedItem("blockSize").getTextContent()).intValue();
+		int thisBlockSize = Integer.parseInt(map.getNamedItem("blockSize").getTextContent());
 		blockSize[blockNr] = thisBlockSize;
 
-		double thisBlockScore = new Double(map.getNamedItem("blockScore").getTextContent()).doubleValue();
+		double thisBlockScore = Double.parseDouble(map.getNamedItem("blockScore").getTextContent());
 		blockScore[blockNr] = thisBlockScore;
 
-		double thisBlockRmsd = new Double(map.getNamedItem("blockRmsd").getTextContent()).doubleValue();
+		double thisBlockRmsd = Double.parseDouble(map.getNamedItem("blockRmsd").getTextContent());
 		blockRmsd[blockNr] = thisBlockRmsd;
 
 
@@ -425,7 +425,7 @@ public class AFPChainXMLParser
 				nrEqr++;
 				NamedNodeMap atts = eqr.getAttributes();
 
-				int eqrNr = new Integer(atts.getNamedItem("eqrNr").getTextContent()).intValue();
+				int eqrNr = Integer.parseInt(atts.getNamedItem("eqrNr").getTextContent());
 
 				String pdbres1 = atts.getNamedItem("pdbres1").getTextContent();
 				String chain1 = atts.getNamedItem("chain1").getTextContent();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/Matrix.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/jama/Matrix.java
@@ -1060,7 +1060,7 @@ public static Matrix read (BufferedReader input) throws java.io.IOException {
 			do {
 				if (j >= n) throw new java.io.IOException
 					("Row " + v.size() + " is too long.");
-				row[j++] = Double.valueOf(tokenizer.sval).doubleValue();
+				row[j++] = Double.parseDouble(tokenizer.sval);
 			} while (tokenizer.nextToken() == StreamTokenizer.TT_WORD);
 			if (j < n) throw new java.io.IOException
 				("Row " + v.size() + " is too short.");

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/DSSPParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/DSSPParser.java
@@ -144,9 +144,9 @@ public class DSSPParser {
 			//Only happens if dssp inserts a line indicating a chain break
 			if(!resNumStr.equals("")) {
 
-				int index = Integer.valueOf(indexStr);
+				int index = Integer.parseInt(indexStr);
 				//Get the group of the structure corresponding to the residue
-				int resNum = Integer.valueOf(resNumStr);
+				int resNum = Integer.parseInt(resNumStr);
 				char insCode = line.charAt(10);
 				String chainId = line.substring(11,13).trim();
 				ResidueNumber r = new ResidueNumber(chainId, resNum, insCode);
@@ -187,7 +187,7 @@ public class DSSPParser {
 
 					String[] p = val.split(",");
 
-					int partner = Integer.valueOf(p[0]);
+					int partner = Integer.parseInt(p[0]);
 					if (partner != 0) partner += index;
 					double energy = Double.valueOf(p[1]) * 1000.0;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2130 - Parsing should be used to convert Strings to primitives

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2130

Please let me know if you have any questions.

M-Ezzat