### PR TITLE
Version 1.0.0 of MMTF changes

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/BondMaker.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/BondMaker.java
@@ -454,7 +454,10 @@ public class BondMaker {
 				if (g==null)
 					throw new StructureException("Could not find altLoc code "+altLoc+" in group "+resSeq+iCode+" of chain "+ chainID);
 			}
-			outMap.put(i,g.getAtom(name));
+			Atom a = g.getAtom(name);
+			if (a!=null){
+				outMap.put(i,a);
+			}
 		}
 		return outMap;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/BondMaker.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/BondMaker.java
@@ -281,8 +281,10 @@ public class BondMaker {
 				if(a.containsKey(i) && b.containsKey(i)){
 					// TODO determine what the actual bond order of this bond is; for
 					// now, we're assuming they're single bonds
-					Bond ssbond =  new BondImpl(a.get(i), b.get(i), 1);
-					structure.addSSBond(ssbond);
+					if(!a.get(i).equals(b.get(i))){
+						Bond ssbond =  new BondImpl(a.get(i), b.get(i), 1);
+						structure.addSSBond(ssbond);
+					}
 				}
 			}
 
@@ -322,7 +324,9 @@ public class BondMaker {
 				if(a.containsKey(i) && b.containsKey(i)){
 					// TODO determine what the actual bond order of this bond is; for
 					// now, we're assuming they're single bonds
-					new BondImpl(a.get(i), b.get(i), 1);
+					if(!a.get(i).equals(b.get(i))){
+						new BondImpl(a.get(i), b.get(i), 1);
+					}
 				}
 			}
 		}catch (StructureException e) {
@@ -336,7 +340,7 @@ public class BondMaker {
 		}
 	}
 
-	
+
 	public void formBondsFromStructConn(List<StructConn> structConn) {
 
 		final String symop = "1_555"; // For now - accept bonds within origin asymmetric unit.
@@ -413,7 +417,9 @@ public class BondMaker {
 			for(int i=0; i<structure.nrModels(); i++){
 				Bond bond = null;
 				if(a1.containsKey(i) && a2.containsKey(i)){
-					bond = new BondImpl(a1.get(i), a2.get(i), 1);
+					if(!a1.get(i).equals(a2.get(i))){
+						bond = new BondImpl(a1.get(i), a2.get(i), 1);
+					}
 				}
 				if(bond!=null){
 					if (conn.getConn_type_id().equals("disulf")) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -29,6 +29,7 @@ import org.biojava.nbio.structure.PDBHeader;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureImpl;
 import org.biojava.nbio.structure.StructureTools;
+import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
 import org.biojava.nbio.structure.io.mmcif.chem.ResidueType;
 import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.biojava.nbio.structure.quaternary.BioAssemblyInfo;
@@ -185,7 +186,8 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 			char insertionCode, String chemCompType, int atomCount, int bondCount,
 			char singleLetterCode, int sequenceIndexId, int secStructType) {
 		// Get the polymer type
-		int polymerType = getGroupTypIndicator(chemCompType);
+		ResidueType residueType = ResidueType.getResidueTypeFromString(chemCompType);
+		int polymerType = getGroupTypIndicator(residueType.polymerType);
 		switch (polymerType) {
 		case 1:
 			AminoAcid aa = new AminoAcidImpl();
@@ -204,7 +206,6 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 		ChemComp chemComp = new ChemComp();
 		chemComp.setOne_letter_code(String.valueOf(singleLetterCode));
 		chemComp.setType(chemCompType.toUpperCase());
-		ResidueType residueType = ResidueType.getResidueTypeFromString(chemCompType);
 		chemComp.setResidueType(residueType);
 		chemComp.setPolymerType(residueType.polymerType);
 		group.setChemComp(chemComp);
@@ -400,33 +401,14 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 	 * @param currentGroup
 	 * @return The type of group. (0,1 or 2) depending on whether it is an amino aicd (1), nucleic acid (2) or ligand (0)
 	 */
-	private int getGroupTypIndicator(String currentGroupType) {
-		// At the moment - peptide like is a HETATM group (consistent with biojava)
-		if("PEPTIDE-LIKE".equalsIgnoreCase(currentGroupType)){
-			return 0;
-		}
-		// Again to correspond with Biojava - but I suspect we really want this to be 1
-		if("D-PEPTIDE LINKING".equalsIgnoreCase(currentGroupType)){
-			return 0;
-		}
-		if(currentGroupType.toUpperCase().contains("D-GAMMA-PEPTIDE")){
-			return 0;
-		}
-		if(currentGroupType.toUpperCase().contains("D-BETA-PEPTIDE")){
-			return 0;
-		}	
-                if(currentGroupType.toUpperCase().contains("D-PEPTIDE")){
-                        return 0;
-                }
-		if(currentGroupType.toUpperCase().contains("PEPTIDE")){
+	private int getGroupTypIndicator(PolymerType polymerType) {
+		if(PolymerType.PROTEIN_ONLY.contains(polymerType)){
 			return 1;
 		}
-		if(currentGroupType.toUpperCase().contains("DNA") || currentGroupType.toUpperCase().contains("RNA")){
+		if(PolymerType.POLYNUCLEOTIDE_ONLY.contains(polymerType)){
 			return 2;
 		}
-		else{
-			return 0;
-		}
+		return 0;
 	}
 
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -409,6 +409,9 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 		if("D-PEPTIDE LINKING".equalsIgnoreCase(currentGroupType)){
 			return 0;
 		}
+		if(currentGroupType.toUpperCase().contains("D-GAMMA-PEPTIDE")){
+			return 0;
+		}		
 		if(currentGroupType.toUpperCase().contains("PEPTIDE")){
 			return 1;
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -411,7 +411,13 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 		}
 		if(currentGroupType.toUpperCase().contains("D-GAMMA-PEPTIDE")){
 			return 0;
-		}		
+		}
+		if(currentGroupType.toUpperCase().contains("D-BETA-PEPTIDE")){
+			return 0;
+		}	
+                if(currentGroupType.toUpperCase().contains("D-PEPTIDE")){
+                        return 0;
+                }
 		if(currentGroupType.toUpperCase().contains("PEPTIDE")){
 			return 1;
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureWriter.java
@@ -159,22 +159,25 @@ public class MmtfStructureWriter {
 			if (entityChains.isEmpty()){
 				// Error mapping chain to entity
 				System.err.println("ERROR MAPPING CHAIN TO ENTITY: "+description);
+				mmtfDecoderInterface.setEntityInfo(new int[0], "", description, type);
 				continue;
 			}
-			int[] chainIndices = new int[entityChains.size()];
-			for (int i=0; i<entityChains.size(); i++) {
-				chainIndices[i] = allChains.indexOf(entityChains.get(i));
-			}
-			Chain chain = entityChains.get(0);
-			ChainImpl chainImpl;
-			if (chain instanceof ChainImpl){
-				chainImpl = (ChainImpl) entityChains.get(0);
-			}
 			else{
-				throw new RuntimeException();
+				int[] chainIndices = new int[entityChains.size()];
+				for (int i=0; i<entityChains.size(); i++) {
+					chainIndices[i] = allChains.indexOf(entityChains.get(i));
+				}
+				Chain chain = entityChains.get(0);
+				ChainImpl chainImpl;
+				if (chain instanceof ChainImpl){
+					chainImpl = (ChainImpl) entityChains.get(0);
+				}
+				else{
+					throw new RuntimeException();
+				}
+				String sequence = chainImpl.getSeqResOneLetterSeq();
+				mmtfDecoderInterface.setEntityInfo(chainIndices, sequence, description, type);
 			}
-			String sequence = chainImpl.getSeqResOneLetterSeq();
-			mmtfDecoderInterface.setEntityInfo(chainIndices, sequence, description, type);
 		}		
 	}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
@@ -228,7 +228,37 @@ public class TestBond {
 			}
 		}
 		return nonBondedCounter;
+	}
 
+	private int testBondedToSelf(String pdbId) throws IOException, StructureException {
+		Structure inputStructure = StructureIO.getStructure(pdbId);
+		int bondedToSelf =0;
+		for(int i=0;i<inputStructure.nrModels();i++){
+			for(Chain c: inputStructure.getChains(i)){
+				for(Group g: c.getAtomGroups()){
+					// Skip single atom groups
+					if(g.size()<=1){
+						continue;
+					}
+					// Get all the atoms
+					List<Atom> atomsList = new ArrayList<>(g.getAtoms());
+					for(Group altLocOne: g.getAltLocs()){
+						atomsList.addAll(altLocOne.getAtoms());
+					}
+					// Check they all have bonds
+					for(Atom a: atomsList){
+						if(a.getBonds()!=null){
+						for(Bond b: a.getBonds()){
+							if(b.getAtomA().equals(b.getAtomB())){
+								bondedToSelf+=1;
+							}
+						}
+						}
+					}
+				}
+			}
+		}
+		return bondedToSelf;
 	}
 
 
@@ -284,6 +314,14 @@ public class TestBond {
 	@Test
 	public void testWeirdCase() throws IOException, StructureException {
 		assertEquals(testMissingBonds("1IU6"),6);
+	}
+
+
+	@Test
+	public void testSSBonds() throws IOException, StructureException {
+		for(String pdbCode : new String[]{"3ZXW",	"1NTY", "4H2I", "2K6D", "2MLM"}){
+			assertEquals(testBondedToSelf(pdbCode),0);
+		}
 	}
 
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
@@ -293,8 +293,8 @@ public class TestBond {
 
 	/**
 	 * Test that all the atoms in deuterated structures are bonded.
-	 * @throws IOException
-	 * @throws StructureException
+	 * @throws IOException an error getting the required file
+	 * @throws StructureException an error parsing the required file
 	 */
 	@Test
 	public void testDeuterated() throws IOException, StructureException {
@@ -308,8 +308,8 @@ public class TestBond {
 	/**
 	 * Test this weird case - with missing Oxygen atoms, alternate locations on Deuterium 
 	 * and terminal hydrogens.
-	 * @throws IOException
-	 * @throws StructureException
+	 * @throws IOException an error getting the required file
+	 * @throws StructureException an error parsing the required file
 	 */
 	@Test
 	public void testWeirdCase() throws IOException, StructureException {
@@ -317,9 +317,14 @@ public class TestBond {
 	}
 
 
+	/**
+	 * Test that Sulphur atoms are not found to be bonded to them selves
+	 * @throws IOException an error getting the required file
+	 * @throws StructureException an error parsing the required file
+	 */
 	@Test
 	public void testSSBonds() throws IOException, StructureException {
-		for(String pdbCode : new String[]{"3ZXW",	"1NTY", "4H2I", "2K6D", "2MLM"}){
+		for(String pdbCode : new String[]{"3ZXW","1NTY", "4H2I", "2K6D", "2MLM"}){
 			assertEquals(testBondedToSelf(pdbCode),0);
 		}
 	}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestBond.java
@@ -318,7 +318,7 @@ public class TestBond {
 
 
 	/**
-	 * Test that Sulphur atoms are not found to be bonded to them selves
+	 * Test that Sulphur atoms are not found to be bonded to themselves
 	 * @throws IOException an error getting the required file
 	 * @throws StructureException an error parsing the required file
 	 */

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>
 		<maxmem>512M</maxmem>
-		<mmtf.version>0.2.2</mmtf.version>
+		<mmtf.version>1.0.0</mmtf.version>
 		<slf4j.version>1.7.21</slf4j.version>
 		<log4j.version>2.6.1</log4j.version>
 	</properties>


### PR DESCRIPTION
- Fixed issues with reading a few MMTF files (related to hetatm vs amino)
- Fixed a bug in generation of disulphide bonds - including a test case.
- Fixed a null pointer exception from getAtomFromRecord
- Fixed handling of entities with no chains
- Upgrade to v1.0.0
- Fixed the formatting and added some javadocs