### PR TITLE
Cleanup - squid:S2272 - "Iterator.next()" methods should throw "NoSuchElementEx…

### DIFF
--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/GuideTree.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/GuideTree.java
@@ -318,7 +318,11 @@ public class GuideTree<S extends Sequence<C>, C extends Compound> implements Ite
 
 		@Override
 		public GuideTreeNode<S, C> next() {
-			while (hasNext()) {
+            if(!hasNext()){
+                throw new NoSuchElementException();
+            }
+
+            while (hasNext()) {
 				Node next = nodes.peek(), child1 = (Node) next.getChild1(), child2 = (Node) next.getChild2();
 				if (child1 != null && !child1.isVisited()) {
 					nodes.push(child1);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hit.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hit.java
@@ -22,6 +22,8 @@ package org.biojava.nbio.core.search.io;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
+
 import org.biojava.nbio.core.sequence.template.Sequence;
 
 /**
@@ -130,7 +132,10 @@ public abstract class Hit implements Iterable<Hsp>{
 
 			@Override
 			public Hsp next() {
-				return hsps.get(current++);
+                if(!hasNext()){
+                    throw new NoSuchElementException();
+                }
+                return hsps.get(current++);
 			}
 
 			@Override

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Result.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Result.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.NoSuchElementException;
+
 import org.biojava.nbio.core.sequence.template.Sequence;
 
 /**
@@ -168,7 +170,10 @@ public abstract class Result implements Iterable<Hit>{
 
 			@Override
 			public Hit next() {
-				return hits.get(currentResult++);
+                if(!hasNext()){
+                    throw new NoSuchElementException();
+                }
+                return hits.get(currentResult++);
 			}
 
 			@Override

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/SearchIO.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/SearchIO.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.NoSuchElementException;
 
 /**
  * Designed by Paolo Pavan.
@@ -172,7 +173,10 @@ public class SearchIO implements Iterable<Result>{
 
 			@Override
 			public Result next() {
-				return results.get(currentResult++);
+                if(!hasNext()){
+                    throw new NoSuchElementException();
+                }
+                return results.get(currentResult++);
 			}
 
 			@Override

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/views/WindowedSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/views/WindowedSequence.java
@@ -26,6 +26,7 @@ import org.biojava.nbio.core.sequence.template.SequenceView;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * A sliding window view of a sequence which does not implement any
@@ -142,7 +143,10 @@ public class WindowedSequence<C extends Compound> implements Iterable<SequenceVi
 
 		@Override
 		public SequenceView<C> next() {
-			SequenceView<C> v = seq.getSubSequence(currentIndex, currentIndex + offset);
+            if(!hasNext()){
+                throw new NoSuchElementException();
+            }
+            SequenceView<C> v = seq.getSubSequence(currentIndex, currentIndex + offset);
 			currentIndex = currentIndex + window;
 			return v;
 		}

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/LocIterator.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/LocIterator.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * Move a sliding window over a Location.
@@ -169,7 +170,10 @@ public class LocIterator implements Iterator<Location> {
 	@Override
 	public Location next()
 	{
-		return next( mWindowSize, mIncrement );
+        if(!hasNext()){
+            throw new NoSuchElementException();
+        }
+        return next( mWindowSize, mIncrement );
 	}
 
 	/**

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/IntegerOntology.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/IntegerOntology.java
@@ -80,7 +80,10 @@ implements Ontology {
 
 					@Override
 					public Object next() {
-						return resolveInt(i++);
+                        if(!hasNext()){
+                            throw new NoSuchElementException();
+                        }
+                        return resolveInt(i++);
 					}
 
 					@Override

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRange.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRange.java
@@ -275,7 +275,10 @@ public class ResidueRange {
 
 			@Override
 			public ResidueNumber next() {
-				ResidueNumber pos = next.getKey();
+                if(!hasNext()){
+                    throw new NoSuchElementException();
+                }
+                ResidueNumber pos = next.getKey();
 				loadNext();
 				return pos;
 			}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2272 - "Iterator.next()" methods should throw "NoSuchElementException"

You can find more information about the issue here: https://sonarqube.com/coding_rules#rule_key=squid:S2272

Please let me know if you have any questions.

M-Ezzat