### PR TITLE
Fixed the cookbook link in the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ Please visit our [homepage](http://www.biojava.org/).
 
 ### Documentation
 
-The [BioJava Cookbook](http://biojava.org/wiki/BioJava:CookBook) is a collection of simple examples that teach the basics for how to work with BioJava.
+The [BioJava Cookbook](http://biojava.org/wikis/BioJava:CookBook4.0/) is a collection of simple examples that teach the basics for how to work with BioJava.
 We are also working on a [tutorial](https://github.com/biojava/biojava3-tutorial) for biojava (currently only for protein structure modules). 
 
 ### Maven Repository


### PR DESCRIPTION
It was 404 not found. I took the link from the homepage.