### PR TITLE
Improve ligand handling of substructures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,4 @@
+BioJava 5.0.0
+=============
+
+- For short structure selections (e.g. 1abc.A:1-100), ligands within 5A will be included

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -105,21 +105,18 @@ public class StructureToolsTest extends TestCase {
 		Structure hivA = cache.getStructure("1hiv.A");
 		Atom[] caSa = StructureTools.getRepresentativeAtomArray(hivA);
 		Atom[] caCa = StructureTools.getRepresentativeAtomArray(hivA.getChainByIndex(0));
-		//TODO Residue 67 is PTM. In BioJava 4 this is treated as a ligand, so it
-		//     gets added to caSa. In BioJava 5 this should be fixed, so they
-		//     should match again.
 		assertEquals("did not find the same number of Atoms from structure and from chain..",
-				caSa.length-1,caCa.length);
+				caSa.length,caCa.length);
 		Structure hivB = cache.getStructure("1hiv.B");
 		Atom[] caSb = StructureTools.getRepresentativeAtomArray(hivB);
 		Atom[] caCb = StructureTools.getRepresentativeAtomArray(hivB.getChainByIndex(0));
 		assertEquals("did not find the same number of Atoms from structure and from chain..",
-				caSb.length-1,caCb.length);
+				caSb.length,caCb.length);
 		//Both chains have to be the same size (A and B)
-		assertEquals(99,caSa.length-1);
+		assertEquals(99,caSa.length);
 		assertEquals("did not find the same number of Atoms in both chains...",
-				caSa.length-1,caCb.length);
-		assertEquals(99,caSa.length-1);
+				caSa.length,caCb.length);
+		assertEquals(99,caSa.length);
 
 		ChemCompGroupFactory.setChemCompProvider(provider);
 	}
@@ -273,22 +270,26 @@ public class StructureToolsTest extends TestCase {
 
 		String name11 = "4hhb.A";
 		Structure s = cache.getStructure(name11);
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getPolyChains().size());
+		assertEquals(3,s.getChains().size()); // protein, HEM, water
 
 
 		String name12 = "4hhb.A:";
 		s = cache.getStructure(name12);
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getPolyChains().size());
+		assertEquals(3,s.getChains().size());
 
 		String name13 = "4hhb.A_";
 		s = cache.getStructure(name13);
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getPolyChains().size());
+		assertEquals(3,s.getChains().size());
 
 		String name9 = "4hhb.C_1-83";
 		String chainId = "C";
 		s = cache.getStructure(name9);
+		assertEquals(1,s.getPolyChains().size());
+		assertEquals(2,s.getChains().size()); // drops waters
 
-		assertTrue(s.getChains().size() == 1);
 		Chain c = s.getPolyChainByPDB(chainId);
 		assertEquals(c.getName(),chainId);
 		Atom[] ca = StructureTools.getRepresentativeAtomArray(s);
@@ -296,7 +297,8 @@ public class StructureToolsTest extends TestCase {
 
 		String name10 = "4hhb.C_1-83,A_1-10";
 		s = cache.getStructure(name10);
-		assertTrue(s.getChains().size() == 2);
+		assertEquals(2,s.getPolyChains().size());
+		assertEquals(3,s.getChains().size()); // Includes C heme
 		ca = StructureTools.getRepresentativeAtomArray(s);
 		assertEquals(93, ca.length);
 
@@ -416,9 +418,7 @@ public class StructureToolsTest extends TestCase {
 		// range including insertion
 		range = "H:35-37"; //includes 36A
 		substr = StructureTools.getSubRanges(structure3, range);
-		// Because we are loading from PDB, TYS I:363 is recognized as a ligand
-		// rather than a PTM, so it gets included here
-		assertEquals("Wrong number of chains in "+range, 2, substr.size());
+		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
 		chain = substr.getChainByIndex(0);
 
@@ -428,7 +428,7 @@ public class StructureToolsTest extends TestCase {
 		// end with insertion
 		range = "H:35-36A";
 		substr = StructureTools.getSubRanges(structure3, range);
-		assertEquals("Wrong number of chains in "+range, 2, substr.size());
+		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
 		chain = substr.getChainByIndex(0);
 

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -105,18 +105,21 @@ public class StructureToolsTest extends TestCase {
 		Structure hivA = cache.getStructure("1hiv.A");
 		Atom[] caSa = StructureTools.getRepresentativeAtomArray(hivA);
 		Atom[] caCa = StructureTools.getRepresentativeAtomArray(hivA.getChainByIndex(0));
+		//TODO Residue 67 is PTM. In BioJava 4 this is treated as a ligand, so it
+		//     gets added to caSa. In BioJava 5 this should be fixed, so they
+		//     should match again.
 		assertEquals("did not find the same number of Atoms from structure and from chain..",
-				caSa.length,caCa.length);
+				caSa.length-1,caCa.length);
 		Structure hivB = cache.getStructure("1hiv.B");
 		Atom[] caSb = StructureTools.getRepresentativeAtomArray(hivB);
 		Atom[] caCb = StructureTools.getRepresentativeAtomArray(hivB.getChainByIndex(0));
 		assertEquals("did not find the same number of Atoms from structure and from chain..",
-				caSb.length,caCb.length);
+				caSb.length-1,caCb.length);
 		//Both chains have to be the same size (A and B)
-		assertEquals(caSa.length,99);
+		assertEquals(99,caSa.length-1);
 		assertEquals("did not find the same number of Atoms in both chains...",
-				caSa.length,caCb.length);
-		assertEquals(caSa.length, 99);
+				caSa.length-1,caCb.length);
+		assertEquals(99,caSa.length-1);
 
 		ChemCompGroupFactory.setChemCompProvider(provider);
 	}
@@ -413,7 +416,9 @@ public class StructureToolsTest extends TestCase {
 		// range including insertion
 		range = "H:35-37"; //includes 36A
 		substr = StructureTools.getSubRanges(structure3, range);
-		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		// Because we are loading from PDB, TYS I:363 is recognized as a ligand
+		// rather than a PTM, so it gets included here
+		assertEquals("Wrong number of chains in "+range, 2, substr.size());
 
 		chain = substr.getChainByIndex(0);
 
@@ -423,7 +428,7 @@ public class StructureToolsTest extends TestCase {
 		// end with insertion
 		range = "H:35-36A";
 		substr = StructureTools.getSubRanges(structure3, range);
-		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		assertEquals("Wrong number of chains in "+range, 2, substr.size());
 
 		chain = substr.getChainByIndex(0);
 
@@ -439,7 +444,7 @@ public class StructureToolsTest extends TestCase {
 		assertEquals("Did not find the expected number of residues in "+range, 3, chain.getAtomLength() );
 
 		// within insertion
-		range = "L:14-14K"; //includes 36A
+		range = "L:14-14K";
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 
@@ -448,7 +453,7 @@ public class StructureToolsTest extends TestCase {
 		assertEquals("Did not find the expected number of residues in "+range, 12, chain.getAtomLength() );
 
 		// within insertion
-		range = "L:14C-14J"; //includes 36A
+		range = "L:14C-14J";
 		substr = StructureTools.getSubRanges(structure3, range);
 		assertEquals("Wrong number of chains in "+range, 1, substr.size());
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryDisplay.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryDisplay.java
@@ -134,6 +134,7 @@ public class SymmetryDisplay {
 			jmol.evalString(printSymmetryGroup(symmResult));
 			jmol.evalString(printSymmetryAxes(symmResult));
 			jmol.setTitle(getSymmTitle(symmResult));
+			jmol.evalString("save STATE state_1");
 			return jmol;
 		} else {
 			// Show the optimal self-alignment
@@ -145,6 +146,7 @@ public class SymmetryDisplay {
 					cloned);
 			RotationAxis axis = new RotationAxis(symmResult.getSelfAlignment());
 			jmol.evalString(axis.getJmolScript(symmResult.getAtoms()));
+			jmol.evalString("save STATE state_1");
 			return jmol;
 		}
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryListener.java
@@ -68,11 +68,14 @@ public class SymmetryListener implements ActionListener {
 				MultipleAlignmentJmol j = SymmetryDisplay.displayRepeats(symm);
 				String s = SymmetryDisplay.printSymmetryAxes(symm, false);
 				j.evalString(s);
+				j.evalString("save STATE state_1");
+
 
 			} else if (cmd.equals("Multiple Structure Alignment")) {
 				MultipleAlignmentJmol j = SymmetryDisplay.displayFull(symm);
 				String s = SymmetryDisplay.printSymmetryAxes(symm);
 				j.evalString(s);
+				j.evalString("save STATE state_1");
 
 			} else if (cmd.equals("Optimal Self Alignment")) {
 				Atom[] cloned = StructureTools.cloneAtomArray(symm.getAtoms());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomIterator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomIterator.java
@@ -41,21 +41,35 @@ public class AtomIterator implements Iterator<Atom> {
 
 	private final static Logger logger = LoggerFactory.getLogger(AtomIterator.class);
 
-	private Structure structure     ;
 	private Group     group         ;
 	private int current_atom_pos    ;
 	private GroupIterator groupiter ;
 
 	/**
-	 * Constructs an AtomIterator object.
+	 * Constructs an AtomIterator object over all models
 	 *
 	 * @param struct  a Structure object
 	 */
 	public AtomIterator(Structure struct) {
-		structure = struct;
 		current_atom_pos = -1 ;
 
-		groupiter = new GroupIterator(structure) ;
+		groupiter = new GroupIterator(struct) ;
+		if ( groupiter.hasNext() ) {
+			group = groupiter.next() ;
+		}
+		else
+			group = null ;
+	}
+	
+	/**
+	 * Constructs an AtomIterator object over a single model
+	 *
+	 * @param struct  a Structure object
+	 */
+	public AtomIterator(Structure struct,int modelNr) {
+		current_atom_pos = -1 ;
+
+		groupiter = new GroupIterator(struct,modelNr) ;
 		if ( groupiter.hasNext() ) {
 			group = groupiter.next() ;
 		}
@@ -86,12 +100,9 @@ public class AtomIterator implements Iterator<Atom> {
 	 * @param g  a Group object
 	 */
 	public AtomIterator(Group g) {
-		structure = null;
 		group = g ;
 		current_atom_pos = -1 ;
 		groupiter = null ;
-
-
 	}
 
 	/** Is there a next atom ?

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Calc.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Calc.java
@@ -22,17 +22,21 @@
  */
 package org.biojava.nbio.structure;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import javax.vecmath.Matrix3d;
+import javax.vecmath.Matrix4d;
+import javax.vecmath.Point3d;
+import javax.vecmath.Vector3d;
+
 import org.biojava.nbio.structure.geometry.CalcPoint;
 import org.biojava.nbio.structure.geometry.Matrices;
 import org.biojava.nbio.structure.geometry.SuperPositionSVD;
 import org.biojava.nbio.structure.jama.Matrix;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.vecmath.Matrix3d;
-import javax.vecmath.Matrix4d;
-import javax.vecmath.Point3d;
-import javax.vecmath.Vector3d;
 
 /**
  * Utility operations on Atoms, AminoAcids, Matrices, Point3d, etc.
@@ -1226,6 +1230,20 @@ public class Calc {
 		Point3d[] points = new Point3d[atoms.length];
 		for (int i = 0; i < atoms.length; i++) {
 			points[i] = atoms[i].getCoordsAsPoint3d();
+		}
+		return points;
+	}
+	/**
+	 * Convert an array of atoms into an array of vecmath points
+	 * 
+	 * @param atoms
+	 *            list of atoms
+	 * @return list of Point3ds storing the x,y,z coordinates of each atom
+	 */
+	public static List<Point3d> atomsToPoints(Collection<Atom> atoms) {
+		ArrayList<Point3d> points = new ArrayList<>(atoms.size());
+		for (Atom atom : atoms) {
+			points.add(atom.getCoordsAsPoint3d());
 		}
 		return points;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Group.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Group.java
@@ -293,6 +293,8 @@ public interface Group {
 	/**
 	 * Utility method for returning the chainId of the Group or null if no
 	 * Chain has been set. This is equivalent to calling getChain().getId()
+	 * 
+	 * Prior to version 5.0 this method returned the chain name.
 	 * @since 3.0
 	 * @return  the ID of the chain
 	 */

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/GroupIterator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/GroupIterator.java
@@ -42,19 +42,32 @@ public class GroupIterator implements Iterator<Group> {
 	private int current_model_pos ;
 	private int current_chain_pos ;
 	private int current_group_pos ;
+	private boolean fixed_model   ;
+	
 
 	/**
-	 * Constructs a GroupIterator object.
+	 * Constructs a GroupIterator object over all models
 	 *
 	 * @param struct  a Structure object
 	 */
-
 	public GroupIterator (Structure struct) {
 		structure = struct     ;
 		current_model_pos = 0  ;
 		current_chain_pos = 0  ;
 		current_group_pos = -1 ;
-
+		fixed_model = false    ;
+	}
+	/**
+	 * Constructs a GroupIterator object over a specific model
+	 *
+	 * @param struct  a Structure object
+	 */
+	public GroupIterator (Structure struct, int modelNr) {
+		structure = struct     ;
+		current_model_pos = modelNr;
+		current_chain_pos = 0  ;
+		current_group_pos = -1 ;
+		fixed_model = true     ;
 	}
 
 
@@ -75,6 +88,7 @@ public class GroupIterator implements Iterator<Group> {
 		gr.setModelPos(this.getModelPos());
 		gr.setChainPos(this.getChainPos());
 		gr.setGroupPos(this.getGroupPos());
+		gr.fixed_model = this.fixed_model;
 		return gr ;
 
 	}
@@ -99,6 +113,8 @@ public class GroupIterator implements Iterator<Group> {
 		List<Chain> model = structure.getModel(tmp_model);
 
 		if (tmp_chain >= model.size()) {
+			if(fixed_model)
+				return false;
 			return hasSubGroup(tmp_model + 1, 0, 0);
 		}
 
@@ -164,6 +180,8 @@ public class GroupIterator implements Iterator<Group> {
 		List<Chain> model = structure.getModel(tmp_model);
 
 		if ( tmp_chain >= model.size() ){
+			if(fixed_model)
+				throw new NoSuchElementException("arrived at end of model!");
 			return getNextGroup(tmp_model+1,0,0);
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
@@ -722,7 +722,7 @@ public interface Structure extends Cloneable {
 	 * Request a particular entity by its entity id (mol id in legacy PDB format)
 	 *
 	 * @param entityId the number of the entity
-	 * @return an entity 
+	 * @return an entity, or null if the molId was not found
 	 */	
 	EntityInfo getEntityById(int entityId);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Structure.java
@@ -535,6 +535,9 @@ public interface Structure extends Cloneable {
 	/** 
 	 * Retrieve a polymeric Chain based on the 'internal' chain
 	 * id (asymId) for the first model
+	 * 
+	 * <p>See {@link #getPolyChainByPDB(String)} for a similar
+	 * method using the chain name (authId).
 	 * @param asymId the asymId (chainId)
 	 * @return a polymeric Chain or null if it can't be found
 	 * @since 5.0 
@@ -544,6 +547,9 @@ public interface Structure extends Cloneable {
 	/** 
 	 * Retrieve a polymeric Chain based on the 'internal' chain
 	 * id (asymId) for the given model index
+	 * 
+	 * <p>See {@link #getPolyChainByPDB(String, int)} for a similar
+	 * method using the chain name (authId).
 	 * @param asymId the asymId (chainId)
 	 * @param modelIdx the index of the required model (0-based)
 	 * @return a polymeric Chain or null if it can't be found
@@ -554,6 +560,9 @@ public interface Structure extends Cloneable {
 	/** 
 	 * Retrieve a polymeric Chain based on the 'public' chain
 	 * name (authId) for the first model
+	 * 
+	 * <p>See {@link #getPolyChain(String)} for a similar
+	 * method using the chain id (asymId).
 	 * @param authId the author id (chainName, public chain id)
 	 * @return a polymeric Chain or null if it can't be found
 	 * @since 5.0 
@@ -562,11 +571,15 @@ public interface Structure extends Cloneable {
 	
 	/** 
 	 * Retrieve a polymeric Chain based on the 'public' chain
-	 * name (authId) for the given model index
+	 * name (authId) for the given model index.
+	 * 
+	 * <p>See {@link #getPolyChain(String, int)} for a similar
+	 * method using the chain id (asymId).
 	 * @param authId the author id (chainName, public chain id)
 	 * @param modelIdx the index of the required model (0-based)
 	 * @return a polymeric Chain or null if it can't be found
 	 * @since 5.0 
+	 * 
 	 */
 	Chain getPolyChainByPDB(String authId, int modelIdx);
 
@@ -702,6 +715,7 @@ public interface Structure extends Cloneable {
 	 * @return a entityInfo
 	 * @deprecated use {@link #getEntityById(int)} instead
 	 */
+	@Deprecated
 	EntityInfo getCompoundById(int entityId);
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -690,6 +690,9 @@ public class StructureImpl implements Structure, Serializable {
 	@Override
 	public Chain getChainByPDB(String chainId)
 			throws StructureException{
+		if(nrModels() < 1 ) {
+			throw new StructureException("No chains are present.");
+		}
 		return getChainByPDB(chainId,0);
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -203,36 +203,37 @@ public class StructureImpl implements Structure, Serializable {
 
 		// first we need to gather all groups with the author id chainName: polymers, non-polymers and waters
 		Chain polyChain = getPolyChainByPDB(chainName, modelnr);
-		List<Group> groups = new ArrayList<>();
+		if(polyChain != null) {
+			List<Group> groups = new ArrayList<>();
 
-		groups.addAll(polyChain.getAtomGroups());
-
-
-		// there can be more thatn one non-poly chain for a given author id
-		for (Chain chain: getNonPolyChainsByPDB(chainName, modelnr)) {
-			groups.addAll(chain.getAtomGroups());
-		}
-		
-		Chain water = getWaterChainByPDB(chainName, modelnr);
-		
-		if (water!=null)
-			groups.addAll(water.getAtomGroups());
-		
+			groups.addAll(polyChain.getAtomGroups());
 
 
-		// now iterate over all groups 
-		// in order to find the amino acid that has this pdbRenum.
+			// there can be more than one non-poly chain for a given author id
+			for (Chain chain: getNonPolyChainsByPDB(chainName, modelnr)) {
+				groups.addAll(chain.getAtomGroups());
+			}
 
-		for (Group g : groups) {
-			String rnum = g.getResidueNumber().toString();
-			//System.out.println(g + " >" + rnum + "< >" + pdbResnum + "<");
-			// we only mutate amino acids
-			// and ignore hetatoms and nucleotides in this case
-			if (rnum.equals(pdbResnum)) {
-				return g;
+			Chain water = getWaterChainByPDB(chainName, modelnr);
+
+			if (water!=null)
+				groups.addAll(water.getAtomGroups());
+
+
+
+			// now iterate over all groups 
+			// in order to find the amino acid that has this pdbRenum.
+
+			for (Group g : groups) {
+				String rnum = g.getResidueNumber().toString();
+				//System.out.println(g + " >" + rnum + "< >" + pdbResnum + "<");
+				// we only mutate amino acids
+				// and ignore hetatoms and nucleotides in this case
+				if (rnum.equals(pdbResnum)) {
+					return g;
+				}
 			}
 		}
-
 		throw new StructureException("could not find group " + pdbResnum +
 				" in chain " + chainName);
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -345,7 +345,7 @@ public class StructureTools {
 	}
 
 	/**
-	 * Convert all atoms of the structure (first model) into an Atom array
+	 * Convert all atoms of the structure (all models) into an Atom array
 	 *
 	 * @param s
 	 *            input structure
@@ -361,9 +361,27 @@ public class StructureTools {
 		}
 		return atoms.toArray(new Atom[atoms.size()]);
 	}
+	/**
+	 * Convert all atoms of the structure (specified model) into an Atom array
+	 *
+	 * @param s
+	 *            input structure
+	 * @return all atom array
+	 */
+	public static final Atom[] getAllAtomArray(Structure s, int model) {
+		List<Atom> atoms = new ArrayList<Atom>();
+
+		AtomIterator iter = new AtomIterator(s,model);
+		while (iter.hasNext()) {
+			Atom a = iter.next();
+			atoms.add(a);
+		}
+		return atoms.toArray(new Atom[atoms.size()]);
+
+	}
 
 	/**
-	 * Returns and array of all atoms of the chain (first model), including
+	 * Returns and array of all atoms of the chain, including
 	 * Hydrogens (if present) and all HETATOMs. Waters are not included.
 	 *
 	 * @param c

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -504,6 +504,77 @@ public class StructureTools {
 		}
 		return ligands;
 	}
+	
+	/**
+	 * Expand a set of atoms into all groups from the same structure.
+	 * 
+	 * If the structure is set, only the first atom is used (assuming all
+	 * atoms come from the same original structure).
+	 * If the atoms aren't linked to a structure (for instance, for cloned atoms),
+	 * searches all chains of all atoms for groups.
+	 * @param atoms Sample of atoms
+	 * @return All groups from all chains accessible from the input atoms
+	 */
+	public static Set<Group> getAllGroupsFromSubset(Atom[] atoms) {
+		return getAllGroupsFromSubset(atoms,null);
+	}
+	/**
+	 * Expand a set of atoms into all groups from the same structure.
+	 * 
+	 * If the structure is set, only the first atom is used (assuming all
+	 * atoms come from the same original structure).
+	 * If the atoms aren't linked to a structure (for instance, for cloned atoms),
+	 * searches all chains of all atoms for groups.
+	 * @param atoms Sample of atoms
+	 * @param types Type of groups to return (useful for getting only ligands, for instance).
+	 *  Null gets all groups.
+	 * @return All groups from all chains accessible from the input atoms
+	 */
+	public static Set<Group> getAllGroupsFromSubset(Atom[] atoms,GroupType types) {
+		// Get the full structure
+		Structure s = null;
+		if (atoms.length > 0) {
+			Group g = atoms[0].getGroup();
+			if (g != null) {
+				Chain c = g.getChain();
+				if (c != null) {
+					s = c.getStructure();
+				}
+			}
+		}
+		// Collect all groups from the structure
+		Set<Chain> allChains = new HashSet<>();
+		if( s != null ) {
+			allChains.addAll(s.getChains());
+		}
+		// In case the structure wasn't set, need to use ca chains too
+		for(Atom a : atoms) {
+			Group g = a.getGroup();
+			if(g != null) {
+				Chain c = g.getChain();
+				if( c != null ) {
+					allChains.add(c);
+				}
+			}
+		}
+
+		if(allChains.isEmpty() ) {
+			return Collections.emptySet();
+		}
+		
+		// Extract all ligand groups
+		Set<Group> full = new HashSet<>();
+		for(Chain c : allChains) {
+			if(types == null) {
+				full.addAll(c.getAtomGroups());
+			} else {
+				full.addAll(c.getAtomGroups(types));
+			}
+		}
+
+		return full;
+	}
+
 
 	/**
 	 * Returns and array of all non-Hydrogen atoms in the given Structure,

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -468,10 +468,10 @@ public class StructureTools {
 	 * Finds all ligand groups from the target which fall within the cutoff distance
 	 * of some atom from the query set.
 	 * 
-	 * @param target Set of groups
-	 * @param query
-	 * @param cutoff
-	 * @return
+	 * @param target Set of groups including the ligands
+	 * @param query Atom selection
+	 * @param cutoff Distance from query atoms to consider, in angstroms
+	 * @return All groups from the target with at least one atom within cutoff of a query atom
 	 * @see StructureTools#DEFAULT_LIGAND_PROXIMITY_CUTOFF
 	 */
 	public static List<Group> getLigandsByProximity(Collection<Group> target, Atom[] query, double cutoff) {
@@ -586,9 +586,26 @@ public class StructureTools {
 	 * @return
 	 */
 	public static final Atom[] getAllNonHAtomArray(Structure s, boolean hetAtoms) {
+		AtomIterator iter = new AtomIterator(s);
+		return getAllNonHAtomArray(s, hetAtoms, iter);
+	}
+	/**
+	 * Returns and array of all non-Hydrogen atoms in the given Structure,
+	 * optionally including HET atoms or not. Waters are not included.
+	 *
+	 * @param s
+	 * @param hetAtoms
+	 *            if true HET atoms are included in array, if false they are not
+	 * @param modelNr Model number to draw atoms from
+	 * @return
+	 */
+	public static final Atom[] getAllNonHAtomArray(Structure s, boolean hetAtoms, int modelNr) {
+		AtomIterator iter = new AtomIterator(s,modelNr);
+		return getAllNonHAtomArray(s, hetAtoms, iter);
+	}
+	private static final Atom[] getAllNonHAtomArray(Structure s, boolean hetAtoms, AtomIterator iter) {
 		List<Atom> atoms = new ArrayList<Atom>();
 
-		AtomIterator iter = new AtomIterator(s);
 		while (iter.hasNext()) {
 			Atom a = iter.next();
 			if (a.getElement() == Element.H)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -156,7 +156,7 @@ public class StructureTools {
 	/**
 	 * Threshold for plausible binding of a ligand to the selected substructure
 	 */
-	public static final double DEFAULT_LIGAND_PROXIMITY_CUTOFF = 7;
+	public static final double DEFAULT_LIGAND_PROXIMITY_CUTOFF = 5;
 
 	// there is a file format change in PDB 3.0 and nucleotides are being
 	// renamed

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -45,6 +45,8 @@ import org.biojava.nbio.structure.contact.AtomContactSet;
 import org.biojava.nbio.structure.contact.Grid;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.PDBFileParser;
+import org.biojava.nbio.structure.io.mmcif.chem.PolymerType;
+import org.biojava.nbio.structure.io.mmcif.chem.ResidueType;
 import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.biojava.nbio.structure.io.util.FileDownloadUtils;
 import org.slf4j.Logger;
@@ -503,6 +505,69 @@ public class StructureTools {
 			ligands.add(g);
 		}
 		return ligands;
+	}
+	
+	/**
+	 * Adds a particular group to a structure. A new chain will be created if necessary.
+	 * 
+	 * <p>When adding multiple groups, pass the return value of one call as the
+	 * chainGuess parameter of the next call for efficiency.
+	 * <pre>
+	 * Chain guess = null;
+	 * for(Group g : groups) {
+	 *     guess = addGroupToStructure(s, g, guess );
+	 * }
+	 * </pre>
+	 * @param s structure to receive the group
+	 * @param g group to add
+	 * @param chainGuess (optional) If not null, should be a chain from s. Used
+	 *  to improve performance when adding many groups from the same chain
+	 * @param clone Indicates whether the input group should be cloned before
+	 *  being added to the new chain
+	 * @return the chain g was added to
+	 */
+	public static Chain addGroupToStructure(Structure s, Group g, Chain chainGuess, boolean clone ) {
+		// Find or create the chain
+		String chainId = g.getChainId();
+		assert !chainId.isEmpty();
+		Chain chain;
+		if(chainGuess != null && chainGuess.getId() == chainId) {
+			// previously guessed chain
+			chain = chainGuess;
+		} else {
+			// Try to guess
+			chain = s.getChain(chainId);
+			if(chain == null) {
+				// no chain found
+				chain = new ChainImpl();
+				chain.setId(chainId);
+				chain.setName(g.getChain().getName());
+				s.addChain(chain);
+			}
+		}
+		
+		// Add cloned group
+		if(clone) {
+			g = (Group)g.clone();
+		}
+		chain.addGroup(g);
+		
+		return chain;
+	}
+
+	/**
+	 * Add a list of groups to a new structure. Chains will be automatically
+	 * created in the new structure as needed.
+	 * @param s structure to receive the group
+	 * @param g group to add
+	 * @param clone Indicates whether the input groups should be cloned before
+	 *  being added to the new chain
+	 */
+	public static void addGroupsToStructure(Structure s, Collection<Group> groups, boolean clone) {
+		Chain chainGuess = null;
+		for(Group g : groups) {
+			chainGuess = addGroupToStructure(s, g, chainGuess, clone);
+		}
 	}
 	
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -27,6 +27,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -150,6 +152,11 @@ public class StructureTools {
 	 * character of the chain (protein/nucleotide)
 	 */
 	public static final double RATIO_RESIDUES_TO_TOTAL = 0.95;
+
+	/**
+	 * Threshold for plausible binding of a ligand to the selected substructure
+	 */
+	public static final double DEFAULT_LIGAND_PROXIMITY_CUTOFF = 7;
 
 	// there is a file format change in PDB 3.0 and nucleotides are being
 	// renamed
@@ -455,6 +462,47 @@ public class StructureTools {
 			}
 		}
 		return unadded;
+	}
+
+	/**
+	 * Finds all ligand groups from the target which fall within the cutoff distance
+	 * of some atom from the query set.
+	 * 
+	 * @param target Set of groups
+	 * @param query
+	 * @param cutoff
+	 * @return
+	 * @see StructureTools#DEFAULT_LIGAND_PROXIMITY_CUTOFF
+	 */
+	public static List<Group> getLigandsByProximity(Collection<Group> target, Atom[] query, double cutoff) {
+		// Geometric hashing of the reduced structure
+		Grid grid = new Grid(cutoff);
+		grid.addAtoms(query);
+
+		List<Group> ligands = new ArrayList<>();
+		for(Group g :target ) {
+			// don't worry about waters
+			if(g.isWater()) {
+				continue;
+			}
+
+			ChemComp chemComp = g.getChemComp();
+			if(chemComp != null && chemComp.isStandard() ) {
+				// Polymers aren't ligands
+				continue;
+			}
+
+			// It is a ligand!
+
+			// Check that it's within cutoff of something in reduced
+			List<Atom> groupAtoms = g.getAtoms();
+			if( ! grid.hasAnyContact(Calc.atomsToPoints(groupAtoms))) {
+				continue;
+			}
+
+			ligands.add(g);
+		}
+		return ligands;
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -287,9 +287,10 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 
 					prevChainId = c.getId();
 				} // end range
+
+				// Transfer any close ligands
+				copyLigandsByProximity(s,newS, StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
 			}
-			
-			copyLigandsByProximity(s,newS, StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
 		} // end modelNr
 
 		return newS;
@@ -317,7 +318,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 	 * a distance cutoff. Ligand groups are moved (destructively) from full to reduced
 	 * if they fall within the cutoff of any atom in the reduced structure.
 	 * The {@link StructureTools#DEFAULT_LIGAND_PROXIMITY_CUTOFF default cutoff}
-	 * (currently 7Å) is used.
+	 * is used.
 	 * @param full Structure containing all ligands
 	 * @param reduced Structure with a subset of the polymer groups from full
 	 * @see StructureTools#getLigandsByProximity(java.util.Collection, Atom[], double)
@@ -344,6 +345,8 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 		// Geometric hashing of the reduced structure
 		Grid grid = new Grid(cutoff);
 		Atom[] nonwaters = StructureTools.getAllNonHAtomArray(reduced,true,toModel);
+		if( nonwaters.length < 1 )
+			return;
 		grid.addAtoms(nonwaters);
 
 		

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -31,6 +31,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.biojava.nbio.structure.align.util.AtomCache;
+import org.biojava.nbio.structure.contact.Grid;
+import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,6 +75,9 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 	private static final long serialVersionUID = 1L;
 
 	private static final Logger logger = LoggerFactory.getLogger(SubstructureIdentifier.class);
+	
+	// Threshold for plausible binding of a ligand to the selected substructure
+	private static final double DEFAULT_LIGAND_PROXIMITY_CUTOFF = 7;
 
 	private final String pdbId;
 	private final List<ResidueRange> ranges;
@@ -285,6 +290,8 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 					prevChainId = c.getId();
 				} // end range
 			}
+			
+			copyLigandsByProximity(s,newS, DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
 		} // end modelNr
 
 		return newS;
@@ -307,4 +314,74 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 		return cache.getStructureForPdbId(pdb);
 	}
 
+	static void copyLigandsByProximity(Structure full, Structure reduced) {
+		// Normal case where all models should be copied from full to reduced
+		assert full.nrModels() >= reduced.nrModels();
+		for(int model = 0; model< reduced.nrModels(); model++) {
+			copyLigandsByProximity(full, reduced, DEFAULT_LIGAND_PROXIMITY_CUTOFF, model, model);
+		}
+	}
+	static void copyLigandsByProximity(Structure full, Structure reduced, double cutoff, int fromModel, int toModel) {
+		// Geometric hashing of the reduced structure
+		Grid grid = new Grid(cutoff);
+		grid.addAtoms(StructureTools.getAllAtomArray(reduced,toModel));
+
+		
+		// Find ligands from full structure
+		for(Chain fullChain : full.getModel(fromModel)) {
+			String chainId = fullChain.getChainID();
+			Chain reducedChain = null;
+
+			for(Group g :fullChain.getAtomGroups() ) {
+				
+				// don't worry about waters
+				if(g.isWater()) {
+					continue;
+				}
+				
+				ChemComp chemComp = g.getChemComp();
+				if(chemComp != null && chemComp.isStandard() ) {
+					// Polymers aren't ligands
+					continue;
+				}
+				
+				// It is a ligand
+				// Check that it's within cutoff of something in reduced
+				List<Atom> groupAtoms = g.getAtoms();
+				if( ! grid.hasAnyContact(Calc.atomsToPoints(groupAtoms))) {
+					continue;
+				}
+				
+				// Check that it's not in reduced already
+				try {
+					if( reduced.findGroup(g.getChainId(), g.getResidueNumber().toString(), toModel) != null)
+						continue;
+				} catch (StructureException e) {
+					// not found
+				}
+				
+				// Find or create reducedChain
+				if(reducedChain == null) {
+					try {
+						reducedChain = reduced.findChain(chainId, toModel);
+					} catch( StructureException e) {
+						//chain not yet in structure
+					}
+				}
+				if(reducedChain == null) {
+					// create chain
+					reducedChain = new ChainImpl();
+					reducedChain.setChainID(chainId);
+					reduced.addChain(reducedChain,toModel);
+					reducedChain.setSeqResGroups(fullChain.getSeqResGroups());
+					reducedChain.setSeqMisMatches(fullChain.getSeqMisMatches());
+				}
+				
+				// Add group
+				logger.info("Adding ligand group {} {} by proximity",g.getPDBName(), g.getResidueNumber().toPDB());
+				reducedChain.addGroup(g);
+			}
+		}
+			
+	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -76,8 +76,6 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 
 	private static final Logger logger = LoggerFactory.getLogger(SubstructureIdentifier.class);
 	
-	// Threshold for plausible binding of a ligand to the selected substructure
-	private static final double DEFAULT_LIGAND_PROXIMITY_CUTOFF = 7;
 
 	private final String pdbId;
 	private final List<ResidueRange> ranges;
@@ -291,7 +289,7 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 				} // end range
 			}
 			
-			copyLigandsByProximity(s,newS, DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
+			copyLigandsByProximity(s,newS, StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF, modelNr, modelNr);
 		} // end modelNr
 
 		return newS;
@@ -314,14 +312,35 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 		return cache.getStructureForPdbId(pdb);
 	}
 
-	static void copyLigandsByProximity(Structure full, Structure reduced) {
+	/**
+	 * Supplements the reduced structure with ligands from the full structure based on
+	 * a distance cutoff. Ligand groups are moved (destructively) from full to reduced
+	 * if they fall within the cutoff of any atom in the reduced structure.
+	 * The {@link StructureTools#DEFAULT_LIGAND_PROXIMITY_CUTOFF default cutoff}
+	 * (currently 7Å) is used.
+	 * @param full Structure containing all ligands
+	 * @param reduced Structure with a subset of the polymer groups from full
+	 * @see StructureTools#getLigandsByProximity(java.util.Collection, Atom[], double)
+	 */
+	protected static void copyLigandsByProximity(Structure full, Structure reduced) {
 		// Normal case where all models should be copied from full to reduced
 		assert full.nrModels() >= reduced.nrModels();
 		for(int model = 0; model< reduced.nrModels(); model++) {
-			copyLigandsByProximity(full, reduced, DEFAULT_LIGAND_PROXIMITY_CUTOFF, model, model);
+			copyLigandsByProximity(full, reduced, StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF, model, model);
 		}
 	}
-	static void copyLigandsByProximity(Structure full, Structure reduced, double cutoff, int fromModel, int toModel) {
+	/**
+	 * Supplements the reduced structure with ligands from the full structure based on
+	 * a distance cutoff. Ligand groups are moved (destructively) from full to reduced
+	 * if they fall within the cutoff of any atom in the reduced structure.
+	 * @param full Structure containing all ligands
+	 * @param reduced Structure with a subset of the polymer groups from full
+	 * @param cutoff Distance cutoff (Å)
+	 * @param fromModel source model in full
+	 * @param toModel destination model in reduced
+	 * @see StructureTools#getLigandsByProximity(java.util.Collection, Atom[], double)
+	 */
+	protected static void copyLigandsByProximity(Structure full, Structure reduced, double cutoff, int fromModel, int toModel) {
 		// Geometric hashing of the reduced structure
 		Grid grid = new Grid(cutoff);
 		grid.addAtoms(StructureTools.getAllAtomArray(reduced,toModel));
@@ -384,4 +403,5 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 		}
 			
 	}
+
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -343,7 +343,8 @@ public class SubstructureIdentifier implements Serializable, StructureIdentifier
 	protected static void copyLigandsByProximity(Structure full, Structure reduced, double cutoff, int fromModel, int toModel) {
 		// Geometric hashing of the reduced structure
 		Grid grid = new Grid(cutoff);
-		grid.addAtoms(StructureTools.getAllAtomArray(reduced,toModel));
+		Atom[] nonwaters = StructureTools.getAllNonHAtomArray(reduced,true,toModel);
+		grid.addAtoms(nonwaters);
 
 		
 		// Find ligands from full structure

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/BoundingBox.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/BoundingBox.java
@@ -199,6 +199,20 @@ public class BoundingBox implements Serializable {
 		return true;
 
 	}
+	
+	/**
+	 * Check if a given point falls within this box
+	 * @param atom
+	 * @return
+	 */
+	public boolean contains(Point3d atom) {
+		double x = atom.x;
+		double y = atom.y;
+		double z = atom.z;
+		return xmin <= x && x <= xmax
+				&& ymin <= y && y <= ymax
+				&& zmin <= z && z <= zmax;
+	}
 
 	public void translate(Vector3d translation) {
 		xmin+=translation.x;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/Grid.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/Grid.java
@@ -22,6 +22,8 @@ package org.biojava.nbio.structure.contact;
 
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import javax.vecmath.Point3d;
@@ -451,6 +453,43 @@ public class Grid {
 		}
 
 		return list;
+	}
+
+	/**
+	 * Fast determination of whether any atoms from a given set fall within
+	 * the cutoff of iAtoms. If {@link #addAtoms(Atom[], Atom[])} was called
+	 * with two sets of atoms, contacts to either set are considered.
+	 * @param atoms
+	 * @return
+	 */
+	public boolean hasAnyContact(Point3d[] atoms) {
+		return hasAnyContact(Arrays.asList(atoms));
+	}
+	public boolean hasAnyContact(Collection<Point3d> atoms) {
+		for(Point3d atom : atoms) {
+			// Calculate Grid cell for the atom
+			int xind = xintgrid2xgridindex(getFloor(atom.x));
+			int yind = yintgrid2ygridindex(getFloor(atom.y));
+			int zind = zintgrid2zgridindex(getFloor(atom.z));
+
+			// Consider 3x3x3 grid of cells around point
+			for (int x=xind-1;x<=xind+1;x++) {
+				if( x<0 || cells.length<=x) continue;
+				for (int y=yind-1;y<=yind+1;y++) {
+					if( y<0 || cells[x].length<=y ) continue;
+					for (int z=zind-1;z<=zind+1;z++) {
+						if( z<0 || cells[x][y].length<=z ) continue;
+						
+						GridCell cell = cells[x][y][z];
+						// Check for contacts in this cell
+						if(cell != null && cell.hasContactToAtom(iAtoms, jAtoms, atom, cutoff)) {
+							return true;
+						}
+					}
+				}
+			}
+		}
+		return false;
 	}
 
 	public double getCutoff() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GridCell.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GridCell.java
@@ -141,5 +141,38 @@ public class GridCell {
 
 		return contacts;
 	}
+	
+	/**
+	 * Tests whether any atom in this cell has a contact with the specified query atom
+	 * @param iAtoms the first set of atoms to which the iIndices correspond
+	 * @param jAtoms the second set of atoms to which the jIndices correspond, or null
+	 * @param query test point
+	 * @param cutoff
+	 * @return
+	 */
+	public boolean hasContactToAtom(Point3d[] iAtoms, Point3d[] jAtoms, Point3d query, double cutoff) {
+		for( int i : iIndices ) {
+			double distance = iAtoms[i].distance(query);
+			if( distance<cutoff)
+				return true;
+		}
+		if (jAtoms!=null) {
+			for( int i : jIndices ) {
+				double distance = jAtoms[i].distance(query);
+				if( distance<cutoff)
+					return true;
+			}
+		}
+		return false;
+	}
 
+	/* (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return String.format("GridCell [%d iAtoms,%d jAtoms]",iIndices.size(),jIndices==null?"-":jIndices.size());
+	}
+
+	
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
@@ -34,7 +34,6 @@ import javax.vecmath.Matrix4d;
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.Calc;
 import org.biojava.nbio.structure.Chain;
-import org.biojava.nbio.structure.ChainImpl;
 import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.GroupType;
 import org.biojava.nbio.structure.Structure;
@@ -536,7 +535,7 @@ public class SymmetryTools {
 			Chain prevChain = null;
 			for(int k=res1;k<=res2; k++) {
 				Group g = atoms[k].getGroup();
-				prevChain = StructureTools.addGroupToStructure(s, g, prevChain,true);
+				prevChain = StructureTools.addGroupToStructure(s, g, 0, prevChain,true);
 				repeat.addAll(g.getAtoms());
 			}
 
@@ -548,7 +547,7 @@ public class SymmetryTools {
 			
 			logger.warn("Adding {} ligands to {}",ligands.size(), symmetry.getMultipleAlignment().getStructureIdentifier(i));
 			for( Group ligand : ligands) {
-				prevChain = StructureTools.addGroupToStructure(s, ligand, prevChain,true);
+				prevChain = StructureTools.addGroupToStructure(s, ligand, 0, prevChain,true);
 			}
 
 			repeats.add(s);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
@@ -36,6 +36,7 @@ import org.biojava.nbio.structure.Calc;
 import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.ChainImpl;
 import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.GroupType;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIdentifier;
@@ -510,7 +511,8 @@ public class SymmetryTools {
 					+ "is not refined, repeats cannot be defined");
 
 		int order = symmetry.getMultipleAlignment().size();
-		Atom[] atoms = StructureTools.cloneAtomArray(symmetry.getAtoms());
+		Atom[] atoms = symmetry.getAtoms();
+		Set<Group> allGroups = StructureTools.getAllGroupsFromSubset(atoms, GroupType.HETATM);
 		List<StructureIdentifier> repeatsId = symmetry.getRepeatsID();
 		List<Structure> repeats = new ArrayList<Structure>(order);
 
@@ -523,22 +525,83 @@ public class SymmetryTools {
 			Block align = symmetry.getMultipleAlignment().getBlock(0);
 
 			// Get the start and end of the repeat
+			// Repeats are always sequential blocks
 			int res1 = align.getStartResidue(i);
 			int res2 = align.getFinalResidue(i);
-
-			Atom[] repeat = Arrays.copyOfRange(atoms, res1, res2 + 1);
-
-			Chain newCh = new ChainImpl();
-			newCh.setId(repeat[0].getGroup().getChainId());
-
-			for (int k = 0; k < repeat.length; k++) {
-				Group g = (Group) repeat[k].getGroup().clone();
-				newCh.addGroup(g);
+			
+			// All atoms from the repeat, used for ligand search
+			// AA have an average of 8.45 atoms, so guess capacity with that
+			List<Atom> repeat = new ArrayList<>(Math.max(9*(res2-res1+1),9));
+			// speedy chain lookup
+			Chain prevChain = null;
+			for(int k=res1;k<=res2; k++) {
+				Group g = atoms[k].getGroup();
+				prevChain = addGroupToStructure(s, g, prevChain,true);
+				repeat.addAll(g.getAtoms());
 			}
-			s.addChain(newCh);
+
+			
+			List<Group> ligands = StructureTools.getLigandsByProximity(
+					allGroups,
+					repeat.toArray(new Atom[repeat.size()]),
+					StructureTools.DEFAULT_LIGAND_PROXIMITY_CUTOFF);
+			
+			logger.warn("Adding {} ligands to {}",ligands.size(), symmetry.getMultipleAlignment().getStructureIdentifier(i));
+			for( Group ligand : ligands) {
+				prevChain = addGroupToStructure(s, ligand, prevChain,true);
+			}
+
 			repeats.add(s);
 		}
 		return repeats;
+	}
+
+	/**
+	 * Adds a particular group to a structure. A new chain will be created if necessary.
+	 * 
+	 * <p>When adding multiple groups, pass the return value of one call as the
+	 * chainGuess parameter of the next call for efficiency.
+	 * <pre>
+	 * Chain guess = null;
+	 * for(Group g : groups) {
+	 *     guess = addGroupToStructure(s, g, guess );
+	 * }
+	 * </pre>
+	 * @param s structure to receive the group
+	 * @param g group to add
+	 * @param chainGuess (optional) If not null, should be a chain from s. Used
+	 *  to improve performance when adding many groups from the same chain
+	 * @param clone Indicates whether the input group should be cloned before
+	 *  being added to the new chain
+	 * @return the chain g was added to
+	 */
+	public static Chain addGroupToStructure(Structure s, Group g, Chain chainGuess, boolean clone ) {
+		// Find or create the chain
+		String chainId = g.getChainId();
+		assert !chainId.isEmpty();
+		Chain chain;
+		if(chainGuess != null && chainGuess.getId() == chainId) {
+			// previously guessed chain
+			chain = chainGuess;
+		} else {
+			// Try to guess
+			chain = s.getChain(chainId);
+			if(chain == null) {
+				// no chain found
+				chain = new ChainImpl();
+				chain.setId(chainId);
+				chain.setName(g.getChain().getName());
+				s.addChain(chain);
+			}
+		}
+		
+		// Add cloned group
+		if(clone) {
+			g = (Group)g.clone();
+		}
+		chain.addGroup(g);
+		
+		return chain;
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
@@ -536,7 +536,7 @@ public class SymmetryTools {
 			Chain prevChain = null;
 			for(int k=res1;k<=res2; k++) {
 				Group g = atoms[k].getGroup();
-				prevChain = addGroupToStructure(s, g, prevChain,true);
+				prevChain = StructureTools.addGroupToStructure(s, g, prevChain,true);
 				repeat.addAll(g.getAtoms());
 			}
 
@@ -548,60 +548,12 @@ public class SymmetryTools {
 			
 			logger.warn("Adding {} ligands to {}",ligands.size(), symmetry.getMultipleAlignment().getStructureIdentifier(i));
 			for( Group ligand : ligands) {
-				prevChain = addGroupToStructure(s, ligand, prevChain,true);
+				prevChain = StructureTools.addGroupToStructure(s, ligand, prevChain,true);
 			}
 
 			repeats.add(s);
 		}
 		return repeats;
-	}
-
-	/**
-	 * Adds a particular group to a structure. A new chain will be created if necessary.
-	 * 
-	 * <p>When adding multiple groups, pass the return value of one call as the
-	 * chainGuess parameter of the next call for efficiency.
-	 * <pre>
-	 * Chain guess = null;
-	 * for(Group g : groups) {
-	 *     guess = addGroupToStructure(s, g, guess );
-	 * }
-	 * </pre>
-	 * @param s structure to receive the group
-	 * @param g group to add
-	 * @param chainGuess (optional) If not null, should be a chain from s. Used
-	 *  to improve performance when adding many groups from the same chain
-	 * @param clone Indicates whether the input group should be cloned before
-	 *  being added to the new chain
-	 * @return the chain g was added to
-	 */
-	public static Chain addGroupToStructure(Structure s, Group g, Chain chainGuess, boolean clone ) {
-		// Find or create the chain
-		String chainId = g.getChainId();
-		assert !chainId.isEmpty();
-		Chain chain;
-		if(chainGuess != null && chainGuess.getId() == chainId) {
-			// previously guessed chain
-			chain = chainGuess;
-		} else {
-			// Try to guess
-			chain = s.getChain(chainId);
-			if(chain == null) {
-				// no chain found
-				chain = new ChainImpl();
-				chain.setId(chainId);
-				chain.setName(g.getChain().getName());
-				s.addChain(chain);
-			}
-		}
-		
-		// Add cloned group
-		if(clone) {
-			g = (Group)g.clone();
-		}
-		chain.addGroup(g);
-		
-		return chain;
 	}
 
 	/**

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
@@ -81,10 +81,17 @@ public class TestAtomCache {
 		String chainId2 = "C";
 		s = cache.getStructure(name2);
 
-		assertEquals(1,s.getChains().size());
+		assertEquals(1,s.getPolyChains().size());
+		// Chain name 'C' corresponds to three IDs: C (141 res), I (1 HEM), and M (59 water)
+		assertEquals(3,s.getChains().size());
 		Chain c = s.getPolyChainByPDB(chainId2);
 		assertEquals(chainId2,c.getName());
-
+		
+		// Number of groups: Polymer + water + ligand
+		assertEquals(141,c.getAtomLength());
+		assertEquals(141, s.getChainByIndex(0).getAtomLength());
+		assertEquals(1, s.getChainByIndex(1).getAtomLength());
+		assertEquals(59, s.getChainByIndex(2).getAtomLength());
 
 		// Colon separators removed in BioJava 4.1.0
 		String name2b = "4hhb:A";
@@ -100,7 +107,7 @@ public class TestAtomCache {
 		String chainId3 = "B";
 		s = cache.getStructure(name3);
 		assertNotNull(s);
-		assertEquals(1,s.getChains().size());
+		assertEquals(1,s.getPolyChains().size());
 
 		c = s.getPolyChainByPDB(chainId3);
 		assertEquals(chainId3,c.getName());
@@ -110,6 +117,7 @@ public class TestAtomCache {
 		s = cache.getStructure(name4);
 		assertNotNull(s);
 
+		assertEquals(3,s.getPolyChains().size());
 		assertEquals(3,s.getChains().size());
 
 		c = s.getPolyChainByPDB("B");
@@ -119,9 +127,11 @@ public class TestAtomCache {
 		s =cache.getStructure(name5);
 		assertNotNull(s);
 
-		assertEquals(1,s.getChains().size() );
+		assertEquals(1,s.getPolyChains().size() );
+		// two chains: A (22 res), and G (1 HEM)
+		assertEquals(2,s.getChains().size() );
 		c = s.getPolyChainByPDB("A");
-		assertEquals(23,c.getAtomLength());
+		assertEquals(22,c.getAtomLength());
 
 		try {
 			// This syntax used to work, since the first paren is treated as a separator
@@ -134,7 +144,7 @@ public class TestAtomCache {
 		String name8 = "4hhb.(C)";
 		s = cache.getStructure(name8);
 
-		assertEquals(1,s.getChains().size());
+		assertEquals(1,s.getPolyChains().size());
 		c = s.getPolyChainByPDB(chainId2);
 		assertEquals(chainId2,c.getName());
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
@@ -75,15 +75,15 @@ public class TestAtomCache {
 		String name1= "4hhb";
 		Structure s = cache.getStructure(name1);
 		assertNotNull(s);
-		assertTrue(s.getPolyChains().size() == 4);
+		assertEquals(4,s.getPolyChains().size());
 
 		String name2 = "4hhb.C";
 		String chainId2 = "C";
 		s = cache.getStructure(name2);
 
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getChains().size());
 		Chain c = s.getPolyChainByPDB(chainId2);
-		assertEquals(c.getName(),chainId2);
+		assertEquals(chainId2,c.getName());
 
 
 		// Colon separators removed in BioJava 4.1.0
@@ -91,7 +91,6 @@ public class TestAtomCache {
 		try {
 			s = cache.getStructure(name2b);
 			fail("Invalid structure format");
-		} catch(IOException e) {
 		} catch(StructureException e) {
 		}
 
@@ -101,28 +100,28 @@ public class TestAtomCache {
 		String chainId3 = "B";
 		s = cache.getStructure(name3);
 		assertNotNull(s);
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getChains().size());
 
 		c = s.getPolyChainByPDB(chainId3);
-		assertEquals(c.getName(),chainId3);
+		assertEquals(chainId3,c.getName());
 
 
 		String name4 = "4hhb.A:10-20,B:10-20,C:10-20";
 		s = cache.getStructure(name4);
 		assertNotNull(s);
 
-		assertEquals(s.getChains().size(), 3);
+		assertEquals(3,s.getChains().size());
 
 		c = s.getPolyChainByPDB("B");
-		assertEquals(c.getAtomLength(),11);
+		assertEquals(11,c.getAtomLength());
 
 		String name5 = "4hhb.(A:10-20,A:30-40)";
 		s =cache.getStructure(name5);
 		assertNotNull(s);
 
-		assertEquals(s.getChains().size(),1 );
+		assertEquals(1,s.getChains().size() );
 		c = s.getPolyChainByPDB("A");
-		assertEquals(c.getAtomLength(),22);
+		assertEquals(23,c.getAtomLength());
 
 		try {
 			// This syntax used to work, since the first paren is treated as a separator
@@ -135,9 +134,9 @@ public class TestAtomCache {
 		String name8 = "4hhb.(C)";
 		s = cache.getStructure(name8);
 
-		assertTrue(s.getChains().size() == 1);
+		assertEquals(1,s.getChains().size());
 		c = s.getPolyChainByPDB(chainId2);
-		assertEquals(c.getName(),chainId2);
+		assertEquals(chainId2,c.getName());
 
 	}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomIterator.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomIterator.java
@@ -1,0 +1,50 @@
+package org.biojava.nbio.structure;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.NoSuchElementException;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.AtomIterator;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.StructureTools;
+import org.junit.Test;
+
+public class TestAtomIterator {
+	@Test
+	public void test5frf() throws IOException, StructureException {
+		// 5frf: 10 models; residues -2-105, binds a ZN; 1615 atoms/model
+		Structure s = StructureIO.getStructure("5frf");
+		assertEquals("nrModels",10,s.nrModels());
+		
+		Atom[] allAtomArray = StructureTools.getAllAtomArray(s);
+		assertEquals("getAllAtomArray length",16150, allAtomArray.length);
+		
+		int atoms=0;
+		AtomIterator atomIt = new AtomIterator(s);
+		while(atomIt.hasNext()) {
+			atoms++;
+			atomIt.next();
+		}
+		try {
+			atomIt.next();
+			fail("No more elements");
+		} catch( NoSuchElementException e) {}
+		assertEquals("AtomIterator full length",16150, atoms);
+		
+		atoms=0;
+		atomIt = new AtomIterator(s,0);
+		while(atomIt.hasNext()) {
+			atoms++;
+			atomIt.next();
+		}
+		try {
+			atomIt.next();
+			fail("No more elements");
+		} catch( NoSuchElementException e) {}
+		assertEquals("AtomIterator single model",1615, atoms);
+	}
+}


### PR DESCRIPTION
Fixes #560.

Clearly define ligand handling:
- Full-chain selections ('1abc.A') use all groups with that chain name, including waters and ligands
- Residue selections (1ab.A:1-100) do not include waters, and they may include ligands from other chains if they appear within the cutoff distance (5A default)

This PR also bundles some structural changes:
- Use StructureTools.addGroupsToStructure where ever you want to create a new structure. It handles the chain creation as needed.

This code was originally written for the 4.2 branch, but then moved to the 5.0 branch when it became apparent that it would change structure loading too much. As a result, during code review please pay special attention to places where the new chain model is used (e.g. ligands get their own chain), or where the new polymer/nonpolymer/water dicotomy comes into use. For instance, "ligand" is just defined as nonpolymer, and relies on the input structure for correct classification of PTMs. Another tricky place is figuring out when cloning groups and other data structures is necessary.
