### PR TITLE
Add some handling of "?" in seq align position. E.g. for 5dn6

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -1643,9 +1643,17 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 			r.setDbIdCode(structRef.getDb_code());
 		}
 
-
-		int seqbegin = Integer.parseInt(sref.getPdbx_auth_seq_align_beg());
-		int seqend   = Integer.parseInt(sref.getPdbx_auth_seq_align_end());
+		int seqbegin;
+		int seqend;
+		try{
+			seqbegin = Integer.parseInt(sref.getPdbx_auth_seq_align_beg());
+			seqend   = Integer.parseInt(sref.getPdbx_auth_seq_align_end());
+		}
+		catch(NumberFormatException e){
+			logger.info("Couldn't parse sequence alignment positions.");
+			logger.debug(e.toString());
+			return;
+		}
 		Character begin_ins_code = new Character(sref.getPdbx_seq_align_beg_ins_code().charAt(0));
 		Character end_ins_code   = new Character(sref.getPdbx_seq_align_end_ins_code().charAt(0));
 


### PR DESCRIPTION
One entry in the archive has a "?" in the seq_align_beg field. This causes a number format exception. According to mmCIF this is legitimate. So Biojava should handle this gracefully.
