### PR TITLE
Fix #537 - handle missing and empty Element column in PDB files

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/PDBFileParserTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/PDBFileParserTest.java
@@ -552,4 +552,56 @@ public class PDBFileParserTest {
 		assertTrue("the created PDB file does not match the input file", pdb.equals(atomLines));
 
 	}
+	
+	/**
+	 * Test handling of missing Element column. Issue 537 in github.
+	 * @author Aleix Lafita
+	 * @throws IOException 
+	 */
+	@Test
+	public void testMissingElements() throws IOException {
+		
+		// A two residue structure without Element column
+		String missingElement =
+				"ATOM      1  N   ASP L   1A     11.095  19.341  20.188  1.00 30.14"+newline+
+				"ATOM      2  CA  ASP L   1A     10.070  18.634  19.379  1.00 28.34"+newline+
+				"ATOM      3  C   ASP L   1A      9.846  17.102  19.503  1.00 26.08"+newline+
+				"ATOM      4  O   ASP L   1A      8.744  16.584  19.162  1.00 23.47"+newline+
+				"ATOM      5  CB  ASP L   1A     10.255  18.858  17.853  1.00 37.55"+newline+
+				"ATOM      6  CG  ASP L   1A      8.836  19.264  17.401  1.00 42.76"+newline+
+				"ATOM      7  OD1 ASP L   1A      8.058  19.292  18.400  1.00 44.03"+newline+
+				"ATOM      8  OD2 ASP L   1A      8.616  19.668  16.244  1.00 46.88"+newline+
+				"ATOM      9  N   CYS L   1      10.835  16.440  20.113  1.00 23.72"+newline+
+				"ATOM     10 CA   CYS L   1      10.769  14.970  20.210  1.00 20.89"+newline+
+				"ATOM     11  C   CYS L   1       9.580  14.524  21.006  1.00 18.64"+newline+
+				"ATOM     12  O   CYS L   1       9.110  15.220  21.912  1.00 19.03"+newline+
+				"ATOM     13  CB  CYS L   1      12.117  14.468  20.771  1.00 21.77"+newline+
+				"ATOM     14  SG  CYS L   1      12.247  14.885  22.538  1.00 20.55"+newline+
+				"TER                                                               "+newline;
+		
+		String original =
+				"ATOM      1  N   ASP L   1A     11.095  19.341  20.188  1.00 30.14           N"+newline+
+				"ATOM      2  CA  ASP L   1A     10.070  18.634  19.379  1.00 28.34           C"+newline+
+				"ATOM      3  C   ASP L   1A      9.846  17.102  19.503  1.00 26.08           C"+newline+
+				"ATOM      4  O   ASP L   1A      8.744  16.584  19.162  1.00 23.47           O"+newline+
+				"ATOM      5  CB  ASP L   1A     10.255  18.858  17.853  1.00 37.55           C"+newline+
+				"ATOM      6  CG  ASP L   1A      8.836  19.264  17.401  1.00 42.76           C"+newline+
+				"ATOM      7  OD1 ASP L   1A      8.058  19.292  18.400  1.00 44.03           O"+newline+
+				"ATOM      8  OD2 ASP L   1A      8.616  19.668  16.244  1.00 46.88           O"+newline+
+				"ATOM      9  N   CYS L   1      10.835  16.440  20.113  1.00 23.72           N"+newline+
+				"ATOM     10  CA  CYS L   1      10.769  14.970  20.210  1.00 20.89           C"+newline+
+				"ATOM     11  C   CYS L   1       9.580  14.524  21.006  1.00 18.64           C"+newline+
+				"ATOM     12  O   CYS L   1       9.110  15.220  21.912  1.00 19.03           O"+newline+
+				"ATOM     13  CB  CYS L   1      12.117  14.468  20.771  1.00 21.77           C"+newline+
+				"ATOM     14  SG  CYS L   1      12.247  14.885  22.538  1.00 20.55           S"+newline+
+				"TER                                                                             "+newline;
+
+		
+		BufferedReader br = new BufferedReader(new StringReader(missingElement));
+		Structure s = parser.parsePDBFile(br);
+		String pdb = s.toPDB();
+		
+		assertTrue("the created PDB file does not match the input file", pdb.equals(original));
+		
+	}
 }

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/PDBFileParserTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/PDBFileParserTest.java
@@ -579,6 +579,24 @@ public class PDBFileParserTest {
 				"ATOM     14  SG  CYS L   1      12.247  14.885  22.538  1.00 20.55"+newline+
 				"TER                                                               "+newline;
 		
+		// A two residue structure with empty Element column
+		String emptyElement =
+				"ATOM      1  N   ASP L   1A     11.095  19.341  20.188  1.00 30.14            "+newline+
+				"ATOM      2  CA  ASP L   1A     10.070  18.634  19.379  1.00 28.34            "+newline+
+				"ATOM      3  C   ASP L   1A      9.846  17.102  19.503  1.00 26.08            "+newline+
+				"ATOM      4  O   ASP L   1A      8.744  16.584  19.162  1.00 23.47            "+newline+
+				"ATOM      5  CB  ASP L   1A     10.255  18.858  17.853  1.00 37.55            "+newline+
+				"ATOM      6  CG  ASP L   1A      8.836  19.264  17.401  1.00 42.76            "+newline+
+				"ATOM      7  OD1 ASP L   1A      8.058  19.292  18.400  1.00 44.03            "+newline+
+				"ATOM      8  OD2 ASP L   1A      8.616  19.668  16.244  1.00 46.88            "+newline+
+				"ATOM      9  N   CYS L   1      10.835  16.440  20.113  1.00 23.72            "+newline+
+				"ATOM     10  CA  CYS L   1      10.769  14.970  20.210  1.00 20.89            "+newline+
+				"ATOM     11  C   CYS L   1       9.580  14.524  21.006  1.00 18.64            "+newline+
+				"ATOM     12  O   CYS L   1       9.110  15.220  21.912  1.00 19.03            "+newline+
+				"ATOM     13  CB  CYS L   1      12.117  14.468  20.771  1.00 21.77            "+newline+
+				"ATOM     14  SG  CYS L   1      12.247  14.885  22.538  1.00 20.55            "+newline+
+				"TER                                                                             "+newline;
+		
 		String original =
 				"ATOM      1  N   ASP L   1A     11.095  19.341  20.188  1.00 30.14           N"+newline+
 				"ATOM      2  CA  ASP L   1A     10.070  18.634  19.379  1.00 28.34           C"+newline+
@@ -600,8 +618,13 @@ public class PDBFileParserTest {
 		BufferedReader br = new BufferedReader(new StringReader(missingElement));
 		Structure s = parser.parsePDBFile(br);
 		String pdb = s.toPDB();
+		assertTrue("the Element column has not been filled correctly", pdb.equals(original));
 		
-		assertTrue("the created PDB file does not match the input file", pdb.equals(original));
+		
+		br = new BufferedReader(new StringReader(emptyElement));
+		s = parser.parsePDBFile(br);
+		pdb = s.toPDB();
+		assertTrue("the Element column has not been filled correctly", pdb.equals(original));
 		
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -1828,17 +1828,27 @@ public class PDBFileParser  {
 		// missing (i.e. misformatted PDB file), then parse the
 		// element from the chemical component.
 		Element element = Element.R;
+		boolean guessElement = true;
 		if ( line.length() > 77 ) {
 			// parse element from element field
-			String elementSymbol = line.substring (76, 78).trim();
-			try {
-				element = Element.valueOfIgnoreCase(elementSymbol);
-			}  catch (IllegalArgumentException e){
-				logger.warn("Element {} was not recognised. Assigning generic element R to it", elementSymbol);
+			String elementSymbol = line.substring(76, 78).trim();
+			if (elementSymbol.equals("")) {
+				logger.warn("Element column was empty. Assigning atom element "
+						+ "from Chemical Component Dictionary information", elementSymbol);
+			} else {
+				try {
+					element = Element.valueOfIgnoreCase(elementSymbol);
+					guessElement = false;
+				}  catch (IllegalArgumentException e){
+					logger.warn("Element {} was not recognised. Assigning atom element "
+							+ "from Chemical Component Dictionary information", elementSymbol);
+				}
 			}
 		} else {
 			logger.warn("Missformatted PDB file: element column is not present. "
-					+ "Assigning atom elements from Chemical Component Dictionary information");
+					+ "Assigning atom element from Chemical Component Dictionary information");
+		}
+		if (guessElement) {
 			String elementSymbol = null;
 			if (currentGroup.getChemComp() != null) {
 				for (ChemCompAtom a : currentGroup.getChemComp().getAtoms()) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -1832,21 +1832,23 @@ public class PDBFileParser  {
 		if ( line.length() > 77 ) {
 			// parse element from element field
 			String elementSymbol = line.substring(76, 78).trim();
-			if (elementSymbol.equals("")) {
-				logger.warn("Element column was empty. Assigning atom element "
-						+ "from Chemical Component Dictionary information", elementSymbol);
+			if (elementSymbol.isEmpty()) {
+				logger.warn("Element column was empty for atom {} {}. Assigning atom element "
+						+ "from Chemical Component Dictionary information", fullname.trim(), pdbnumber);
 			} else {
 				try {
 					element = Element.valueOfIgnoreCase(elementSymbol);
 					guessElement = false;
 				}  catch (IllegalArgumentException e){
-					logger.warn("Element {} was not recognised. Assigning atom element "
-							+ "from Chemical Component Dictionary information", elementSymbol);
+					logger.warn("Element {} of atom {} {} was not recognised. Assigning atom element "
+							+ "from Chemical Component Dictionary information", elementSymbol, 
+							fullname.trim(), pdbnumber);
 				}
 			}
 		} else {
-			logger.warn("Missformatted PDB file: element column is not present. "
-					+ "Assigning atom element from Chemical Component Dictionary information");
+			logger.warn("Missformatted PDB file: element column of atom {} {} is not present. "
+					+ "Assigning atom element from Chemical Component Dictionary information",
+					fullname.trim(), pdbnumber);
 		}
 		if (guessElement) {
 			String elementSymbol = null;


### PR DESCRIPTION
The element information is filled using the **Chemical Component Dictionary** information, as discussed in #537.