### PR TITLE
Fix #596. Remove test for GenBank identifier parsing

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/AccessionID.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/AccessionID.java
@@ -133,6 +133,8 @@ public class AccessionID {
 
 	/**
 	 * In case if {@link #getID() } in not unique keeps the alternative id, eg. NCBI GI number.
+	 * 
+	 * This may null.
 	 *
 	 * @return
 	 */

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/loader/GenbankProxySequenceReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/loader/GenbankProxySequenceReaderTest.java
@@ -99,9 +99,10 @@ public class GenbankProxySequenceReaderTest {
 		logger.info("accession id: {}", seq.getAccession().getID());
 		Assert.assertNotNull(seq.getAccession().getID());
 		// test GID number
-		Assert.assertEquals(gi, seq.getAccession().getIdentifier());
-		logger.info("found identifier '{}'", seq.getAccession().getIdentifier());
-
+		if( seq.getAccession().getIdentifier() != null) { // GI: in header now optional. See #596
+			Assert.assertEquals(gi, seq.getAccession().getIdentifier());
+			logger.info("found identifier '{}'", seq.getAccession().getIdentifier());
+		}
 		// test taxonomy id
 		logger.info("taxonomy id: {}", seq.getTaxonomy().getID());
 		Assert.assertNotNull(seq.getTaxonomy().getID());


### PR DESCRIPTION
Starting Nov 2016, Entrez stopped including the GI identifier in
GenBank files. In such cases, getAccession().getIdentifier() will
return null.

This updates the tests to reflect that null identifiers are acceptable.

Users who need the GI identifier should store it manually after fetching
the sequence.