### PR TITLE
squid:S2063 - Comparators should be Serializable

### DIFF
--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/routines/AlignerHelper.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/routines/AlignerHelper.java
@@ -25,6 +25,7 @@ package org.biojava.nbio.alignment.routines;
 
 import org.biojava.nbio.core.alignment.template.AlignedSequence.Step;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -207,7 +208,9 @@ public class AlignerHelper {
 			this.queryIndex = queryIndex;
 			this.targetIndex = targetIndex;
 		}
-		public static class QueryIndexComparator implements Comparator<Anchor> {
+		public static class QueryIndexComparator implements Comparator<Anchor>, Serializable {
+            private static final long serialVersionUID = 1;
+
 			@Override
 			public int compare(Anchor o1, Anchor o2) {
 				return o1.getQueryIndex() - o2.getQueryIndex();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/CDSComparator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/CDSComparator.java
@@ -23,11 +23,13 @@
 
 package org.biojava.nbio.core.sequence;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 
 
-	public class CDSComparator implements Comparator<CDSSequence>{
+	public class CDSComparator implements Comparator<CDSSequence>, Serializable{
+        private static final long serialVersionUID = 1;
 
 /**
  * Used to sort two CDSSequences where Negative Strand makes it tough

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ExonComparator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ExonComparator.java
@@ -23,6 +23,7 @@
 
 package org.biojava.nbio.core.sequence;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 
@@ -31,8 +32,8 @@ import java.util.Comparator;
  * where a negative stranded gene should go the other direction. Need to think about this?
  * @author Scooter Willis <willishf at gmail dot com>
  */
-public class ExonComparator implements Comparator<ExonSequence>{
-
+public class ExonComparator implements Comparator<ExonSequence>, Serializable{
+    private static final long serialVersionUID = 1;
 
 	@Override
 	public int compare(ExonSequence o1, ExonSequence o2) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/SequenceComparator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/SequenceComparator.java
@@ -24,14 +24,15 @@ package org.biojava.nbio.core.sequence;
 
 import org.biojava.nbio.core.sequence.template.AbstractSequence;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  * Used to sort sequences
  * @author Scooter Willis <willishf at gmail dot com>
  */
-public class SequenceComparator implements Comparator<AbstractSequence<?>>{
-
+public class SequenceComparator implements Comparator<AbstractSequence<?>>, Serializable{
+    private static final long serialVersionUID = 1;
 
 	@Override
 	public int compare(AbstractSequence<?> o1, AbstractSequence<?> o2) {

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/FeatureList.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/FeatureList.java
@@ -22,6 +22,7 @@ package org.biojava.nbio.genome.parsers.gff;
 
 import org.biojava.nbio.core.sequence.DNASequence;
 
+import java.io.Serializable;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -467,7 +468,8 @@ public class FeatureList extends ArrayList<FeatureI> {
 	/**
 	 * used by sort routine
 	 */
-	private class FeatureComparator implements Comparator<FeatureI> {
+	private class FeatureComparator implements Comparator<FeatureI>, Serializable {
+        private static final long serialVersionUID = 1;
 
 		@Override
 		public int compare(FeatureI a, FeatureI b) {

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MyTableRowSorter.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MyTableRowSorter.java
@@ -26,6 +26,7 @@ package org.biojava.nbio.structure.align.gui;
 
 import javax.swing.table.TableModel;
 import javax.swing.table.TableRowSorter;
+import java.io.Serializable;
 import java.util.Comparator;
 
 public class MyTableRowSorter extends TableRowSorter<TableModel>
@@ -46,7 +47,8 @@ public class MyTableRowSorter extends TableRowSorter<TableModel>
 
 }
 
-class MyComparator implements Comparator<String> {
+class MyComparator implements Comparator<String>, Serializable {
+    private static final long serialVersionUID = 1;
 
 	int column;
 	public MyComparator(int column){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomPositionMap.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomPositionMap.java
@@ -23,6 +23,7 @@
 
 package org.biojava.nbio.structure;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -119,7 +120,8 @@ public class AtomPositionMap {
 	 * @param <V>
 	 *            The value type
 	 */
-	private static class ValueComparator<T, V extends Comparable<V>> implements Comparator<T> {
+	private static class ValueComparator<T, V extends Comparable<V>> implements Comparator<T>, Serializable {
+        private static final long serialVersionUID = 1;
 
 		private Map<T, V> map;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/helper/IdxComparator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/helper/IdxComparator.java
@@ -19,10 +19,12 @@
 
 package org.biojava.nbio.structure.align.helper;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
-public class IdxComparator implements Comparator<int[]>
+public class IdxComparator implements Comparator<int[]>, Serializable
 {
+    private static final long serialVersionUID = 1;
 
 	@Override
 	public int compare(int[] o1, int[] o2)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/AltAligComparator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/AltAligComparator.java
@@ -22,6 +22,7 @@
  */
 package org.biojava.nbio.structure.align.pairwise;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 
@@ -31,8 +32,8 @@ import java.util.Comparator;
  * @author Andreas Prlic
  *
  */
-public class AltAligComparator implements Comparator<AlternativeAlignment> {
-
+public class AltAligComparator implements Comparator<AlternativeAlignment>, Serializable {
+    private static final long serialVersionUID = 1;
 
 	public AltAligComparator() {
 		super();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/FragmentJoiner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/FragmentJoiner.java
@@ -31,6 +31,7 @@ import org.biojava.nbio.structure.align.helper.AlignTools;
 import org.biojava.nbio.structure.align.helper.JointFragments;
 import org.biojava.nbio.structure.jama.Matrix;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -535,7 +536,8 @@ public class FragmentJoiner {
 
 
 class JointFragmentsComparator
-		  implements Comparator<JointFragments> {
+		  implements Comparator<JointFragments>, Serializable {
+    private static final long serialVersionUID = 1;
 
 	@Override
 	public int compare(JointFragments one, JointFragments two) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/SegmentComparator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/SegmentComparator.java
@@ -20,9 +20,11 @@
  */
 package org.biojava.nbio.structure.domain.pdp;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
-public class SegmentComparator implements Comparator<Segment> {
+public class SegmentComparator implements Comparator<Segment>, Serializable {
+    private static final long serialVersionUID = 1;
 
 	@Override
 	public int compare(Segment v1, Segment v2) {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/comparators/CoxVariablesOverallModelFitComparator.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/comparators/CoxVariablesOverallModelFitComparator.java
@@ -23,13 +23,15 @@ package org.biojava.nbio.survival.cox.comparators;
 import org.biojava.nbio.survival.cox.CoxInfo;
 import org.biojava.nbio.survival.cox.CoxVariables;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  *
  * @author Scooter Willis <willishf at gmail dot com>
  */
-public class CoxVariablesOverallModelFitComparator implements Comparator<CoxVariables> {
+public class CoxVariablesOverallModelFitComparator implements Comparator<CoxVariables>, Serializable {
+    private static final long serialVersionUID = 1;
 
 	String variables = "";
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/comparators/MeanModelComparator.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/comparators/MeanModelComparator.java
@@ -23,13 +23,15 @@ package org.biojava.nbio.survival.cox.comparators;
 import org.biojava.nbio.survival.cox.CoxInfo;
 import org.biojava.nbio.survival.cox.CoxVariables;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  *
  * @author Scooter Willis <willishf at gmail dot com>
  */
-public class MeanModelComparator implements Comparator<CoxVariables> {
+public class MeanModelComparator implements Comparator<CoxVariables>, Serializable {
+    private static final long serialVersionUID = 1;
 
 	String variable = "";
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/comparators/SurvivalInfoComparator.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/comparators/SurvivalInfoComparator.java
@@ -22,13 +22,15 @@ package org.biojava.nbio.survival.cox.comparators;
 
 import org.biojava.nbio.survival.cox.SurvivalInfo;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  *
  * @author Scooter Willis <willishf at gmail dot com>
  */
-public class SurvivalInfoComparator implements Comparator<SurvivalInfo> {
+public class SurvivalInfoComparator implements Comparator<SurvivalInfo>, Serializable {
+    private static final long serialVersionUID = 1;
 
 	@Override
 	public int compare(SurvivalInfo t, SurvivalInfo t1) {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/comparators/SurvivalInfoValueComparator.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/comparators/SurvivalInfoValueComparator.java
@@ -22,13 +22,15 @@ package org.biojava.nbio.survival.cox.comparators;
 
 import org.biojava.nbio.survival.cox.SurvivalInfo;
 
+import java.io.Serializable;
 import java.util.Comparator;
 
 /**
  *
  * @author Scooter Willis <willishf at gmail dot com>
  */
-public class SurvivalInfoValueComparator implements Comparator<SurvivalInfo> {
+public class SurvivalInfoValueComparator implements Comparator<SurvivalInfo>, Serializable {
+    private static final long serialVersionUID = 1;
 
 	String variable = "";
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2063 - Comparators should be "Serializable"

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat