### PR TITLE
squid:S1157 - Case insensitive string comparisons should be made with…

### DIFF
--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/InputParameters.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/InputParameters.java
@@ -105,10 +105,10 @@ final class InputParameters {
 		return ResultLayout.VERTICAL;
 	}
 	format = format.trim().substring(InputParameters.formatKey.length());
-	if (format.toUpperCase().equals("V")) {
+	if ("V".equalsIgnoreCase(format)) {
 		return ResultLayout.VERTICAL;
 	}
-	if (format.toUpperCase().equals("H")) {
+	if ("H".equalsIgnoreCase(format)) {
 		return ResultLayout.HORIZONTAL;
 	}
 	throw new IllegalArgumentException("Unrecognised format: '" + format

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -395,11 +395,11 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 	 */
 	private int getGroupTypIndicator(String currentGroupType) {
 		// At the moment - peptide like is a HETATM group (consistent with biojava)
-		if(currentGroupType.toUpperCase().equals("PEPTIDE-LIKE")){
+		if("PEPTIDE-LIKE".equalsIgnoreCase(currentGroupType)){
 			return 0;
 		}
 		// Again to correspond with Biojava - but I suspect we really want this to be 1
-		if(currentGroupType.toUpperCase().equals("D-PEPTIDE LINKING")){
+		if("D-PEPTIDE LINKING".equalsIgnoreCase(currentGroupType)){
 			return 0;
 		}
 		if(currentGroupType.toUpperCase().contains("PEPTIDE")){


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1157 - Case insensitive string comparisons should be made without intermediate upper or lower casing

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1157

Please let me know if you have any questions.

M-Ezzat