### PR TITLE
Solving issue 582

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Atom.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Atom.java
@@ -25,6 +25,8 @@ package org.biojava.nbio.structure;
 
 import java.util.List;
 
+import javax.vecmath.Point3d;
+
 /**
  * A simple interface for an Atom.
  * The coordinates can be accessed via the
@@ -94,10 +96,21 @@ public interface Atom extends Cloneable, PDBRecord {
 
 	/**
 	 * Get the coordinates.
-	 * @return an array of doubles representing the coords value
+	 * @return a new array of doubles representing the coords value
 	 * @see #setCoords
+	 * @see #getCoordsAsPoint3d()
 	 */
 	public double[] getCoords() ;
+	
+	/**
+	 * Get the coordinates.
+	 * <p> 
+	 * Internally the coordinates are represented as Point3d so this 
+	 * is recommended over {@link #getCoords()}
+	 * @return a reference to the Point3d coordinates
+	 * @see #getCoords()
+	 */
+	public Point3d getCoordsAsPoint3d();	
 
 	/**
 	 * Set the X coordinate.

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomImpl.java
@@ -29,6 +29,8 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.vecmath.Point3d;
+
 
 /**
  * Implementation of an Atom of a PDB file.
@@ -47,11 +49,11 @@ public class AtomImpl implements Atom, Serializable, PDBRecord {
 	 */
 	public static final int BONDS_INITIAL_CAPACITY = 3;
 
-	private String name     ;
-	private Element element;
-	private double[] coords ;
-	private int pdbserial   ;
-	private short charge		;
+	private String name;
+	private Element element;	
+	private Point3d coords;
+	private int pdbserial;
+	private short charge;
 
 	private float occupancy ;
 	private float tempfactor;
@@ -62,15 +64,15 @@ public class AtomImpl implements Atom, Serializable, PDBRecord {
 	private List<Bond> bonds;
 
 	public AtomImpl () {
-		name       = null        ;
+		name       = null;
 		element    = Element.R;
-		coords     = new double[3];
-		occupancy  = 0.0f       ;
-		tempfactor = 0.0f       ;
+		coords	   = new Point3d();
+		occupancy  = 0.0f;
+		tempfactor = 0.0f;
 		altLoc 	   = 0;
 		parent     = null;
 		bonds      = null; // let's save some memory and let's not initialise this until it's needed - JD 2016-03-02
-		charge     = 0				;
+		charge     = 0;
 	}
 
 	/**
@@ -101,44 +103,60 @@ public class AtomImpl implements Atom, Serializable, PDBRecord {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void     setCoords( double[] c ) { coords = c   ; }
+	public void     setCoords( double[] c ) { 
+		coords = new Point3d(c); 
+	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public double[] getCoords()            { return coords ; }
+	public double[] getCoords() { 
+		double[] c = new double[3];
+		coords.get(c);
+		return c;		
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Point3d getCoordsAsPoint3d() {
+		return coords;
+	}
 
 	@Override
 	public void setX(double x) {
-		coords[0] = x ;
+		coords.x = x ;
 	}
+	
 	@Override
 	public void setY(double y) {
-		coords[1] = y ;
+		coords.y = y ;
 	}
+	
 	@Override
 	public void setZ(double z) {
-		coords[2] = z ;
+		coords.z = z ;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public double getX() { return coords[0]; }
+	public double getX() { return coords.x; }
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public double getY() { return coords[1]; }
+	public double getY() { return coords.y; }
 
 	/**
 	 * {@inheritDoc}
 	 */
 	@Override
-	public double getZ() { return coords[2]; }
+	public double getZ() { return coords.z; }
 
 	/**
 	 * Set alternate Location.
@@ -167,7 +185,7 @@ public class AtomImpl implements Atom, Serializable, PDBRecord {
 
 	@Override
 	public String toString() {
-		return name + " " + element + " " + pdbserial + " " + coords[0] + " " + coords[1] + " " + coords[2];
+		return name + " " + element + " " + pdbserial + " " + coords.x + " " + coords.y + " " + coords.z;
 	}
 
 	@Override

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Calc.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Calc.java
@@ -190,8 +190,8 @@ public class Calc {
 	 */
 	public static final double angle(Atom a, Atom b) {
 
-		Vector3d va = new Vector3d(a.getCoords());
-		Vector3d vb = new Vector3d(b.getCoords());
+		Vector3d va = new Vector3d(a.getCoordsAsPoint3d());
+		Vector3d vb = new Vector3d(b.getCoordsAsPoint3d());
 
 		return Math.toDegrees(va.angle(vb));
 
@@ -1197,7 +1197,7 @@ public class Calc {
 	 */
 	public static Matrix4d getTransformation(Matrix rot, Atom trans) {
 		return new Matrix4d(new Matrix3d(rot.getColumnPackedCopy()),
-				new Vector3d(trans.getCoords()), 1.0);
+				new Vector3d(trans.getCoordsAsPoint3d()), 1.0);
 	}
 	
 	/**
@@ -1225,7 +1225,7 @@ public class Calc {
 	public static Point3d[] atomsToPoints(Atom[] atoms) {
 		Point3d[] points = new Point3d[atoms.length];
 		for (int i = 0; i < atoms.length; i++) {
-			points[i] = new Point3d(atoms[i].getCoords());
+			points[i] = atoms[i].getCoordsAsPoint3d();
 		}
 		return points;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
@@ -759,7 +759,7 @@ public class ChainImpl implements Chain, Serializable {
 	@Override
 	public GroupType getPredominantGroupType(){
 
-		double RATIO_RESIDUES_TO_TOTAL = StructureTools.RATIO_RESIDUES_TO_TOTAL;
+		double ratioResiduesToTotal = StructureTools.RATIO_RESIDUES_TO_TOTAL;
 
 		int sizeAminos = getAtomGroups(GroupType.AMINOACID).size();
 		int sizeNucleotides = getAtomGroups(GroupType.NUCLEOTIDE).size();
@@ -774,13 +774,13 @@ public class ChainImpl implements Chain, Serializable {
 
 		int fullSize = sizeAminos + sizeNucleotides + sizeHetatomsWithoutWater;
 
-		if ((double) sizeAminos / (double) fullSize > StructureTools.RATIO_RESIDUES_TO_TOTAL)
+		if ((double) sizeAminos / (double) fullSize > ratioResiduesToTotal)
 			return GroupType.AMINOACID;
 
-		if ((double) sizeNucleotides / (double) fullSize > RATIO_RESIDUES_TO_TOTAL)
+		if ((double) sizeNucleotides / (double) fullSize > ratioResiduesToTotal)
 			return GroupType.NUCLEOTIDE;
 
-		if ((double) (sizeHetatomsWithoutWater) / (double) fullSize > RATIO_RESIDUES_TO_TOTAL)
+		if ((double) (sizeHetatomsWithoutWater) / (double) fullSize > ratioResiduesToTotal)
 			return GroupType.HETATM;
 
 		// finally if neither condition works, we try based on majority, but log
@@ -803,7 +803,7 @@ public class ChainImpl implements Chain, Serializable {
 				"Ratio of residues to total for chain with asym_id {} is below {}. Assuming it is a {} chain. "
 						+ "Counts: # aa residues: {}, # nuc residues: {}, # non-water het residues: {}, # waters: {}, "
 						+ "ratio aa/total: {}, ratio nuc/total: {}",
-				getId(), RATIO_RESIDUES_TO_TOTAL, max, sizeAminos,
+				getId(), ratioResiduesToTotal, max, sizeAminos,
 				sizeNucleotides, sizeHetatomsWithoutWater, sizeWaters,
 				(double) sizeAminos / (double) fullSize,
 				(double) sizeNucleotides / (double) fullSize);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/HetatomImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/HetatomImpl.java
@@ -169,7 +169,8 @@ public class HetatomImpl implements Group,Serializable {
 	public void addAtom(Atom atom){
 		atom.setGroup(this);
 		atoms.add(atom);
-		if (atom.getCoords() != null){
+		// TODO this check is useless, coords are always !=null since they are initialized to 0,0,0 in AtomImpl constructor. We need to review this - JD 2016-09-14
+		if (atom.getCoordsAsPoint3d() != null){
 			// we have got coordinates!
 			setPDBFlag(true);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1280,7 +1280,7 @@ public class StructureTools {
 		}
 		grid.addAtoms(atoms);
 
-		return grid.getContacts();
+		return grid.getAtomContacts();
 	}
 
 	/**
@@ -1319,7 +1319,7 @@ public class StructureTools {
 
 		grid.addAtoms(atoms);
 
-		return grid.getContacts();
+		return grid.getAtomContacts();
 	}
 
 	/**
@@ -1341,7 +1341,7 @@ public class StructureTools {
 
 		grid.addAtoms(atoms);
 
-		return grid.getContacts();
+		return grid.getAtomContacts();
 	}
 
 	/**
@@ -1376,7 +1376,7 @@ public class StructureTools {
 		}
 		grid.addAtoms(atoms1, atoms2);
 
-		return grid.getContacts();
+		return grid.getAtomContacts();
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Set;
 
 import javax.vecmath.Matrix4d;
+import javax.vecmath.Point3d;
 
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.contact.AtomContactSet;
@@ -496,6 +497,35 @@ public class StructureTools {
 			}
 		}
 		return atoms.toArray(new Atom[atoms.size()]);
+	}
+	
+	/**
+	 * Returns and array of all non-Hydrogen atoms coordinates in the given Chain,
+	 * optionally including HET atoms or not Waters are not included.
+	 *
+	 * @param c
+	 * @param hetAtoms
+	 *            if true HET atoms are included in array, if false they are not
+	 * @return
+	 */
+	public static final Point3d[] getAllNonHCoordsArray(Chain c, boolean hetAtoms) {
+		List<Point3d> atoms = new ArrayList<Point3d>();
+
+		for (Group g : c.getAtomGroups()) {
+			if (g.isWater())
+				continue;
+			for (Atom a : g.getAtoms()) {
+
+				if (a.getElement() == Element.H)
+					continue;
+
+				if (!hetAtoms && g.getType().equals(GroupType.HETATM))
+					continue;
+
+				atoms.add(a.getCoordsAsPoint3d());
+			}
+		}
+		return atoms.toArray(new Point3d[atoms.size()]);
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/BoundingBox.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/BoundingBox.java
@@ -20,10 +20,10 @@
  */
 package org.biojava.nbio.structure.contact;
 
-import org.biojava.nbio.structure.Atom;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.vecmath.Point3d;
 import javax.vecmath.Vector3d;
 import java.io.Serializable;
 import java.util.Arrays;
@@ -72,26 +72,26 @@ public class BoundingBox implements Serializable {
 	 * Constructs a BoundingBox by calculating maxs and mins of given array of atoms.
 	 * @param atoms
 	 */
-	public BoundingBox (Atom[] atoms) {
+	public BoundingBox (Point3d[] atoms) {
 
 		if (atoms.length==0) logger.error("Error! Empty list of atoms");
 
-		xmax = atoms[0].getX();
+		xmax = atoms[0].x;
 		xmin = xmax;
-		ymax = atoms[0].getY();
+		ymax = atoms[0].y;
 		ymin = ymax;
-		zmax = atoms[0].getZ();
+		zmax = atoms[0].z;
 		zmin = zmax;
 
 		for(int i=1;i<atoms.length;i++) {
-			if(atoms[i].getX() > xmax) xmax = atoms[i].getX();
-			else if(atoms[i].getX() < xmin) xmin = atoms[i].getX();
+			if(atoms[i].x > xmax) xmax = atoms[i].x;
+			else if(atoms[i].x < xmin) xmin = atoms[i].x;
 
-			if(atoms[i].getY() > ymax) ymax = atoms[i].getY();
-			else if(atoms[i].getY() < ymin) ymin = atoms[i].getY();
+			if(atoms[i].y > ymax) ymax = atoms[i].y;
+			else if(atoms[i].y < ymin) ymin = atoms[i].y;
 
-			if(atoms[i].getZ() > zmax) zmax = atoms[i].getZ();
-			else if(atoms[i].getZ() < zmin) zmin = atoms[i].getZ();
+			if(atoms[i].z > zmax) zmax = atoms[i].z;
+			else if(atoms[i].z < zmin) zmin = atoms[i].z;
 		}
 
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/Contact.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/Contact.java
@@ -1,0 +1,39 @@
+package org.biojava.nbio.structure.contact;
+
+import java.io.Serializable;
+
+/**
+ * A simple class to store contacts in the form of pairs of indices and a distance associated to them.
+ * @author Jose Duarte
+ * @since 5.0
+ */
+public class Contact implements Serializable {
+
+	private static final long serialVersionUID = 5059569852079048728L;
+
+	private int i;
+	private int j;
+	private double distance;
+	
+	public Contact(int i, int j, double distance) {
+		this.i = i;
+		this.j = j;
+		this.distance = distance;
+	}
+	
+	public Pair<Integer> getIndexPair() {
+		return new Pair<Integer>(i,j);
+	}
+	
+	public int getI() {
+		return i;
+	}
+	
+	public int getJ() {
+		return j;
+	}
+	
+	public double getDistance() {
+		return distance;
+	}
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GridCell.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GridCell.java
@@ -20,28 +20,29 @@
  */
 package org.biojava.nbio.structure.contact;
 
-import org.biojava.nbio.structure.Atom;
-import org.biojava.nbio.structure.Calc;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.vecmath.Point3d;
+
 
 /**
- * A grid cell to be used in contact calculation via geometric hashing algorithm.
+ * A grid cell to be used in contact calculation via spatial hashing algorithm.
  *
- * @author duarte_j
+ * @author Jose Duarte
  *
  */
 public class GridCell {
 
 
+	private Grid grid;
 	private ArrayList<Integer> iIndices;
 	private ArrayList<Integer> jIndices;
 
-	public GridCell(){
+	public GridCell(Grid parent){
 		iIndices = new ArrayList<Integer>();
 		jIndices = new ArrayList<Integer>();
+		this.grid = parent;
 	}
 
 	public void addIindex(int serial){
@@ -62,22 +63,25 @@ public class GridCell {
 
 	/**
 	 * Calculates all distances of atoms within this cell returning those that are within the given cutoff
-	 * as a list of AtomContacts
-	 * @param iAtoms the first set of atoms to which the iIndices correspond
-	 * @param jAtoms the second set of atoms to which the jIndices correspond, if null distances are within the iAtoms only
-	 * @param cutoff
+	 * as a list of Contacts containing the indices of the pair and the calculated distance.
+	 * 
+	 * If {@link Grid#getIAtoms()} is null, distances are within the iAtoms only
 	 * @return
 	 */
-	public List<AtomContact> getContactsWithinCell(Atom[] iAtoms, Atom[] jAtoms, double cutoff){
+	public List<Contact> getContactsWithinCell(){
 
-		List<AtomContact> contacts = new ArrayList<AtomContact>();
+		List<Contact> contacts = new ArrayList<Contact>();
+		
+		Point3d[] iAtoms = grid.getIAtoms();
+		Point3d[] jAtoms = grid.getJAtoms();
+		double cutoff = grid.getCutoff();
 
 		if (jAtoms==null) {
 			for (int i:iIndices) {
 				for (int j:iIndices) {
 					if (j>i) {
-						double distance = Calc.getDistance(iAtoms[i], iAtoms[j]);
-						if (distance<cutoff) contacts.add(new AtomContact(new Pair<Atom>(iAtoms[i],iAtoms[j]),distance));
+						double distance = iAtoms[i].distance(iAtoms[j]);
+						if (distance<cutoff) contacts.add(new Contact(i, j, distance));
 					}
 				}
 			}
@@ -85,8 +89,8 @@ public class GridCell {
 		} else {
 			for (int i:iIndices) {
 				for (int j:jIndices) {
-					double distance = Calc.getDistance(iAtoms[i], jAtoms[j]);
-					if (distance<cutoff) contacts.add(new AtomContact(new Pair<Atom>(iAtoms[i],jAtoms[j]),distance));
+					double distance = iAtoms[i].distance(jAtoms[j]);
+					if (distance<cutoff) contacts.add(new Contact(i, j, distance));
 				}
 			}
 		}
@@ -96,24 +100,30 @@ public class GridCell {
 
 	/**
 	 * Calculates all distances of atoms between this cell and the given cell returning those that are
-	 * within the given cutoff as a list of AtomContacts
+	 * within the given cutoff as a list of Contacts containing the indices of the pair and the calculated distance.
+	 * 
 	 * @param otherCell
-	 * @param iAtoms the first set of atoms to which the iIndices correspond
-	 * @param jAtoms the second set of atoms to which the jIndices correspond, if null distances are within the iAtoms only
+	 * @param iAtoms the first set of atom coordinates to which the iIndices correspond
+	 * @param jAtoms the second set of atom coordinates to which the jIndices correspond, if null distances are within the iAtoms only
 	 * @param cutoff
 	 * @return
 	 */
-	public List<AtomContact> getContactsToOtherCell(GridCell otherCell , Atom[] iAtoms, Atom[] jAtoms, double cutoff){
+	public List<Contact> getContactsToOtherCell(GridCell otherCell){
 
-		List<AtomContact> contacts = new ArrayList<AtomContact>();
+		List<Contact> contacts = new ArrayList<Contact>();
 
+		Point3d[] iAtoms = grid.getIAtoms();
+		Point3d[] jAtoms = grid.getJAtoms();
+		double cutoff = grid.getCutoff();
+
+		
 		if (jAtoms==null) {
 
 			for (int i:iIndices) {
 				for (int j:otherCell.iIndices) {
 					if (j>i) {
-						double distance = Calc.getDistance(iAtoms[i], iAtoms[j]);
-						if (distance<cutoff) contacts.add(new AtomContact(new Pair<Atom>(iAtoms[i],iAtoms[j]),distance));
+						double distance = iAtoms[i].distance(iAtoms[j]);
+						if (distance<cutoff) contacts.add(new Contact(i, j, distance));
 					}
 				}
 			}
@@ -122,8 +132,8 @@ public class GridCell {
 
 			for (int i:iIndices) {
 				for (int j:otherCell.jIndices) {
-					double distance = Calc.getDistance(iAtoms[i], jAtoms[j]);
-					if (distance<cutoff) contacts.add(new AtomContact(new Pair<Atom>(iAtoms[i],jAtoms[j]),distance));
+					double distance = iAtoms[i].distance(jAtoms[j]);
+					if (distance<cutoff) contacts.add(new Contact(i, j, distance));
 				}
 			}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BioAssemblyTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BioAssemblyTools.java
@@ -26,6 +26,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.vecmath.Point3d;
+
 
 
 
@@ -150,10 +152,10 @@ public class BioAssemblyTools {
 			for (BiologicalAssemblyTransformation m: transformations) {
 				if ( ! m.getChainId().equals(intChainID))
 					continue;
-				double[] coords = a.getCoords();
-				transformedCoords[0] = coords[0];
-				transformedCoords[1] = coords[1];
-				transformedCoords[2] = coords[2];
+				Point3d coords = a.getCoordsAsPoint3d();
+				transformedCoords[0] = coords.x;
+				transformedCoords[1] = coords.y;
+				transformedCoords[2] = coords.z;
 
 				if (transformedCoords[0] < coordinateBounds[0][0] ) {
 					coordinateBounds[0][0] = transformedCoords[0];  // min x
@@ -184,7 +186,7 @@ public class BioAssemblyTools {
 	}
 	public static double[][] getAtomCoordinateBounds(Structure s){
 
-		org.biojava.nbio.structure.Atom[] atoms = StructureTools.getAllAtomArray(s);
+		Atom[] atoms = StructureTools.getAllAtomArray(s);
 		int atomCount = atoms.length;
 		final double[][] coordinateBounds = new double[2][3];
 		if ( atomCount <= 0 ) {
@@ -299,10 +301,10 @@ public class BioAssemblyTools {
 				if (!  m.getChainId().equals(intChainID))
 					continue;
 
-				double[] coords = atom.getCoords();
-				transformedCoordinate[0] = coords[0];
-				transformedCoordinate[1] = coords[1];
-				transformedCoordinate[2] = coords[2];
+				Point3d coords = atom.getCoordsAsPoint3d();
+				transformedCoordinate[0] = coords.x;
+				transformedCoordinate[1] = coords.y;
+				transformedCoordinate[2] = coords.z;
 				m.transformPoint(transformedCoordinate);
 				centroid[0] += transformedCoordinate[0];
 				centroid[1] += transformedCoordinate[1];

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucCalc.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucCalc.java
@@ -173,7 +173,7 @@ public class SecStrucCalc {
 		}
 		else{
 			grid.addAtoms(atoms);
-			contactSet = grid.getContacts();
+			contactSet = grid.getAtomContacts();
 		}
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetrySubunits.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetrySubunits.java
@@ -78,7 +78,7 @@ public class QuatSymmetrySubunits {
 				// Convert atoms to points
 				Point3d[] points = new Point3d[atoms.length];
 				for (int i = 0; i < atoms.length; i++)
-					points[i] = new Point3d(atoms[i].getCoords());
+					points[i] = atoms[i].getCoordsAsPoint3d();
 
 				caCoords.add(points);
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/UnitCellBoundingBox.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/UnitCellBoundingBox.java
@@ -78,7 +78,7 @@ public class UnitCellBoundingBox {
 		List<Chain> polyChains = s.getPolyChains();
 		int j = 0;
 		for (Chain polyChain : polyChains) {
-			chainBbs[i][j] = new BoundingBox(StructureTools.getAllNonHAtomArray(polyChain, includeHetAtoms));
+			chainBbs[i][j] = new BoundingBox(StructureTools.getAllNonHCoordsArray(polyChain, includeHetAtoms));
 			j++;
 		}
 		auBbs[i] = new BoundingBox(chainBbs[i]);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCalc.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCalc.java
@@ -116,7 +116,7 @@ public class TestCalc {
 		Calc.shift(atom, identT);
 
 		Point3d expected = new Point3d(1.0, 1.0, 1.0);
-		Point3d actual = new Point3d(atom.getCoords());
+		Point3d actual = atom.getCoordsAsPoint3d();
 
 		assertEquals(expected, actual);
 
@@ -128,7 +128,7 @@ public class TestCalc {
 		Calc.shift(atom, sampleT);
 
 		expected = new Point3d(2.0, 7.0, -1.3);
-		actual = new Point3d(atom.getCoords());
+		actual = atom.getCoordsAsPoint3d();
 
 		assertEquals(expected, actual);
 	}
@@ -144,7 +144,7 @@ public class TestCalc {
 		Calc.transform(atom, ident);
 
 		Point3d expected = new Point3d(1.0, 1.0, 1.0);
-		Point3d actual = new Point3d(atom.getCoords());
+		Point3d actual = atom.getCoordsAsPoint3d();
 
 		assertEquals(expected, actual);
 
@@ -153,7 +153,7 @@ public class TestCalc {
 		Calc.transform(atom, sample);
 
 		expected = new Point3d(2.0, 7.0, -1.3);
-		actual = new Point3d(atom.getCoords());
+		actual = atom.getCoordsAsPoint3d();
 
 		assertEquals(expected, actual);
 	}


### PR DESCRIPTION
This solves #582 enabling a faster and less memory intensive translation between `Atom[]` and `Point3d[]`. I've also made `AsaCalculator` and `Grid` (contact calculation algorithm) more independent of `Atom[]` following the comments of @pwrose in #545, now it's possible to use both algorithms with either just `Point3d[]` or with `Atom[]`.
