### PR TITLE
Add ligands to subselections by proximity

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -104,18 +104,21 @@ public class StructureToolsTest extends TestCase {
 		Structure hivA = cache.getStructure("1hiv.A");
 		Atom[] caSa = StructureTools.getRepresentativeAtomArray(hivA);
 		Atom[] caCa = StructureTools.getRepresentativeAtomArray(hivA.getChain(0));
+		//TODO Residue 67 is PTM. In BioJava 4 this is treated as a ligand, so it
+		//     gets added to caSa. In BioJava 5 this should be fixed, so they
+		//     should match again.
 		assertEquals("did not find the same number of Atoms from structure and from chain..",
-				caSa.length,caCa.length);
+				caSa.length-1,caCa.length);
 		Structure hivB = cache.getStructure("1hiv.B");
 		Atom[] caSb = StructureTools.getRepresentativeAtomArray(hivB);
 		Atom[] caCb = StructureTools.getRepresentativeAtomArray(hivB.getChain(0));
 		assertEquals("did not find the same number of Atoms from structure and from chain..",
-				caSb.length,caCb.length);
+				caSb.length-1,caCb.length);
 		//Both chains have to be the same size (A and B)
-		assertEquals(caSa.length,99);
+		assertEquals(99,caSa.length-1);
 		assertEquals("did not find the same number of Atoms in both chains...",
-				caSa.length,caCb.length);
-		assertEquals(caSa.length, 99);
+				caSa.length-1,caCb.length);
+		assertEquals(99,caSa.length-1);
 
 		ChemCompGroupFactory.setChemCompProvider(provider);
 	}
@@ -389,7 +392,9 @@ public class StructureToolsTest extends TestCase {
 		// range including insertion
 		range = "H:35-37"; //includes 36A
 		substr = StructureTools.getSubRanges(structure3, range);
-		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		// Because we are loading from PDB, TYS I:363 is recognized as a ligand
+		// rather than a PTM, so it gets included here
+		assertEquals("Wrong number of chains in "+range, 2, substr.size());
 
 		chain = substr.getChain(0);
 
@@ -399,7 +404,7 @@ public class StructureToolsTest extends TestCase {
 		// end with insertion
 		range = "H:35-36A";
 		substr = StructureTools.getSubRanges(structure3, range);
-		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		assertEquals("Wrong number of chains in "+range, 2, substr.size());
 
 		chain = substr.getChain(0);
 
@@ -415,7 +420,7 @@ public class StructureToolsTest extends TestCase {
 		assertEquals("Did not find the expected number of residues in "+range, 3, chain.getAtomLength() );
 
 		// within insertion
-		range = "L:14-14K"; //includes 36A
+		range = "L:14-14K";
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
@@ -424,7 +429,7 @@ public class StructureToolsTest extends TestCase {
 		assertEquals("Did not find the expected number of residues in "+range, 12, chain.getAtomLength() );
 
 		// within insertion
-		range = "L:14C-14J"; //includes 36A
+		range = "L:14C-14J";
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryDisplay.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryDisplay.java
@@ -133,6 +133,7 @@ public class SymmetryDisplay {
 			jmol.evalString(printSymmetryGroup(symmResult));
 			jmol.evalString(printSymmetryAxes(symmResult));
 			jmol.setTitle(getSymmTitle(symmResult));
+			jmol.evalString("save STATE state_1");
 			return jmol;
 		} else {
 			// Show the optimal self-alignment
@@ -144,6 +145,7 @@ public class SymmetryDisplay {
 					cloned);
 			RotationAxis axis = new RotationAxis(symmResult.getSelfAlignment());
 			jmol.evalString(axis.getJmolScript(symmResult.getAtoms()));
+			jmol.evalString("save STATE state_1");
 			return jmol;
 		}
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryListener.java
@@ -68,11 +68,14 @@ public class SymmetryListener implements ActionListener {
 				MultipleAlignmentJmol j = SymmetryDisplay.displayRepeats(symm);
 				String s = SymmetryDisplay.printSymmetryAxes(symm, false);
 				j.evalString(s);
+				j.evalString("save STATE state_1");
+
 
 			} else if (cmd.equals("Multiple Structure Alignment")) {
 				MultipleAlignmentJmol j = SymmetryDisplay.displayFull(symm);
 				String s = SymmetryDisplay.printSymmetryAxes(symm);
 				j.evalString(s);
+				j.evalString("save STATE state_1");
 
 			} else if (cmd.equals("Optimal Self Alignment")) {
 				Atom[] cloned = StructureTools.cloneAtomArray(symm.getAtoms());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomIterator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomIterator.java
@@ -41,21 +41,35 @@ public class AtomIterator implements Iterator<Atom> {
 
 	private final static Logger logger = LoggerFactory.getLogger(AtomIterator.class);
 
-	Structure structure     ;
-	Group     group         ;
-	int current_atom_pos    ;
-	GroupIterator groupiter ;
+	private Group     group         ;
+	private int current_atom_pos    ;
+	private GroupIterator groupiter ;
 
 	/**
-	 * Constructs an AtomIterator object.
+	 * Constructs an AtomIterator object over all models
 	 *
 	 * @param struct  a Structure object
 	 */
 	public AtomIterator(Structure struct) {
-		structure = struct;
 		current_atom_pos = -1 ;
 
-		groupiter = new GroupIterator(structure) ;
+		groupiter = new GroupIterator(struct) ;
+		if ( groupiter.hasNext() ) {
+			group = groupiter.next() ;
+		}
+		else
+			group = null ;
+	}
+	
+	/**
+	 * Constructs an AtomIterator object over a single model
+	 *
+	 * @param struct  a Structure object
+	 */
+	public AtomIterator(Structure struct,int modelNr) {
+		current_atom_pos = -1 ;
+
+		groupiter = new GroupIterator(struct,modelNr) ;
 		if ( groupiter.hasNext() ) {
 			group = groupiter.next() ;
 		}
@@ -86,12 +100,9 @@ public class AtomIterator implements Iterator<Atom> {
 	 * @param g  a Group object
 	 */
 	public AtomIterator(Group g) {
-		structure = null;
 		group = g ;
 		current_atom_pos = -1 ;
 		groupiter = null ;
-
-
 	}
 
 	/** Is there a next atom ?

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/GroupIterator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/GroupIterator.java
@@ -37,23 +37,36 @@ import java.util.NoSuchElementException;
 
 public class GroupIterator implements Iterator<Group> {
 
-	Structure structure   ;
-	int current_model_pos ;
-	int current_chain_pos ;
-	int current_group_pos ;
+	private Structure structure   ;
+	private int current_model_pos ;
+	private int current_chain_pos ;
+	private int current_group_pos ;
+	private boolean fixed_model   ;
+	
 
 	/**
-	 * Constructs a GroupIterator object.
+	 * Constructs a GroupIterator object over all models
 	 *
 	 * @param struct  a Structure object
 	 */
-
 	public GroupIterator (Structure struct) {
 		structure = struct     ;
 		current_model_pos = 0  ;
 		current_chain_pos = 0  ;
 		current_group_pos = -1 ;
-
+		fixed_model = false    ;
+	}
+	/**
+	 * Constructs a GroupIterator object over a specific model
+	 *
+	 * @param struct  a Structure object
+	 */
+	public GroupIterator (Structure struct, int modelNr) {
+		structure = struct     ;
+		current_model_pos = modelNr;
+		current_chain_pos = 0  ;
+		current_group_pos = -1 ;
+		fixed_model = true     ;
 	}
 
 
@@ -74,6 +87,7 @@ public class GroupIterator implements Iterator<Group> {
 		gr.setModelPos(this.getModelPos());
 		gr.setChainPos(this.getChainPos());
 		gr.setGroupPos(this.getGroupPos());
+		gr.fixed_model = this.fixed_model;
 		return gr ;
 
 	}
@@ -98,6 +112,8 @@ public class GroupIterator implements Iterator<Group> {
 		List<Chain> model = structure.getModel(tmp_model);
 
 		if (tmp_chain >= model.size()) {
+			if(fixed_model)
+				return false;
 			return hasSubGroup(tmp_model + 1, 0, 0);
 		}
 
@@ -163,6 +179,8 @@ public class GroupIterator implements Iterator<Group> {
 		List<Chain> model = structure.getModel(tmp_model);
 
 		if ( tmp_chain >= model.size() ){
+			if(fixed_model)
+				throw new NoSuchElementException("arrived at end of model!");
 			return getNextGroup(tmp_model+1,0,0);
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -306,13 +306,17 @@ public class StructureImpl implements Structure, Serializable {
 
 	/**
 	 * {@inheritDoc}
+	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public void      setConnections(List<Map<String,Integer>> conns) { connections = conns ; }
 
 	/**
 	 * {@inheritDoc}
+	 * @deprecated
 	 */
+	@Deprecated
 	@Override
 	public List<Map<String,Integer>> getConnections()                { return connections ;}
 
@@ -630,6 +634,9 @@ public class StructureImpl implements Structure, Serializable {
 	@Override
 	public Chain getChainByPDB(String chainId)
 			throws StructureException{
+		if(nrModels() < 1 ) {
+			throw new StructureException("No chains are present.");
+		}
 		return getChainByPDB(chainId,0);
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -467,10 +467,10 @@ public class StructureTools {
 	 * Finds all ligand groups from the target which fall within the cutoff distance
 	 * of some atom from the query set.
 	 * 
-	 * @param target Set of groups
-	 * @param query
-	 * @param cutoff
-	 * @return
+	 * @param target Set of groups including the ligands
+	 * @param query Atom selection
+	 * @param cutoff Distance from query atoms to consider, in angstroms
+	 * @return All groups from the target with at least one atom within cutoff of a query atom
 	 * @see StructureTools#DEFAULT_LIGAND_PROXIMITY_CUTOFF
 	 */
 	public static List<Group> getLigandsByProximity(Collection<Group> target, Atom[] query, double cutoff) {
@@ -585,9 +585,26 @@ public class StructureTools {
 	 * @return
 	 */
 	public static final Atom[] getAllNonHAtomArray(Structure s, boolean hetAtoms) {
+		AtomIterator iter = new AtomIterator(s);
+		return getAllNonHAtomArray(s, hetAtoms, iter);
+	}
+	/**
+	 * Returns and array of all non-Hydrogen atoms in the given Structure,
+	 * optionally including HET atoms or not. Waters are not included.
+	 *
+	 * @param s
+	 * @param hetAtoms
+	 *            if true HET atoms are included in array, if false they are not
+	 * @param modelNr Model number to draw atoms from
+	 * @return
+	 */
+	public static final Atom[] getAllNonHAtomArray(Structure s, boolean hetAtoms, int modelNr) {
+		AtomIterator iter = new AtomIterator(s,modelNr);
+		return getAllNonHAtomArray(s, hetAtoms, iter);
+	}
+	private static final Atom[] getAllNonHAtomArray(Structure s, boolean hetAtoms, AtomIterator iter) {
 		List<Atom> atoms = new ArrayList<Atom>();
 
-		AtomIterator iter = new AtomIterator(s);
 		while (iter.hasNext()) {
 			Atom a = iter.next();
 			if (a.getElement() == Element.H)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -343,7 +343,7 @@ public class StructureTools {
 	}
 
 	/**
-	 * Convert all atoms of the structure (first model) into an Atom array
+	 * Convert all atoms of the structure (all models) into an Atom array
 	 *
 	 * @param s
 	 *            input structure
@@ -359,9 +359,27 @@ public class StructureTools {
 		}
 		return atoms.toArray(new Atom[atoms.size()]);
 	}
+	/**
+	 * Convert all atoms of the structure (specified model) into an Atom array
+	 *
+	 * @param s
+	 *            input structure
+	 * @return all atom array
+	 */
+	public static final Atom[] getAllAtomArray(Structure s, int model) {
+		List<Atom> atoms = new ArrayList<Atom>();
+
+		AtomIterator iter = new AtomIterator(s,model);
+		while (iter.hasNext()) {
+			Atom a = iter.next();
+			atoms.add(a);
+		}
+		return atoms.toArray(new Atom[atoms.size()]);
+
+	}
 
 	/**
-	 * Returns and array of all atoms of the chain (first model), including
+	 * Returns and array of all atoms of the chain, including
 	 * Hydrogens (if present) and all HETATOMs. Waters are not included.
 	 *
 	 * @param c

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -503,6 +503,77 @@ public class StructureTools {
 		}
 		return ligands;
 	}
+	
+	/**
+	 * Expand a set of atoms into all groups from the same structure.
+	 * 
+	 * If the structure is set, only the first atom is used (assuming all
+	 * atoms come from the same original structure).
+	 * If the atoms aren't linked to a structure (for instance, for cloned atoms),
+	 * searches all chains of all atoms for groups.
+	 * @param atoms Sample of atoms
+	 * @return All groups from all chains accessible from the input atoms
+	 */
+	public static Set<Group> getAllGroupsFromSubset(Atom[] atoms) {
+		return getAllGroupsFromSubset(atoms,null);
+	}
+	/**
+	 * Expand a set of atoms into all groups from the same structure.
+	 * 
+	 * If the structure is set, only the first atom is used (assuming all
+	 * atoms come from the same original structure).
+	 * If the atoms aren't linked to a structure (for instance, for cloned atoms),
+	 * searches all chains of all atoms for groups.
+	 * @param atoms Sample of atoms
+	 * @param types Type of groups to return (useful for getting only ligands, for instance).
+	 *  Null gets all groups.
+	 * @return All groups from all chains accessible from the input atoms
+	 */
+	public static Set<Group> getAllGroupsFromSubset(Atom[] atoms,GroupType types) {
+		// Get the full structure
+		Structure s = null;
+		if (atoms.length > 0) {
+			Group g = atoms[0].getGroup();
+			if (g != null) {
+				Chain c = g.getChain();
+				if (c != null) {
+					s = c.getStructure();
+				}
+			}
+		}
+		// Collect all groups from the structure
+		Set<Chain> allChains = new HashSet<>();
+		if( s != null ) {
+			allChains.addAll(s.getChains());
+		}
+		// In case the structure wasn't set, need to use ca chains too
+		for(Atom a : atoms) {
+			Group g = a.getGroup();
+			if(g != null) {
+				Chain c = g.getChain();
+				if( c != null ) {
+					allChains.add(c);
+				}
+			}
+		}
+
+		if(allChains.isEmpty() ) {
+			return Collections.emptySet();
+		}
+		
+		// Extract all ligand groups
+		Set<Group> full = new HashSet<>();
+		for(Chain c : allChains) {
+			if(types == null) {
+				full.addAll(c.getAtomGroups());
+			} else {
+				full.addAll(c.getAtomGroups(types));
+			}
+		}
+
+		return full;
+	}
+
 
 	/**
 	 * Returns and array of all non-Hydrogen atoms in the given Structure,

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -155,7 +155,7 @@ public class StructureTools {
 	/**
 	 * Threshold for plausible binding of a ligand to the selected substructure
 	 */
-	public static final double DEFAULT_LIGAND_PROXIMITY_CUTOFF = 7;
+	public static final double DEFAULT_LIGAND_PROXIMITY_CUTOFF = 5;
 
 	// there is a file format change in PDB 3.0 and nucleotides are being
 	// renamed

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -352,7 +352,8 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 	protected static void copyLigandsByProximity(Structure full, Structure reduced, double cutoff, int fromModel, int toModel) {
 		// Geometric hashing of the reduced structure
 		Grid grid = new Grid(cutoff);
-		grid.addAtoms(StructureTools.getAllAtomArray(reduced,toModel));
+		Atom[] nonwaters = StructureTools.getAllNonHAtomArray(reduced,true,toModel);
+		grid.addAtoms(nonwaters);
 
 		
 		// Find ligands from full structure

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -76,8 +76,6 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 
 	private static final Logger logger = LoggerFactory.getLogger(SubstructureIdentifier.class);
 	
-	// Threshold for plausible binding of a ligand to the selected substructure
-	private static final double DEFAULT_LIGAND_PROXIMITY_CUTOFF = 7;
 
 	private final String pdbId;
 	private final List<ResidueRange> ranges;
@@ -300,7 +298,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 				} // end range
 			}
 			
-			copyLigandsByProximity(s,newS, DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
+			copyLigandsByProximity(s,newS, StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
 		} // end modelNr
 
 		return newS;
@@ -323,14 +321,35 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 		return cache.getStructureForPdbId(pdb);
 	}
 
-	static void copyLigandsByProximity(Structure full, Structure reduced) {
+	/**
+	 * Supplements the reduced structure with ligands from the full structure based on
+	 * a distance cutoff. Ligand groups are moved (destructively) from full to reduced
+	 * if they fall within the cutoff of any atom in the reduced structure.
+	 * The {@link StructureTools#DEFAULT_LIGAND_PROXIMITY_CUTOFF default cutoff}
+	 * (currently 7Å) is used.
+	 * @param full Structure containing all ligands
+	 * @param reduced Structure with a subset of the polymer groups from full
+	 * @see StructureTools#getLigandsByProximity(java.util.Collection, Atom[], double)
+	 */
+	protected static void copyLigandsByProximity(Structure full, Structure reduced) {
 		// Normal case where all models should be copied from full to reduced
 		assert full.nrModels() >= reduced.nrModels();
 		for(int model = 0; model< reduced.nrModels(); model++) {
-			copyLigandsByProximity(full, reduced, DEFAULT_LIGAND_PROXIMITY_CUTOFF, model, model);
+			copyLigandsByProximity(full, reduced, StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF, model, model);
 		}
 	}
-	static void copyLigandsByProximity(Structure full, Structure reduced, double cutoff, int fromModel, int toModel) {
+	/**
+	 * Supplements the reduced structure with ligands from the full structure based on
+	 * a distance cutoff. Ligand groups are moved (destructively) from full to reduced
+	 * if they fall within the cutoff of any atom in the reduced structure.
+	 * @param full Structure containing all ligands
+	 * @param reduced Structure with a subset of the polymer groups from full
+	 * @param cutoff Distance cutoff (Å)
+	 * @param fromModel source model in full
+	 * @param toModel destination model in reduced
+	 * @see StructureTools#getLigandsByProximity(java.util.Collection, Atom[], double)
+	 */
+	protected static void copyLigandsByProximity(Structure full, Structure reduced, double cutoff, int fromModel, int toModel) {
 		// Geometric hashing of the reduced structure
 		Grid grid = new Grid(cutoff);
 		grid.addAtoms(StructureTools.getAllAtomArray(reduced,toModel));
@@ -393,4 +412,5 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 		}
 			
 	}
+
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -296,9 +296,10 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 
 					prevChainId = c.getChainID();
 				} // end range
+
+				// Transfer any close ligands
+				copyLigandsByProximity(s,newS, StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
 			}
-			
-			copyLigandsByProximity(s,newS, StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
 		} // end modelNr
 
 		return newS;
@@ -326,7 +327,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 	 * a distance cutoff. Ligand groups are moved (destructively) from full to reduced
 	 * if they fall within the cutoff of any atom in the reduced structure.
 	 * The {@link StructureTools#DEFAULT_LIGAND_PROXIMITY_CUTOFF default cutoff}
-	 * (currently 7Å) is used.
+	 * is used.
 	 * @param full Structure containing all ligands
 	 * @param reduced Structure with a subset of the polymer groups from full
 	 * @see StructureTools#getLigandsByProximity(java.util.Collection, Atom[], double)
@@ -353,6 +354,8 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 		// Geometric hashing of the reduced structure
 		Grid grid = new Grid(cutoff);
 		Atom[] nonwaters = StructureTools.getAllNonHAtomArray(reduced,true,toModel);
+		if( nonwaters.length < 1 )
+			return;
 		grid.addAtoms(nonwaters);
 
 		

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/BoundingBox.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/BoundingBox.java
@@ -199,6 +199,20 @@ public class BoundingBox implements Serializable {
 		return true;
 
 	}
+	
+	/**
+	 * Check if a given point falls within this box
+	 * @param atom
+	 * @return
+	 */
+	public boolean contains(Atom atom) {
+		double x = atom.getX();
+		double y = atom.getY();
+		double z = atom.getZ();
+		return xmin <= x && x <= xmax
+				&& ymin <= y && y <= ymax
+				&& zmin <= z && z <= zmax;
+	}
 
 	public void translate(Vector3d translation) {
 		xmin+=translation.x;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/Grid.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/Grid.java
@@ -21,6 +21,9 @@
 package org.biojava.nbio.structure.contact;
 
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.biojava.nbio.structure.Atom;
 
 
@@ -292,6 +295,44 @@ public class Grid {
 		return contacts;
 	}
 
+	/**
+	 * Fast determination of whether any atoms from a given set fall within
+	 * the cutoff of iAtoms. If {@link #addAtoms(Atom[], Atom[])} was called
+	 * with two sets of atoms, contacts to either set are considered.
+	 * @param atoms
+	 * @return
+	 */
+	public boolean hasAnyContact(Atom[] atoms) {
+		return hasAnyContact(Arrays.asList(atoms));
+	}
+	public boolean hasAnyContact(List<Atom> atoms) {
+		for(Atom atom : atoms) {
+
+			// Calculate Grid cell for the atom
+			int xind = xintgrid2xgridindex(getFloor(atom.getX()));
+			int yind = yintgrid2ygridindex(getFloor(atom.getY()));
+			int zind = zintgrid2zgridindex(getFloor(atom.getZ()));
+
+			// Consider 3x3x3 grid of cells around point
+			for (int x=xind-1;x<=xind+1;x++) {
+				if( x<0 || cells.length<=x) continue;
+				for (int y=yind-1;y<=yind+1;y++) {
+					if( y<0 || cells[x].length<=y ) continue;
+					for (int z=zind-1;z<=zind+1;z++) {
+						if( z<0 || cells[x][y].length<=z ) continue;
+						
+						GridCell cell = cells[x][y][z];
+						// Check for contacts in this cell
+						if(cell != null && cell.hasContactToAtom(iAtoms, jAtoms, atom, cutoff)) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+		return false;
+	}
+
 	public double getCutoff() {
 		return cutoff;
 	}
@@ -304,5 +345,6 @@ public class Grid {
 	public boolean isNoOverlap() {
 		return noOverlap;
 	}
+	
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GridCell.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GridCell.java
@@ -131,5 +131,38 @@ public class GridCell {
 
 		return contacts;
 	}
+	
+	/**
+	 * Tests whether any atom in this cell has a contact with the specified query atom
+	 * @param iAtoms the first set of atoms to which the iIndices correspond
+	 * @param jAtoms the second set of atoms to which the jIndices correspond, or null
+	 * @param query test point
+	 * @param cutoff
+	 * @return
+	 */
+	public boolean hasContactToAtom(Atom[] iAtoms, Atom[] jAtoms, Atom query, double cutoff) {
+		for( int i : iIndices ) {
+			double distance = Calc.getDistance(iAtoms[i], query);
+			if( distance<cutoff)
+				return true;
+		}
+		if (jAtoms!=null) {
+			for( int i : jIndices ) {
+				double distance = Calc.getDistance(jAtoms[i], query);
+				if( distance<cutoff)
+					return true;
+			}
+		}
+		return false;
+	}
 
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return String.format("GridCell [%d iAtoms,%d jAtoms]",iIndices.size(),jIndices==null?"-":jIndices.size());
+	}
+
+	
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/Test2JA5.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/Test2JA5.java
@@ -20,9 +20,7 @@
  */
 package org.biojava.nbio.structure;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 
@@ -55,13 +53,14 @@ public class Test2JA5 {
 		// assertTrue(StructureTools.getNrAtoms(s1) == 0);
 
 		// SeqRes contains 15 chains, but since we cannot align Chain N to AtomGroups => 14.
-		assertTrue(s1.getChains().size() == 14);
+		assertEquals(14,s1.getChains().size());
 
 		Chain nChain = null;
 		try {
 			nChain = s1.getChainByPDB("N");
+			fail("No chain N");
 		} catch (StructureException e){
-			// this is expected here, since there is no chain N
+			// this is expected here, since there is no chain N density
 		}
 		assertNull(nChain);
 	}
@@ -82,17 +81,13 @@ public class Test2JA5 {
 		Structure s1 = StructureIO.getStructure("2ja5");
 
 		// This is not applicable anymore, we need to parse atoms to have chains to match.
-		assertTrue(StructureTools.getNrAtoms(s1) == 0);
+		assertEquals(0,StructureTools.getNrAtoms(s1));
 
 		// All 15 seqres chains will be store.
-		assertTrue(s1.getChains().size() == 15);
+		assertEquals(15,s1.getChains().size());
 
-		Chain nChain = null;
-		try {
-			nChain = s1.getChainByPDB("N");
-		} catch (StructureException e){
-			// this is expected here, since there is no chain N
-		}
+		// Chain N does have SEQRES, so it is present in headerOnly
+		Chain nChain = s1.getChainByPDB("N");
 		assertNotNull(nChain);
 	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
@@ -75,15 +75,15 @@ public class TestAtomCache {
 		String name1= "4hhb";
 		Structure s = cache.getStructure(name1);
 		assertNotNull(s);
-		assertTrue(s.getChains().size() == 4);
+		assertEquals(4,s.getChains().size());
 
 		String name2 = "4hhb.C";
 		String chainId2 = "C";
 		s = cache.getStructure(name2);
 
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getChains().size());
 		Chain c = s.getChainByPDB(chainId2);
-		assertEquals(c.getChainID(),chainId2);
+		assertEquals(chainId2,c.getChainID());
 
 
 		// Colon separators removed in BioJava 4.1.0
@@ -91,7 +91,6 @@ public class TestAtomCache {
 		try {
 			s = cache.getStructure(name2b);
 			fail("Invalid structure format");
-		} catch(IOException e) {
 		} catch(StructureException e) {
 		}
 
@@ -101,28 +100,28 @@ public class TestAtomCache {
 		String chainId3 = "B";
 		s = cache.getStructure(name3);
 		assertNotNull(s);
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getChains().size());
 
 		c = s.getChainByPDB(chainId3);
-		assertEquals(c.getChainID(),chainId3);
+		assertEquals(chainId3,c.getChainID());
 
 
 		String name4 = "4hhb.A:10-20,B:10-20,C:10-20";
 		s = cache.getStructure(name4);
 		assertNotNull(s);
 
-		assertEquals(s.getChains().size(), 3);
+		assertEquals(3,s.getChains().size());
 
 		c = s.getChainByPDB("B");
-		assertEquals(c.getAtomLength(),11);
+		assertEquals(11,c.getAtomLength());
 
 		String name5 = "4hhb.(A:10-20,A:30-40)";
 		s =cache.getStructure(name5);
 		assertNotNull(s);
 
-		assertEquals(s.getChains().size(),1 );
+		assertEquals(1,s.getChains().size() );
 		c = s.getChainByPDB("A");
-		assertEquals(c.getAtomLength(),22);
+		assertEquals(23,c.getAtomLength());
 
 		try {
 			// This syntax used to work, since the first paren is treated as a separator
@@ -135,9 +134,9 @@ public class TestAtomCache {
 		String name8 = "4hhb.(C)";
 		s = cache.getStructure(name8);
 
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getChains().size());
 		c = s.getChainByPDB(chainId2);
-		assertEquals(c.getChainID(),chainId2);
+		assertEquals(chainId2,c.getChainID());
 
 	}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomIterator.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomIterator.java
@@ -1,0 +1,50 @@
+package org.biojava.nbio.structure;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.AtomIterator;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.StructureTools;
+import org.junit.Test;
+
+public class TestAtomIterator {
+	@Test
+	public void test5frf() throws IOException, StructureException {
+		// 5frf: 10 models; residues -2-105, binds a ZN; 1615 atoms/model
+		Structure s = StructureIO.getStructure("5frf");
+		assertEquals("nrModels",10,s.nrModels());
+		
+		Atom[] allAtomArray = StructureTools.getAllAtomArray(s);
+		assertEquals("getAllAtomArray length",16150, allAtomArray.length);
+		
+		int atoms=0;
+		AtomIterator atomIt = new AtomIterator(s);
+		while(atomIt.hasNext()) {
+			atoms++;
+			atomIt.next();
+		}
+		try {
+			atomIt.next();
+			fail("No more elements");
+		} catch( NoSuchElementException e) {}
+		assertEquals("AtomIterator full length",16150, atoms);
+		
+		atoms=0;
+		atomIt = new AtomIterator(s,0);
+		while(atomIt.hasNext()) {
+			atoms++;
+			atomIt.next();
+		}
+		try {
+			atomIt.next();
+			fail("No more elements");
+		} catch( NoSuchElementException e) {}
+		assertEquals("AtomIterator single model",1615, atoms);
+	}
+}


### PR DESCRIPTION
Fix #560.

SubstructureIdentifier now expands its selection to any ligands within 5A of the selection.
This also gets done for CE-Symm when creating a new structure.