### PR TITLE
squid:S1206 - "equals(Object obj)" and "hashCode()" should be overrid…

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/BetaBridge.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/BetaBridge.java
@@ -41,6 +41,17 @@ public class BetaBridge {
 	}
 
 	@Override
+        public int hashCode()
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getType().hashCode();
+            result = prime * result + partner1;
+            result = prime * result + partner2;
+            return result;
+        }
+
+	@Override
 	public boolean equals(Object o) {
 
 		if (!(o instanceof BetaBridge))

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucCalc.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucCalc.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -676,6 +677,14 @@ public class SecStrucCalc {
 			buf.append(getSecStrucState(g).getType());
 		}
 		return buf.toString();
+	}
+
+	@Override
+	public int hashCode() {
+	    final int prime = 31;
+	    int result = 1;
+	    result = prime * result + Arrays.hashCode(atoms);
+	    return result;
 	}
 
 	@Override

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucInfo.java
@@ -74,6 +74,15 @@ public class SecStrucInfo {
 	}
 
 	@Override
+	public int hashCode() {
+	    final int prime = 31;
+	    int result = 1;
+	    result = prime * result
+		    + ((assignment == null) ? 0 : type.hashCode());
+	    return result;
+	}
+
+	@Override
 	public boolean equals(Object o) {
 		if (!(o instanceof SecStrucInfo))
 			return false;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/PermutationGroup.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/PermutationGroup.java
@@ -137,6 +137,21 @@ public class PermutationGroup {
 
 	@Override
 	public int hashCode() {
-		return getGroupTable().hashCode();
+	    return getGroupTable().hashCode();
 	}
+
+	@Override
+	public boolean equals(Object obj) {
+	    if (this == obj) {
+		return true;
+	    }
+	    if (obj == null) {
+		return false;
+	    }
+	    if (this.getClass() == obj.getClass()) {
+		return permutations.equals(((PermutationGroup)obj).permutations);
+	    }
+	    return false;
+	}
+
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/SpaceGroup.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/SpaceGroup.java
@@ -37,6 +37,7 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.Serializable;
@@ -374,6 +375,14 @@ public class SpaceGroup implements Serializable {
 	 */
 	public String getTransfAlgebraic(int i) {
 		return transfAlgebraic.get(i);
+	}
+
+	@Override
+	public int hashCode() {
+	    final int prime = 31;
+	    int result = 1;
+	    result = prime * result + id;
+	    return result;
 	}
 
 	@Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - "equals(Object obj)" and "hashCode()" should be overridden in pairs

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1206

Please let me know if you have any questions.

M-Ezzat