### PR TITLE
Cleanup - squid:S1858 - "toString()" should never be called on a Stri…

### DIFF
--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmStructure.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmStructure.java
@@ -301,7 +301,7 @@ public class StockholmStructure {
 	private String[] splitSeqName(String sequenceName) {
 		String[] result = new String[3];
 
-		String[] barSplit = sequenceName.toString().split("/");
+		String[] barSplit = sequenceName.split("/");
 		if (barSplit.length == 2) {
 			result[0] = barSplit[0];
 			String[] positions = barSplit[1].split("-");

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/TranscriptSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/TranscriptSequence.java
@@ -181,7 +181,7 @@ public class TranscriptSequence extends DNASequence {
 
 			DNASequence dnaCodingSequence = null;
 			try {
-				dnaCodingSequence = new DNASequence(codingSequence.toString().toUpperCase());
+				dnaCodingSequence = new DNASequence(codingSequence.toUpperCase());
 			} catch (CompoundNotFoundException e) {
 				// if I understand this should not happen, please correct if I'm wrong - JD 2014-10-24
 				logger.error("Could not create DNA coding sequence, {}. This is most likely a bug.", e.getMessage());

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractCompound.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractCompound.java
@@ -126,6 +126,6 @@ public void setMolecularWeight(Float molecularWeight) {
 			return false;
 		}
 		AbstractCompound them = (AbstractCompound) compound;
-		return this.base.toString().equalsIgnoreCase(them.base.toString());
+		return this.base.equalsIgnoreCase(them.base);
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
@@ -165,10 +165,10 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 		if( path == null) {
 			UserConfiguration config = new UserConfiguration();
 			path = config.getPdbFilePath();
-			logger.debug("Initialising from system property/environment variable to path: {}", path.toString());
+			logger.debug("Initialising from system property/environment variable to path: {}", path);
 		} else {
 			path = FileDownloadUtils.expandUserHome(path);
-			logger.debug("Initialising with path {}", path.toString());
+			logger.debug("Initialising with path {}", path);
 		}
 		this.path = new File(path);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/DownloadChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/DownloadChemCompProvider.java
@@ -224,7 +224,7 @@ public class DownloadChemCompProvider implements ChemCompProvider {
 
 		try ( PrintWriter pw = new PrintWriter(new GZIPOutputStream(new FileOutputStream(localName))) ) {
 
-			pw.print(contents.toString());
+			pw.print(contents);
 			pw.flush();
 		}
 	}

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/ResidualsCoxph.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/ResidualsCoxph.java
@@ -153,7 +153,7 @@ public class ResidualsCoxph {
 	   //     Collections.sort(index);
 
 			for (int m = 0; m < index.size(); m++) {
-				String key = index.get(m).toString();
+				String key = index.get(m);
 				sum[m][j] = sumMap.get(key);
 			}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1858 - "toString()" should never be called on a String object

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1858

Please let me know if you have any questions.

M-Ezzat