### PR TITLE
Update Jmol

### DIFF
--- a/biojava-structure-gui/pom.xml
+++ b/biojava-structure-gui/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>net.sourceforge.jmol</groupId>
             <artifactId>jmol</artifactId>
-            <version>14.6.1_2016.08.20</version>
+            <version>14.6.2_2016.08.28</version>
         </dependency>
         <!-- logging dependencies (managed by parent pom, don't set versions or
             scopes here) -->

--- a/biojava-structure-gui/pom.xml
+++ b/biojava-structure-gui/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>net.sourceforge.jmol</groupId>
             <artifactId>jmol</artifactId>
-            <version>13.0.14</version>
+            <version>14.6.1_2016.08.20</version>
         </dependency>
         <!-- logging dependencies (managed by parent pom, don't set versions or
             scopes here) -->

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/AbstractAlignmentJmol.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/AbstractAlignmentJmol.java
@@ -41,6 +41,7 @@ import org.biojava.nbio.structure.align.util.ResourceManager;
 import org.biojava.nbio.structure.jama.Matrix;
 import org.jcolorbrewer.ColorBrewer;
 import org.jmol.api.JmolViewer;
+import org.jmol.viewer.Viewer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,7 +103,7 @@ implements MouseMotionListener, MouseListener, WindowListener, ActionListener {
 	public void setAtoms(Atom[] atoms){
 		Structure s = new StructureImpl();
 		Chain c = new ChainImpl();
-		c.setChainID("A");
+		c.setId("A");
 		for (Atom a: atoms){
 			c.addGroup(a.getGroup());
 		}
@@ -219,7 +220,7 @@ implements MouseMotionListener, MouseListener, WindowListener, ActionListener {
 		int pos = viewer.findNearestAtomIndex( e.getX(), e.getY() );
 		if ( pos == -1 ) { return ; }
 
-		String atomInfo = viewer.getAtomInfo(pos);
+		String atomInfo = ((Viewer) viewer).getAtomInfo(pos);
 		text.setText(atomInfo);
 
 	}
@@ -243,7 +244,7 @@ implements MouseMotionListener, MouseListener, WindowListener, ActionListener {
 		int pos = viewer.findNearestAtomIndex(e.getX(), e.getY());
 		if (pos == -1) return;
 
-		String atomInfo = viewer.getAtomInfo(pos);
+		String atomInfo = ((Viewer) viewer).getAtomInfo(pos);
 		status.setText("clicked: " + atomInfo);
 		AtomInfo ai = AtomInfoParser.parse(atomInfo);
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolPanel.java
@@ -117,8 +117,8 @@ implements ActionListener
 	public void setStructure(Structure s)
 	{
 		this.structure = s;
-		String pdb = s.toPDB();
-		viewer.openStringInline(pdb);
+		String serialized = s.toMMCIF();
+		viewer.openStringInline(serialized);
 		evalString("save STATE state_1");
 	}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/JmolPanel.java
@@ -38,9 +38,12 @@ import org.jmol.adapter.smarter.SmarterJmolAdapter;
 import org.jmol.api.JmolAdapter;
 import org.jmol.api.JmolStatusListener;
 import org.jmol.api.JmolViewer;
-import org.jmol.util.Logger;
+import org.jmol.util.LoggerInterface;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.swing.*;
+
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -52,6 +55,8 @@ public class JmolPanel
 extends JPrintPanel
 implements ActionListener
 {
+	private static final Logger logger = LoggerFactory.getLogger(JmolPanel.class);
+	
 	private static final long serialVersionUID = -3661941083797644242L;
 
 	private JmolViewer viewer;
@@ -62,13 +67,13 @@ implements ActionListener
 
 	Structure structure;
 
-	private boolean verbose = false;
-
 	public JmolPanel() {
 		super();
 		statusListener = new MyJmolStatusListener();
 		adapter = new SmarterJmolAdapter();
-		Logger.setLogLevel( verbose?Logger.LEVEL_INFO:Logger.LEVEL_ERROR);
+		JmolLoggerAdapter jmolLogger = new JmolLoggerAdapter(LoggerFactory.getLogger(org.jmol.api.JmolViewer.class));
+		org.jmol.util.Logger.setLogger(jmolLogger);
+		org.jmol.util.Logger.setLogLevel( jmolLogger.getLogLevel() );
 		viewer = JmolViewer.allocateViewer(this,
 				adapter,
 				null,null,null,null,
@@ -173,7 +178,8 @@ implements ActionListener
 			return;
 		}
 
-		JComboBox source = (JComboBox) event.getSource();
+		@SuppressWarnings("unchecked")
+		JComboBox<String> source = (JComboBox<String>) event.getSource();
 		String value = source.getSelectedItem().toString();
 		evalString("save selection; ");
 
@@ -267,7 +273,7 @@ implements ActionListener
 			List<String>ranges = domain.getRanges();
 
 			for (String range : ranges){
-				if(verbose) System.out.println(range);
+				logger.debug(range);
 				String[] spl = range.split(":");
 				String script = " select  ";
 				if ( spl.length > 1 )
@@ -276,7 +282,7 @@ implements ActionListener
 					script += "*" + spl[0]+"/1;";
 				script += " color [" + c1.getRed() + ","+c1.getGreen() + "," +c1.getBlue()+"];";
 				script += " color cartoon [" + c1.getRed() + ","+c1.getGreen() + "," +c1.getBlue()+"] ;";
-				if(verbose) System.out.println(script);
+				logger.debug(script);
 				evalString(script);
 
 			}
@@ -286,7 +292,7 @@ implements ActionListener
 	}
 
 	private void colorByPDP() {
-		if(verbose) System.out.println("colorByPDP");
+		logger.debug("colorByPDP");
 		if ( structure == null)
 			return;
 
@@ -310,13 +316,13 @@ implements ActionListener
 					int end = s.getTo();
 					Group startG = ca[start].getGroup();
 					Group endG = ca[end].getGroup();
-					if(verbose) System.out.println("   Segment: " +startG.getResidueNumber() +":" + startG.getChainId() + " - " + endG.getResidueNumber()+":"+endG.getChainId() + " " + s);
+					logger.debug("   Segment: " +startG.getResidueNumber() +":" + startG.getChainId() + " - " + endG.getResidueNumber()+":"+endG.getChainId() + " " + s);
 					String j1 = startG.getResidueNumber()+"";
 					String j2 = endG.getResidueNumber()+":"+endG.getChainId();
 					String script = " select  " +j1 +"-" +j2 +"/1;";
 					script += " color [" + c1.getRed() + ","+c1.getGreen() + "," +c1.getBlue()+"];";
 					script += " color cartoon [" + c1.getRed() + ","+c1.getGreen() + "," +c1.getBlue()+"] ;";
-					if(verbose) System.out.println(script);
+					logger.debug(script);
 					evalString(script);
 				}
 
@@ -356,15 +362,55 @@ implements ActionListener
 		adapter = null;
 	}
 
-	public boolean isVerbose() {
-		return verbose;
-	}
-
-	public void setVerbose(boolean verbose) {
-		this.verbose = verbose;
-		if(statusListener instanceof MyJmolStatusListener) {
-			((MyJmolStatusListener)statusListener).setVerbose(verbose);
+	public static class JmolLoggerAdapter implements LoggerInterface {
+		private Logger slf;
+		public JmolLoggerAdapter(Logger slf) {
+			this.slf=slf;
+		}
+		public int getLogLevel() {
+			if( slf.isTraceEnabled() )
+				return org.jmol.util.Logger.LEVEL_MAX;
+			if( slf.isDebugEnabled() )
+				return org.jmol.util.Logger.LEVEL_DEBUG;
+			if( slf.isInfoEnabled() )
+				return org.jmol.util.Logger.LEVEL_INFO;
+			if( slf.isWarnEnabled() )
+				return org.jmol.util.Logger.LEVEL_WARN;
+			if( slf.isErrorEnabled() )
+				return org.jmol.util.Logger.LEVEL_ERROR;
+			throw new IllegalStateException("Unknown SLF4J error level");
+		}
+		@Override
+		public void debug(String txt) {
+			slf.debug(txt);
+		}
+		@Override
+		public void info(String txt) {
+			slf.info(txt);
+		}
+		@Override
+		public void warn(String txt) {
+			slf.warn(txt);
+		}
+		@Override
+		public void warnEx(String txt, Throwable e) {
+			slf.warn(txt,e);
+		}
+		@Override
+		public void error(String txt) {
+			slf.error(txt);
+		}
+		@Override
+		public void errorEx(String txt, Throwable e) {
+			slf.error(txt,e);
+		}
+		@Override
+		public void fatal(String txt) {
+			slf.error(txt);
+		}
+		@Override
+		public void fatalEx(String txt, Throwable e) {
+			slf.error(txt,e);
 		}
 	}
-
 }

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/MyJmolStatusListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/MyJmolStatusListener.java
@@ -24,17 +24,17 @@
 
 package org.biojava.nbio.structure.align.gui.jmol;
 
-import org.jmol.api.JmolStatusListener;
-import org.jmol.constant.EnumCallback;
-
-import javax.swing.*;
-
-import java.util.Hashtable;
 import java.util.Map;
 
-public class MyJmolStatusListener implements JmolStatusListener {
+import javax.swing.JTextField;
 
-	private boolean verbose = false;
+import org.jmol.api.JmolStatusListener;
+import org.jmol.c.CBK;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MyJmolStatusListener implements JmolStatusListener {
+	private static final Logger logger = LoggerFactory.getLogger(MyJmolStatusListener.class);
 
 	JTextField status;
 	public MyJmolStatusListener(){
@@ -46,33 +46,30 @@ public class MyJmolStatusListener implements JmolStatusListener {
 
 	@Override
 	public String createImage(String arg0, String arg1, Object arg2, int arg3) {
-		// TODO Auto-generated method stub
-		return null;
+		return null; //Cancelled
 	}
 
 	@Override
 	public String eval(String arg0) {
-		if(verbose) System.out.println("eval " + arg0);
+		logger.debug("eval {}",arg0);
 		return null;
 	}
 
 	@Override
 	public float[][] functionXY(String arg0, int arg1, int arg2) {
-		if(verbose) System.out.println("XY " + arg0 + " " + arg1 + " " + arg2);
-		return null;
+		logger.debug("XY {} {} {}",arg0,arg1, arg2);
+		return null; //Ignore isosurface commands
 	}
 
 	@Override
 	public float[][][] functionXYZ(String arg0, int arg1, int arg2, int arg3) {
-		// TODO Auto-generated method stub
-		return null;
+		logger.debug("XYZ {} {} {} {}",arg0,arg1, arg2, arg3);
+		return null; //Ignore isosurface commands
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
-	public Hashtable getRegistryInfo() {
-		// TODO Auto-generated method stub
-		return null;
+	public Map<String, Object> getRegistryInfo() {
+		return null; //Ignore
 	}
 
 	@Override
@@ -87,79 +84,48 @@ public class MyJmolStatusListener implements JmolStatusListener {
 	}
 
 	public boolean notifyEnabled(int arg0) {
-		// TODO Auto-generated method stub
 		return false;
 	}
 
 	@Override
 	public void setCallbackFunction(String arg0, String arg1) {
-		if(verbose) System.out.println("callback:" + arg0 + " " + arg1);
+		logger.debug("callback: {} {}", arg0, arg1);
 		status.setText(arg0 + " " + arg1);
-
 	}
 
 	public String dialogAsk(String arg0, String arg1) {
-		// TODO Auto-generated method stub
-		if(verbose) System.out.println("dialogAsk");
-		return null;
+		logger.debug("dialogAsk {} {}",arg0,arg1);
+		return null; //Ignore
 	}
 
 	public void handlePopupMenu(int arg0, int arg1) {
-		// TODO Auto-generated method stub
-		if(verbose) System.out.println("handlePopupMenu");
+		logger.debug("handlePopupMenu {} {}",arg0,arg1);
 	}
 
 	public void showConsole(boolean arg0) {
-
-		// TODO Auto-generated method stub
-		if(verbose) System.out.println("showConsole");
-
+		logger.debug("showConsole {}",arg0);
 	}
 
 
-	@Override
-	public void notifyCallback(EnumCallback arg0, Object[] arg1) {
-		// TODO Auto-generated method stub
 
+	@Override
+	public void notifyCallback(CBK message, Object[] data) {
 	}
 
-
 	@Override
-	public boolean notifyEnabled(EnumCallback arg0) {
-		// TODO Auto-generated method stub
+	public boolean notifyEnabled(CBK type) {
 		return false;
 	}
 
-
 	@Override
-	public Map<String, Object> getProperty(String arg0) {
-		// TODO Auto-generated method stub
-		return null;
-	}
-
-
-
 	public Map<String, Object> getJSpecViewProperty(String arg0) {
-		// TODO Auto-generated method stub
 		return null;
 	}
 
 
 	@Override
-	public void resizeInnerPanel(String data) {
-		// TODO Auto-generated method stub
-
+	public int[] resizeInnerPanel(String data) {
+		return null;
 	}
-
-	public boolean isVerbose() {
-		return verbose;
-	}
-
-	public void setVerbose(boolean verbose) {
-		this.verbose = verbose;
-	}
-
-
-
 
 }


### PR DESCRIPTION
Also uses mmCIF for communication with Jmol.

This was an important step for #462 to make chain renaming more robust. It also takes a step towards #201, although MMTF (or direct Java data structures) might make more sense.