### PR TITLE
Allow partial residue ranges (#557)

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -386,6 +386,41 @@ public class StructureToolsTest extends TestCase {
 
 		assertEquals("Did not find the expected number of residues in "+range, 6, chain.getAtomLength() );
 
+		// partial ranges
+		range = "A:-+1";
+		substr = StructureTools.getSubRanges(structure2, range);
+		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		chain = substr.getChainByIndex(0);
+		assertEquals("Did not find the expected number of residues in "+range, 4, chain.getAtomLength() );
+		
+		range = "A:--1";
+		substr = StructureTools.getSubRanges(structure2, range);
+		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		chain = substr.getChainByIndex(0);
+		assertEquals("Did not find the expected number of residues in "+range, 3, chain.getAtomLength() );
+
+		range = "A:^-+1";
+		substr = StructureTools.getSubRanges(structure2, range);
+		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		chain = substr.getChainByIndex(0);
+		assertEquals("Did not find the expected number of residues in "+range, 4, chain.getAtomLength() );
+		
+		range = "A:^-$";
+		substr = StructureTools.getSubRanges(structure2, range);
+		assertEquals("Wrong number of chains in "+range, 1, substr.getPolyChains().size());
+		chain = substr.getPolyChains().get(0);
+		
+		range = "A:400-";
+		substr = StructureTools.getSubRanges(structure2, range);
+		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		chain = substr.getChainByIndex(0);
+		assertEquals("Did not find the expected number of residues in "+range, 6, chain.getAtomLength() );
+
+		range = "A:400-$";
+		substr = StructureTools.getSubRanges(structure2, range);
+		assertEquals("Wrong number of chains in "+range, 1, substr.size());
+		chain = substr.getChainByIndex(0);
+		assertEquals("Did not find the expected number of residues in "+range, 6, chain.getAtomLength() );
 
 		// whitespace
 		range = "A:3-7, B:8-12";

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Chain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Chain.java
@@ -165,8 +165,8 @@ public interface Chain {
 	/** 
 	 * Get all groups that are located between two PDB residue numbers.
 	 *
-	 * @param pdbresnumStart PDB residue number of start
-	 * @param pdbresnumEnd PDB residue number of end
+	 * @param pdbresnumStart PDB residue number of start. If null, defaults to the chain start.
+	 * @param pdbresnumEnd PDB residue number of end. If null, defaults to the chain end.
 	 * @return Groups in between. or throws a StructureException if either start or end can not be found,
 	 * @throws StructureException
 	 */
@@ -179,8 +179,8 @@ public interface Chain {
 	 * of groups as specified by the DBREF records - these frequently are rather inaccurate.
 	 *
 	 *
-	 * @param pdbresnumStart PDB residue number of start
-	 * @param pdbresnumEnd PDB residue number of end
+	 * @param pdbresnumStart PDB residue number of start. If null, defaults to the chain start.
+	 * @param pdbresnumEnd PDB residue number of end. If null, defaults to the chain end.
 	 * @param ignoreMissing ignore missing groups in this range.
 	 * @return Groups in between. or throws a StructureException if either start or end can not be found,
 	 * @throws StructureException

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
@@ -340,58 +340,60 @@ public class ChainImpl implements Chain, Serializable {
 	}
 
 	@Override
-	@Deprecated // TODO dmyersturnbull: why is this deprecated if it's declared in Chain?
 	public Group[] getGroupsByPDB(ResidueNumber start, ResidueNumber end, boolean ignoreMissing)
 			throws StructureException {
-
-		if (! ignoreMissing )
-			return getGroupsByPDB(start, end);
+		// Short-circut for include all groups
+		if(start == null && end == null) {
+			return groups.toArray(new Group[groups.size()]);
+		}
 
 
 		List<Group> retlst = new ArrayList<>();
 
-		String pdbresnumStart = start.toString();
-		String pdbresnumEnd   = end.toString();
+		boolean adding, foundStart;
+		if( start == null ) {
+			// start with first group
+			adding = true;
+			foundStart = true;
+		} else {
+			adding = false;
+			foundStart = false;
+		}
 
-		int startPos = start.getSeqNum();
-		int endPos   = end.getSeqNum();
-
-		boolean adding = false;
-		boolean foundStart = false;
-
+		
 		for (Group g: groups){
 
-			if ( g.getResidueNumber().toString().equals(pdbresnumStart)) {
+			// Check for start
+			if (!adding && start.equalsPositional(g.getResidueNumber())) {
 				adding = true;
 				foundStart = true;
 			}
 
-			if ( ! (foundStart && adding) ) {
+			// Check if past start
+			if ( ignoreMissing && ! (foundStart && adding) ) {
+				ResidueNumber pos = g.getResidueNumber();
 
-
-				int pos = g.getResidueNumber().getSeqNum();
-
-				if ( pos >= startPos) {
+				if ( start != null && start.compareToPositional(pos) <= 0) {
 					foundStart = true;
 					adding = true;
 				}
-
-
 			}
 
 			if ( adding)
 				retlst.add(g);
 
-			if ( g.getResidueNumber().toString().equals(pdbresnumEnd)) {
+			// check for end
+			if ( end != null && end.equalsPositional(g.getResidueNumber())) {
 				if ( ! adding)
-					throw new StructureException("did not find start PDB residue number " + pdbresnumStart + " in chain " + authId);
+					throw new StructureException("did not find start PDB residue number " + start + " in chain " + authId);
 				adding = false;
 				break;
 			}
-			if (adding){
+			// check if past end
+			if ( ignoreMissing && adding && end != null){
 
-				int pos = g.getResidueNumber().getSeqNum();
-				if (pos >= endPos) {
+				ResidueNumber pos = g.getResidueNumber();
+				if ( end.compareToPositional(pos) <= 0) {
 					adding = false;
 					break;
 				}
@@ -400,7 +402,10 @@ public class ChainImpl implements Chain, Serializable {
 		}
 
 		if ( ! foundStart){
-			throw new StructureException("did not find start PDB residue number " + pdbresnumStart + " in chain " + authId);
+			throw new StructureException("did not find start PDB residue number " + start + " in chain " + authId);
+		}
+		if ( end != null && adding && !ignoreMissing) {
+			throw new StructureException("did not find end PDB residue number " + end + " in chain " + authId);
 		}
 
 
@@ -432,42 +437,7 @@ public class ChainImpl implements Chain, Serializable {
 	@Override
 	public Group[] getGroupsByPDB(ResidueNumber start, ResidueNumber end)
 			throws StructureException {
-
-		String pdbresnumStart = start.toString();
-		String pdbresnumEnd   = end.toString();
-
-		List<Group> retlst = new ArrayList<>();
-
-		Iterator<Group> iter = groups.iterator();
-		boolean adding = false;
-		boolean foundStart = false;
-
-		while ( iter.hasNext()){
-			Group g = iter.next();
-			if ( g.getResidueNumber().toString().equals(pdbresnumStart)) {
-				adding = true;
-				foundStart = true;
-			}
-
-			if ( adding)
-				retlst.add(g);
-
-			if ( g.getResidueNumber().toString().equals(pdbresnumEnd)) {
-				if ( ! adding)
-					throw new StructureException("did not find start PDB residue number " + pdbresnumStart + " in chain " + authId);
-				adding = false;
-				break;
-			}
-		}
-
-		if ( ! foundStart){
-			throw new StructureException("did not find start PDB residue number " + pdbresnumStart + " in chain " + authId);
-		}
-		if ( adding) {
-			throw new StructureException("did not find end PDB residue number " + pdbresnumEnd + " in chain " + authId);
-		}
-
-		return retlst.toArray(new Group[retlst.size()] );
+		return getGroupsByPDB(start, end, false);
 	}
 
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueNumber.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueNumber.java
@@ -111,6 +111,35 @@ public class ResidueNumber implements Serializable, Comparable<ResidueNumber>
 
 		return true;
 	}
+	
+	/**
+	 * Check if the seqNum and insertion code are equivalent,
+	 * ignoring the chain
+	 * @param obj
+	 * @return
+	 */
+	public boolean equalsPositional(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ResidueNumber other = (ResidueNumber) obj;
+		if (insCode == null) {
+			if (other.insCode != null)
+				return false;
+		} else if (!insCode.equals(other.insCode))
+			return false;
+		if (seqNum == null) {
+			if (other.seqNum != null)
+				return false;
+		} else if (!seqNum.equals(other.seqNum))
+			return false;
+
+		return true;
+
+	}
 
 	@Override
 	public int hashCode() {
@@ -192,6 +221,9 @@ public class ResidueNumber implements Serializable, Comparable<ResidueNumber>
 	}
 
 
+	/**
+	 * Compare residue numbers by chain, sequence number, and insertion code
+	 */
 	@Override
 	public int compareTo(ResidueNumber other) {
 
@@ -205,6 +237,16 @@ public class ResidueNumber implements Serializable, Comparable<ResidueNumber>
 			return -1;
 		}
 
+		return compareToPositional(other);
+	}
+
+	/**
+	 * Compare residue numbers by sequence number and insertion code,
+	 * ignoring the chain
+	 * @param other
+	 * @return
+	 */
+	public int compareToPositional(ResidueNumber other) {
 		// sequence number
 		if (seqNum != null && other.seqNum != null) {
 			if (!seqNum.equals(other.seqNum)) return seqNum.compareTo(other.seqNum);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/ResidueRangeTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/ResidueRangeTest.java
@@ -265,10 +265,35 @@ public class ResidueRangeTest {
 		ResidueRange.parse("-");
 	}
 
-	@Test(expected=IllegalArgumentException.class)
+	@Test
 	public void testPartialRange() throws IOException, StructureException {
+		String rangeStr = "C_1023-";
+		ResidueRange range = ResidueRange.parse(rangeStr);
+		assertEquals(rangeStr,1023,(int)range.getStart().getSeqNum());
+		assertNull(rangeStr,range.getEnd());
+
+		rangeStr = "C_-";
+		range = ResidueRange.parse(rangeStr);
+		assertNull(rangeStr,range.getStart());
+		assertNull(rangeStr,range.getEnd());
+		
+		rangeStr = "A_-+55";
+		range = ResidueRange.parse(rangeStr);
+		assertNull(rangeStr,range.getStart());
+		assertEquals(rangeStr,55,(int)range.getEnd().getSeqNum());
+
+	}
+	@Test
+	public void testPartialRangeLength() throws IOException, StructureException {
 		AtomPositionMap map = new AtomPositionMap(cache.getAtoms("2eke"));
-		ResidueRangeAndLength.parse("C_1023-", map);
+		String rangeStr = "C_1023-";
+		ResidueRangeAndLength range = ResidueRangeAndLength.parse(rangeStr, map);
+		
+		assertEquals(rangeStr,1023,(int)range.getStart().getSeqNum());
+		assertEquals(rangeStr,1095,(int)range.getEnd().getSeqNum());
+		assertEquals(rangeStr, 73, range.getLength());
+		
+		
 	}
 
 	/**
@@ -338,20 +363,42 @@ public class ResidueRangeTest {
 				"3A:1-100", // Weird chain name
 				"_", "_:1-10", "__-2--1", "__", // catch-all chain
 				"A:-3-+1","A:-3-+1","A:+1-6", // Positive numbers ok, although weird
+				"A:1-","A:1S-","A:--5","A:-+5", // Partial ranges
 		};
 		for (String s : yes) {
 			assertTrue(s + " was not considered a valid range format",
 					ResidueRange.RANGE_REGEX.matcher(s).matches());
 		}
 		// invalid ranges
-		String[] no = new String[] { "A_1-", "A_1S-", "A_1-100-",
-				"A_-10-1000_", "", "-", "___", "__:",
-				"A:1-","A:--5","A:-+5", // Partial ranges
+		String[] no = new String[] {  "A_1-100-",
+				 "", "-", "___", "__:","A_-10-1000_",
+				
 		};
 		for (String s : no) {
 			assertFalse(s + " was considered a valid range format",
 					ResidueRange.RANGE_REGEX.matcher(s).matches());
 		}
+	}
+	
+	@Test
+	public void testTerminalSymbols() {
+		String rangeStr;
+		ResidueRange range;
+		
+		rangeStr = "A:1-$";
+		range = ResidueRange.parse(rangeStr);
+		assertEquals(rangeStr,1,(int)range.getStart().getSeqNum());
+		assertNull(rangeStr,range.getEnd());
+		
+		rangeStr = "A:^-1";
+		range = ResidueRange.parse(rangeStr);
+		assertNull(rangeStr,range.getStart());
+		assertEquals(rangeStr,1,(int)range.getEnd().getSeqNum());
+		
+		rangeStr = "A:^-$";
+		range = ResidueRange.parse(rangeStr);
+		assertNull(rangeStr,range.getStart());
+		assertNull(rangeStr,range.getEnd());
 	}
 
 }


### PR DESCRIPTION
Allow partial residue ranges (#557)

- Introduce '^' and '$' symbols to stand for the beginning and end of the
  chain. E.g. "A:^-100"
- Accept partial ranges for cases where they could not be confused with
  negative residue numbers. E.g. "A:-5" refers to a single residue, while
  "A:-+5" gives all residues up to and including 5. 

