### PR TITLE
MMTF roundtripping in Biojava

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -257,6 +257,9 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 		atom.setPDBserial(serialNumber);
 		atom.setName(atomName.trim());
 		atom.setElement(Element.valueOfIgnoreCase(element));
+		if(alternativeLocationId==MmtfStructure.UNAVAILABLE_CHAR_VALUE){
+			alternativeLocationId = ' ';
+		}
 		if (alternativeLocationId != ' ') {
 			// Get the altGroup
 			altGroup = getCorrectAltLocGroup(alternativeLocationId);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -129,7 +129,6 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 				structure.addChain(modelChain, i);
 				String sequence = chainSequenceMap.get(modelChain.getId());
 				MmtfUtils.addSeqRes(modelChain, sequence);
-
 			}
 		}
 		StructureTools.cleanUpAltLocs(structure);
@@ -199,11 +198,12 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 			break;
 		default:
 			group = new HetatomImpl();
+			break;
 		}
 		atomsInGroup = new ArrayList<Atom>();
-		// Set the CC -> empty but not null
 		ChemComp chemComp = new ChemComp();
 		chemComp.setOne_letter_code(String.valueOf(singleLetterCode));
+		chemComp.setType(chemCompType.toUpperCase());
 		ResidueType residueType = ResidueType.getResidueTypeFromString(chemCompType);
 		chemComp.setResidueType(residueType);
 		chemComp.setPolymerType(residueType.polymerType);
@@ -216,7 +216,7 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 					groupNumber, insertionCode);
 		}
 		group.setAtoms(new ArrayList<Atom>(atomCount));
-		if (polymerType != 0) {
+		if (polymerType==1 || polymerType==2) {
 			MmtfUtils.insertSeqResGroup(chain, group, sequenceIndexId);
 		}
 		if (atomCount > 0) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureWriter.java
@@ -82,7 +82,7 @@ public class MmtfStructureWriter {
 						singleLetterCode = chemComp.getOne_letter_code().charAt(0);
 					}
 					mmtfDecoderInterface.setGroupInfo(group.getPDBName(), group.getResidueNumber().getSeqNum(), insCode.charValue(), 
-							chemComp.getType(), atomsInGroup.size(), MmtfUtils.getNumBondsInGroup(atomsInGroup), singleLetterCode,
+							chemComp.getType().toUpperCase(), atomsInGroup.size(), MmtfUtils.getNumBondsInGroup(atomsInGroup), singleLetterCode,
 							sequenceGroups.indexOf(group), MmtfUtils.getSecStructType(group));
 					for (Atom atom : atomsInGroup){
 						char altLoc = MmtfStructure.UNAVAILABLE_CHAR_VALUE;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfUtils.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfUtils.java
@@ -31,6 +31,7 @@ import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.mmcif.ChemCompGroupFactory;
 import org.biojava.nbio.structure.io.mmcif.DownloadChemCompProvider;
+import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.biojava.nbio.structure.quaternary.BioAssemblyInfo;
 import org.biojava.nbio.structure.quaternary.BiologicalAssemblyTransformation;
 import org.biojava.nbio.structure.secstruc.DSSPParser;
@@ -478,7 +479,7 @@ public class MmtfUtils {
 		List<Group> seqResGroups = modelChain.getSeqResGroups();
 		GroupType chainType = getChainType(modelChain.getAtomGroups());
 		for(int i=0; i<sequence.length(); i++){
-			char aa = sequence.charAt(i);
+			char singleLetterCode = sequence.charAt(i);
 			Group group;
 			if(seqResGroups.size()<=i){
 				group=null;
@@ -490,7 +491,7 @@ public class MmtfUtils {
 				group=null;
 				continue;
 			}
-			group = getSeqResGroup(modelChain, aa, chainType);
+			group = getSeqResGroup(modelChain, singleLetterCode, chainType);
 			addGroupAtId(seqResGroups, group, i);
 			seqResGroups.set(i, group);
 			group=null;
@@ -518,15 +519,21 @@ public class MmtfUtils {
 		}		
 	}
 	
-	private static Group getSeqResGroup(Chain modelChain, char aa, GroupType type) {
+	private static Group getSeqResGroup(Chain modelChain, char singleLetterCode, GroupType type) {
 		if(type==GroupType.AMINOACID){
 			AminoAcidImpl a = new AminoAcidImpl();
 			a.setRecordType(AminoAcid.SEQRESRECORD);
-			a.setAminoType(aa);
+			a.setAminoType(singleLetterCode);
+			ChemComp chemComp = new ChemComp();
+			chemComp.setOne_letter_code(""+singleLetterCode);
+			a.setChemComp(chemComp);
 			return a;
 
 		} else if (type==GroupType.NUCLEOTIDE) {
 			NucleotideImpl n = new NucleotideImpl();
+			ChemComp chemComp = new ChemComp();
+			chemComp.setOne_letter_code(""+singleLetterCode);
+			n.setChemComp(chemComp);
 			return n;
 		}
 		else{

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestBasicMmtf.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestBasicMmtf.java
@@ -19,6 +19,7 @@ import org.biojava.nbio.structure.PDBHeader;
 import org.biojava.nbio.structure.ResidueNumber;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureImpl;
+import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -65,6 +66,10 @@ public class TestBasicMmtf {
 		chain.setName("A");
 		Group group = new AminoAcidImpl(); 
 		group.setPDBName("FKF");
+		ChemComp chemComp = new ChemComp();
+		chemComp.setType("TYPfdl");
+		chemComp.setOne_letter_code("A");
+		group.setChemComp(chemComp);
 		Atom atom = new AtomImpl();
 		atom.setName("A");
 		atom.setElement(Element.Ag);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfRoundTrip.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfRoundTrip.java
@@ -1,7 +1,19 @@
 package org.biojava.nbio.structure.io.mmtf;
 
-import java.io.IOException;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.Bond;
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
@@ -28,6 +40,201 @@ public class TestMmtfRoundTrip {
 		new MmtfStructureWriter(structure, writerToEncoder);
 		MmtfStructureReader mmtfStructureReader = new MmtfStructureReader();
 		new StructureDataToAdapter(writerToEncoder, mmtfStructureReader);
-		mmtfStructureReader.getStructure();
+		assertTrue(checkIfAtomsSame(structure,mmtfStructureReader.getStructure()));
 	}
+
+	/**
+	 * Broad test of atom similarity
+	 * @param structOne the first input structure
+	 * @param structTwo the second input structure
+	 * @param mmtfParams
+	 * @return
+	 */
+	private boolean checkIfAtomsSame(Structure structOne, Structure structTwo) {
+		int numModels = structOne.nrModels();
+		if(numModels!=structTwo.nrModels()){
+			System.out.println("Error - diff number models: "+structOne.getPDBCode());
+			return false;
+		}
+		for(int i=0;i<numModels;i++){
+			List<Chain> chainsOne = structOne.getChains(i);
+			List<Chain> chainsTwo = structTwo.getChains(i);
+			if(chainsOne.size()!=chainsTwo.size()){
+				System.out.println("Error - diff number chains: "+structOne.getPDBCode());
+				return false;
+			}
+			// Now make sure they're sorted in the right order
+			sortChains(chainsOne, chainsTwo);
+			// Check that each one has the same number of poly, non-poly and water chains
+			checkDiffChains(structOne, structTwo, i);
+			// Now loop over
+			for(int j=0; j<chainsOne.size();j++){
+				Chain chainOne = chainsOne.get(j);
+				Chain chainTwo = chainsTwo.get(j);
+				// Check they have the same chain id
+				assertEquals(chainOne.getId(), chainTwo.getId());
+				List<Group> groupsOne = chainOne.getAtomGroups();
+				List<Group> groupsTwo = chainTwo.getAtomGroups();
+				if(groupsOne.size()!=groupsTwo.size()){
+					System.out.println("Error - diff number groups: "+structOne.getPDBCode());
+					System.out.println(chainOne.getId()+":"+groupsOne.size()+" "+groupsTwo.size());
+					return false;
+				}
+				for(int k=0; k<groupsOne.size();k++){
+					Group groupOne = groupsOne.get(k);
+					Group groupTwo = groupsTwo.get(k);
+					// Check if the groups are of the same type
+					if(groupOne.getType().equals(groupTwo.getType())==false){
+						System.out.println("Error - diff group type: "+structOne.getPDBCode());
+						System.out.println(groupOne.getPDBName() + " and type: "+groupOne.getType());
+						System.out.println(groupTwo.getPDBName() + " and type: "+groupTwo.getType());;
+					}
+					// Check the single letter amino aicd is correct
+					if(groupOne.getChemComp().getOne_letter_code().length()==1 && groupTwo.getChemComp().getOne_letter_code().length()==1){
+						if(!groupOne.getChemComp().getOne_letter_code().equals(groupTwo.getChemComp().getOne_letter_code())){
+							System.out.println(groupOne.getPDBName());
+						}
+						assertEquals(groupOne.getChemComp().getOne_letter_code(), groupTwo.getChemComp().getOne_letter_code());
+					}
+					assertEquals(groupOne.getType(), groupTwo.getType());
+					assertEquals(groupOne.getResidueNumber().getSeqNum(), groupTwo.getResidueNumber().getSeqNum());
+					assertEquals(groupOne.getResidueNumber().getInsCode(), groupTwo.getResidueNumber().getInsCode());
+					assertEquals(groupOne.getResidueNumber().getChainName(), groupTwo.getResidueNumber().getChainName());
+					if(groupTwo.getAltLocs().size()!=groupOne.getAltLocs().size()){
+						System.out.println("Error - diff number alt locs: "+structOne.getPDBCode()+" "+groupOne.getPDBName()+" "+groupOne.getResidueNumber().getSeqNum());
+						System.out.println(groupOne.getAltLocs().size());
+						System.out.println(groupTwo.getAltLocs().size());
+
+					}
+					// Get the first conf
+					List<Atom> atomsOne = new ArrayList<>(groupOne.getAtoms());
+					List<Atom> atomsTwo = new ArrayList<>(groupTwo.getAtoms());
+
+					for(Group altLocOne: groupOne.getAltLocs()){
+						for(Atom atomAltLocOne: altLocOne.getAtoms()){
+							atomsOne.add(atomAltLocOne);
+						}
+					}
+					for(Group altLocTwo: groupTwo.getAltLocs()){
+						for(Atom atomAltLocTwo: altLocTwo.getAtoms()){
+							atomsTwo.add(atomAltLocTwo);
+						}
+					}
+					if(atomsOne.size()!=atomsTwo.size()){
+						System.out.println("Error - diff number atoms: "+structOne.getPDBCode());
+						System.out.println(groupOne.getResidueNumber());
+						System.out.println(groupOne.getPDBName()+" vs "+groupTwo.getPDBName());
+						System.out.println(atomsOne.size()+" vs "+atomsTwo.size());
+						return false;           
+					}
+					// Now sort the atoms 
+					sortAtoms(atomsOne, atomsTwo);
+					// Now loop through the atoms
+					for(int l=0;l<atomsOne.size();l++){
+						Atom atomOne = atomsOne.get(l);
+						Atom atomTwo = atomsTwo.get(l);
+						assertTrue(atomOne.getGroup().getPDBName().equals(atomTwo.getGroup().getPDBName()));
+						assertTrue(atomOne.getCharge()==atomTwo.getCharge());
+						// Check the coords are the same to three db
+						assertArrayEquals(atomOne.getCoords(), atomTwo.getCoords(), 0.0009999999);
+						assertEquals(atomOne.getTempFactor(), atomTwo.getTempFactor(), 0.009999999);
+						assertEquals(atomOne.getOccupancy(), atomTwo.getOccupancy(), 0.009999999);
+						assertTrue(atomOne.getElement()==atomTwo.getElement());
+						assertTrue(atomOne.getName().equals(atomTwo.getName()));
+						assertTrue(atomOne.getAltLoc()==atomTwo.getAltLoc());
+						if(i==0){
+							if(atomOne.getBonds()==null){
+								if(atomTwo.getBonds()!=null){
+									System.out.println("Null bonds in one and not the other");
+									return false;
+								}
+							}
+							else if(atomTwo.getBonds()==null){
+								System.out.println("Null bonds in one and not the other");
+								return false;
+							}
+							else if(atomOne.getBonds().size()!=atomTwo.getBonds().size()){
+								System.out.println("Error different number of bonds: "+structOne.getPDBCode());
+								System.out.println(atomOne.getBonds().size()+" vs. "+atomTwo.getBonds().size());
+								System.out.println(atomOne);
+								System.out.println(atomTwo);
+								for(Bond bond : atomOne.getBonds()) {
+									System.out.println(bond);
+								}
+								for(Bond bond : atomTwo.getBonds()) {
+									System.out.println(bond);
+								}
+								return false;
+							}
+						}
+					}
+				}
+			}
+		} 
+		return true;
+	}
+	/**
+	 * Check both structures have the same number of poly,non-poly and water chains
+	 * @param structOne the first structure
+	 * @param structTwo the second structure
+	 * @param i the model index
+	 */
+	private void checkDiffChains(Structure structOne, Structure structTwo, int i) {
+		assertEquals(structOne.getPolyChains(i).size(), structTwo.getPolyChains(i).size());
+		assertEquals(structOne.getNonPolyChains(i).size(), structTwo.getNonPolyChains(i).size());
+		assertEquals(structOne.getWaterChains(i).size(), structTwo.getWaterChains(i).size());
+	}
+	/**
+	 * Sort the atom based on PDB serial id
+	 * @param atomsOne the first list
+	 * @param atomsTwo  the second list
+	 */
+	private void sortAtoms(List<Atom> atomsOne, List<Atom> atomsTwo) {
+		atomsOne.sort(new Comparator<Atom>() {
+			@Override
+			public int compare(Atom o1, Atom o2) {
+				//  
+				if (o1.getPDBserial()<o2.getPDBserial()){
+					return -1;
+				}
+				else{
+					return 1;
+				}
+			}
+		});
+		atomsTwo.sort(new Comparator<Atom>() {
+			@Override
+			public int compare(Atom o1, Atom o2) {
+				//  
+				if (o1.getPDBserial()<o2.getPDBserial()){
+					return -1;
+				}
+				else{
+					return 1;
+				}
+			}
+		});  		
+	}
+
+	/**
+	 * Sort the chains based on chain id.
+	 * @param chainsOne the first list of chains
+	 * @param chainsTwo the second list of chains
+	 */
+	private void sortChains(List<Chain> chainsOne, List<Chain> chainsTwo) {
+		Collections.sort(chainsOne, new Comparator<Chain>() {
+			@Override
+			public int compare(Chain o1, Chain o2) {
+				return o1.getId().compareTo(o2.getId());
+			}
+		});
+		Collections.sort(chainsTwo, new Comparator<Chain>() {
+			@Override
+			public int compare(Chain o1, Chain o2) {
+				return o1.getId().compareTo(o2.getId());
+			}
+		});
+
+	}
+
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfRoundTrip.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfRoundTrip.java
@@ -1,0 +1,33 @@
+package org.biojava.nbio.structure.io.mmtf;
+
+import java.io.IOException;
+
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.junit.Test;
+import org.rcsb.mmtf.decoder.StructureDataToAdapter;
+import org.rcsb.mmtf.encoder.AdapterToStructureData;
+
+/**
+ * Tests to see if roundtripping of MMTF can be done.
+ * @author Anthony Bradley
+ *
+ */
+public class TestMmtfRoundTrip {
+
+	/**
+	 * Test that we can round trip a simple structure.
+	 * @throws IOException an error reading the file
+	 * @throws StructureException an error parsing the structure
+	 */
+	@Test
+	public void testRoundTrip() throws IOException, StructureException {
+		Structure structure = StructureIO.getStructure("4CUP");
+		AdapterToStructureData writerToEncoder = new AdapterToStructureData();
+		new MmtfStructureWriter(structure, writerToEncoder);
+		MmtfStructureReader mmtfStructureReader = new MmtfStructureReader();
+		new StructureDataToAdapter(writerToEncoder, mmtfStructureReader);
+		mmtfStructureReader.getStructure();
+	}
+}


### PR DESCRIPTION
1. Fix for the MmtfStructureReader to handle altLoc being a null byte.
2. Ensure groupType is upper case
3. SeqResGroups get a working chemComp
4. Added test that Biojava can roundtrip structures