### PR TITLE
FileConvert altLoc fix

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -408,6 +408,10 @@ public class FileConvert {
 
 
 		Character  altLoc = a.getAltLoc()           ;
+		
+		if ( altLoc == null)
+			altLoc = ' ';
+		
 		String resseq = "" ;
 		if ( hasInsertionCode(pdbcode) )
 			resseq     = String.format("%5s",pdbcode);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -405,10 +405,7 @@ public class FileConvert {
 		String serial     = String.format("%5d",seri);
 		String fullName   = formatAtomName(a);
 
-
-
-		Character  altLoc = a.getAltLoc()           ;
-		
+		Character  altLoc = a.getAltLoc();		
 		if ( altLoc == null)
 			altLoc = ' ';
 		


### PR DESCRIPTION
Inserts space when altLoc is null, so that the rest of fields are properly aligned.
Two similar commits created by a mistake.