### PR TITLE
Implementing parsing of atom_sites category in mmcif parser/consumer

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/ChemCompConsumer.java
@@ -78,19 +78,19 @@ public class ChemCompConsumer implements MMcifConsumer {
 
 	@Override
 	public void newAtomSite(AtomSite atom) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newDatabasePDBremark(DatabasePDBremark remark) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newDatabasePDBrev(DatabasePDBrev dbrev) {
-		// TODO Auto-generated method stub
+
 
 	}
 
@@ -101,94 +101,99 @@ public class ChemCompConsumer implements MMcifConsumer {
 
 	@Override
 	public void newEntity(Entity entity) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newEntityPolySeq(EntityPolySeq epolseq) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newExptl(Exptl exptl) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newCell(Cell cell) {
-		// TODO Auto-generated method stub
+
 	}
 
 	@Override
 	public void newSymmetry(Symmetry symmetry) {
-		// TODO Auto-generated method stub
+
 	}
 
 	@Override
 	public void newStructNcsOper(StructNcsOper sNcsOper) {
-		// TODO Auto-generated method stub
+
+	}
+	
+	@Override
+	public void newAtomSites(AtomSites atomSites) {
+		
 	}
 
 	@Override
 	public void newPdbxEntityNonPoly(PdbxEntityNonPoly pen) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newPdbxNonPolyScheme(PdbxNonPolyScheme ppss) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newPdbxPolySeqScheme(PdbxPolySeqScheme ppss) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newRefine(Refine r) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newStructAsym(StructAsym sasym) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newStructKeywords(StructKeywords kw) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newStructRef(StructRef sref) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newStructRefSeq(StructRefSeq sref) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newStructRefSeqDif(StructRefSeqDif sref) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void setStruct(Struct struct) {
-		// TODO Auto-generated method stub
+
 
 	}
 
@@ -203,7 +208,7 @@ public class ChemCompConsumer implements MMcifConsumer {
 	@Override
 	public void newAuditAuthor(AuditAuthor aa)
 	{
-		// TODO Auto-generated method stub
+
 
 	}
 
@@ -217,7 +222,7 @@ public class ChemCompConsumer implements MMcifConsumer {
 	@Override
 	public void setFileParsingParameters(FileParsingParameters params)
 	{
-		// TODO Auto-generated method stub
+
 
 	}
 
@@ -230,19 +235,19 @@ public class ChemCompConsumer implements MMcifConsumer {
 
 	@Override
 	public void newPdbxStructOperList(PdbxStructOperList structOper) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newPdbxStrucAssembly(PdbxStructAssembly strucAssembly) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newPdbxStrucAssemblyGen(PdbxStructAssemblyGen strucAssembly) {
-		// TODO Auto-generated method stub
+
 
 	}
 
@@ -253,7 +258,7 @@ public class ChemCompConsumer implements MMcifConsumer {
 
 	@Override
 	public void newPdbxChemCompIndentifier(PdbxChemCompIdentifier id) {
-		// TODO Auto-generated method stub
+
 
 	}
 
@@ -264,46 +269,46 @@ public class ChemCompConsumer implements MMcifConsumer {
 
 	@Override
 	public void newPdbxChemCompDescriptor(PdbxChemCompDescriptor desc) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newEntitySrcGen(EntitySrcGen entitySrcGen) {
-		// TODO Auto-generated method stub
+
 
 	}
 	@Override
 	public void newEntitySrcNat(EntitySrcNat entitySrcNat) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newEntitySrcSyn(EntitySrcSyn entitySrcSyn) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newStructConn(StructConn structConn) {
-		// TODO Auto-generated method stub
+
 
 	}
 
 	@Override
 	public void newStructSiteGen(StructSiteGen gen) {
-		// TODO
+
 	}
 
 	@Override
 	public void newStructSite(StructSite site) {
-		// TODO
+
 	}
 
 	@Override
 	public void newEntityPoly(EntityPoly entityPoly) {
-		// TODO Auto-generated method stub
+
 		
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MMcifConsumer.java
@@ -62,6 +62,7 @@ public interface MMcifConsumer {
 	public void newCell(Cell cell);
 	public void newSymmetry(Symmetry symmetry);
 	public void newStructNcsOper(StructNcsOper sNcsOper);
+	public void newAtomSites(AtomSites atomSites);
 	public void newStructRef(StructRef sref);
 	public void newStructRefSeq(StructRefSeq sref);
 	public void newStructRefSeqDif(StructRefSeqDif sref);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MetalBondConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MetalBondConsumer.java
@@ -99,6 +99,11 @@ public class MetalBondConsumer implements MMcifConsumer{
     public void newStructNcsOper(StructNcsOper sNcsOper) {
 
     }
+    
+    @Override 
+    public void newAtomSites(AtomSites atomSites) {
+    	
+    }
 
     @Override
     public void newStructRef(StructRef sref) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -61,6 +61,7 @@ import org.biojava.nbio.structure.io.EntityFinder;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.SeqRes2AtomAligner;
 import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
+import org.biojava.nbio.structure.io.mmcif.model.AtomSites;
 import org.biojava.nbio.structure.io.mmcif.model.AuditAuthor;
 import org.biojava.nbio.structure.io.mmcif.model.Cell;
 import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
@@ -149,6 +150,8 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 	private List<StructNcsOper> structNcsOper;
 	private List<StructRefSeqDif> sequenceDifs;
 	private List<StructSiteGen> structSiteGens;
+	
+	private AtomSites atomSites;
 
 
 
@@ -1579,6 +1582,10 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 	public void newStructNcsOper(StructNcsOper sNcsOper) {
 		structNcsOper.add(sNcsOper);
 	}
+	
+	public void newAtomSites(AtomSites atomSites) {
+		this.atomSites = atomSites;
+	}
 
 	@Override
 	public void newStructRef(StructRef sref) {
@@ -1897,6 +1904,9 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 		return structOpers;
 	}
 
+	public AtomSites getAtomSites() {
+		return atomSites;
+	}
 
 
 	@Override

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
@@ -40,6 +40,7 @@ import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.io.MMCIFFileReader;
 import org.biojava.nbio.structure.io.StructureIOFile;
 import org.biojava.nbio.structure.io.mmcif.model.AtomSite;
+import org.biojava.nbio.structure.io.mmcif.model.AtomSites;
 import org.biojava.nbio.structure.io.mmcif.model.AuditAuthor;
 import org.biojava.nbio.structure.io.mmcif.model.CIFLabel;
 import org.biojava.nbio.structure.io.mmcif.model.Cell;
@@ -680,6 +681,12 @@ public class SimpleMMcifParser implements MMcifParser {
 					StructNcsOper.class.getName(), 
 					loopFields, lineData, loopWarnings);
 			triggerNewStructNcsOper(sNcsOper);
+		} else if ( category.equals("_atom_sites")) {
+			
+			AtomSites atomSites = (AtomSites) buildObject(
+					AtomSites.class.getName(),
+					loopFields, lineData, loopWarnings);
+			triggerNewAtomSites(atomSites);
 
 		} else if ( category.equals("_struct_ref")){
 			StructRef sref  = (StructRef) buildObject(
@@ -896,6 +903,12 @@ public class SimpleMMcifParser implements MMcifParser {
 			c.newStructNcsOper(sNcsOper);
 		}
 
+	}
+	
+	public void triggerNewAtomSites(AtomSites atomSites) {
+		for(MMcifConsumer c : consumers){
+			c.newAtomSites(atomSites);
+		}
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/AtomSites.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/AtomSites.java
@@ -1,0 +1,218 @@
+package org.biojava.nbio.structure.io.mmcif.model;
+
+/**
+ * A class containing the _atom_sites data. Equivalent to the SCALE records in PDB files.
+ * 
+ * 
+ * @author Jose Duarte
+ *
+ */
+public class AtomSites extends AbstractBean {
+	
+	String entry_id;
+	String Cartn_transform_axes;
+	
+	@CIFLabel(label="fract_transf_matrix[1][1]")
+	String fract_transf_matrix11;
+
+	@CIFLabel(label="fract_transf_matrix[1][2]")
+	String fract_transf_matrix12;
+
+	@CIFLabel(label="fract_transf_matrix[1][3]")
+	String fract_transf_matrix13;
+
+
+	@CIFLabel(label="fract_transf_matrix[2][1]")
+	String fract_transf_matrix21;
+
+	@CIFLabel(label="fract_transf_matrix[2][2]")
+	String fract_transf_matrix22;
+
+	@CIFLabel(label="fract_transf_matrix[2][3]")
+	String fract_transf_matrix23;
+	
+
+	@CIFLabel(label="fract_transf_matrix[3][1]")
+	String fract_transf_matrix31;
+
+	@CIFLabel(label="fract_transf_matrix[3][2]")
+	String fract_transf_matrix32;
+
+	@CIFLabel(label="fract_transf_matrix[3][3]")
+	String fract_transf_matrix33;
+
+
+	@CIFLabel(label="fract_transf_vector[1]")
+	String fract_transf_vector1;
+	
+	@CIFLabel(label="fract_transf_vector[2]")
+	String fract_transf_vector2;
+
+	@CIFLabel(label="fract_transf_vector[3]")
+	String fract_transf_vector3;
+
+	
+	public String getEntry_id() {
+		return entry_id;
+	}
+	public void setEntry_id(String entry_id) {
+		this.entry_id = entry_id;
+	}
+	/**
+	 * @return the cartn_transform_axes
+	 */
+	public String getCartn_transform_axes() {
+		return Cartn_transform_axes;
+	}
+	/**
+	 * @param cartn_transform_axes the cartn_transform_axes to set
+	 */
+	public void setCartn_transform_axes(String cartn_transform_axes) {
+		Cartn_transform_axes = cartn_transform_axes;
+	}
+	/**
+	 * @return the fract_transf_matrix11
+	 */
+	public String getFract_transf_matrix11() {
+		return fract_transf_matrix11;
+	}
+	/**
+	 * @param fract_transf_matrix11 the fract_transf_matrix11 to set
+	 */
+	public void setFract_transf_matrix11(String fract_transf_matrix11) {
+		this.fract_transf_matrix11 = fract_transf_matrix11;
+	}
+	/**
+	 * @return the fract_transf_matrix12
+	 */
+	public String getFract_transf_matrix12() {
+		return fract_transf_matrix12;
+	}
+	/**
+	 * @param fract_transf_matrix12 the fract_transf_matrix12 to set
+	 */
+	public void setFract_transf_matrix12(String fract_transf_matrix12) {
+		this.fract_transf_matrix12 = fract_transf_matrix12;
+	}
+	/**
+	 * @return the fract_transf_matrix13
+	 */
+	public String getFract_transf_matrix13() {
+		return fract_transf_matrix13;
+	}
+	/**
+	 * @param fract_transf_matrix13 the fract_transf_matrix13 to set
+	 */
+	public void setFract_transf_matrix13(String fract_transf_matrix13) {
+		this.fract_transf_matrix13 = fract_transf_matrix13;
+	}
+	/**
+	 * @return the fract_transf_matrix21
+	 */
+	public String getFract_transf_matrix21() {
+		return fract_transf_matrix21;
+	}
+	/**
+	 * @param fract_transf_matrix21 the fract_transf_matrix21 to set
+	 */
+	public void setFract_transf_matrix21(String fract_transf_matrix21) {
+		this.fract_transf_matrix21 = fract_transf_matrix21;
+	}
+	/**
+	 * @return the fract_transf_matrix22
+	 */
+	public String getFract_transf_matrix22() {
+		return fract_transf_matrix22;
+	}
+	/**
+	 * @param fract_transf_matrix22 the fract_transf_matrix22 to set
+	 */
+	public void setFract_transf_matrix22(String fract_transf_matrix22) {
+		this.fract_transf_matrix22 = fract_transf_matrix22;
+	}
+	/**
+	 * @return the fract_transf_matrix23
+	 */
+	public String getFract_transf_matrix23() {
+		return fract_transf_matrix23;
+	}
+	/**
+	 * @param fract_transf_matrix23 the fract_transf_matrix23 to set
+	 */
+	public void setFract_transf_matrix23(String fract_transf_matrix23) {
+		this.fract_transf_matrix23 = fract_transf_matrix23;
+	}
+	/**
+	 * @return the fract_transf_matrix31
+	 */
+	public String getFract_transf_matrix31() {
+		return fract_transf_matrix31;
+	}
+	/**
+	 * @param fract_transf_matrix31 the fract_transf_matrix31 to set
+	 */
+	public void setFract_transf_matrix31(String fract_transf_matrix31) {
+		this.fract_transf_matrix31 = fract_transf_matrix31;
+	}
+	/**
+	 * @return the fract_transf_matrix32
+	 */
+	public String getFract_transf_matrix32() {
+		return fract_transf_matrix32;
+	}
+	/**
+	 * @param fract_transf_matrix32 the fract_transf_matrix32 to set
+	 */
+	public void setFract_transf_matrix32(String fract_transf_matrix32) {
+		this.fract_transf_matrix32 = fract_transf_matrix32;
+	}
+	/**
+	 * @return the fract_transf_matrix33
+	 */
+	public String getFract_transf_matrix33() {
+		return fract_transf_matrix33;
+	}
+	/**
+	 * @param fract_transf_matrix33 the fract_transf_matrix33 to set
+	 */
+	public void setFract_transf_matrix33(String fract_transf_matrix33) {
+		this.fract_transf_matrix33 = fract_transf_matrix33;
+	}
+	/**
+	 * @return the fract_transf_vector1
+	 */
+	public String getFract_transf_vector1() {
+		return fract_transf_vector1;
+	}
+	/**
+	 * @param fract_transf_vector1 the fract_transf_vector1 to set
+	 */
+	public void setFract_transf_vector1(String fract_transf_vector1) {
+		this.fract_transf_vector1 = fract_transf_vector1;
+	}
+	/**
+	 * @return the fract_transf_vector2
+	 */
+	public String getFract_transf_vector2() {
+		return fract_transf_vector2;
+	}
+	/**
+	 * @param fract_transf_vector2 the fract_transf_vector2 to set
+	 */
+	public void setFract_transf_vector2(String fract_transf_vector2) {
+		this.fract_transf_vector2 = fract_transf_vector2;
+	}
+	/**
+	 * @return the fract_transf_vector3
+	 */
+	public String getFract_transf_vector3() {
+		return fract_transf_vector3;
+	}
+	/**
+	 * @param fract_transf_vector3 the fract_transf_vector3 to set
+	 */
+	public void setFract_transf_vector3(String fract_transf_vector3) {
+		this.fract_transf_vector3 = fract_transf_vector3;
+	}
+
+}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestAtomSitesParsing.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmcif/TestAtomSitesParsing.java
@@ -1,0 +1,61 @@
+package org.biojava.nbio.structure.io.mmcif;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+import javax.vecmath.Matrix4d;
+
+import org.biojava.nbio.structure.io.mmcif.MMcifParser;
+import org.biojava.nbio.structure.io.mmcif.SimpleMMcifConsumer;
+import org.biojava.nbio.structure.io.mmcif.SimpleMMcifParser;
+import org.biojava.nbio.structure.io.mmcif.model.AtomSites;
+
+/**
+ * A test for the parsing of _atom_sites category in mmcif, equivalent to SCALE records
+ * in PDB files. Currently the category is parsed but is not used to populate any field
+ * in the Structure hierarchy. Getting the data from the parser can be useful for things like
+ * checking the consistency of the SCALE matrix, see https://github.com/eppic-team/owl/issues/4
+ * 
+ * 
+ * 
+ * @author Jose Duarte
+ *
+ */
+public class TestAtomSitesParsing {
+	
+	@Test
+	public void test4hhb() throws Exception {
+		
+		InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream("/4hhb.cif.gz"));
+		assertNotNull(inStream);
+
+		MMcifParser mmcifpars = new SimpleMMcifParser();
+		SimpleMMcifConsumer consumer = new SimpleMMcifConsumer();
+		
+		mmcifpars.addMMcifConsumer(consumer);
+
+		mmcifpars.parse(inStream) ;
+		
+		AtomSites atomSites = consumer.getAtomSites();
+		
+		//System.out.println(consumer.getAtomSites());
+		
+		Matrix4d m = new Matrix4d(
+				Double.parseDouble(atomSites.getFract_transf_matrix11()), Double.parseDouble(atomSites.getFract_transf_matrix12()), Double.parseDouble(atomSites.getFract_transf_matrix13()), Double.parseDouble(atomSites.getFract_transf_vector1()),
+				Double.parseDouble(atomSites.getFract_transf_matrix21()), Double.parseDouble(atomSites.getFract_transf_matrix22()), Double.parseDouble(atomSites.getFract_transf_matrix23()), Double.parseDouble(atomSites.getFract_transf_vector2()),
+				Double.parseDouble(atomSites.getFract_transf_matrix31()), Double.parseDouble(atomSites.getFract_transf_matrix32()), Double.parseDouble(atomSites.getFract_transf_matrix33()), Double.parseDouble(atomSites.getFract_transf_vector3()),
+				0,0,0,1);
+		
+		// translation components are 0
+		assertEquals(0.26656, m.m03, 0.00001);
+		assertEquals(0.16413, m.m13, 0.00001);
+		assertEquals(0.75059, m.m23, 0.00001);
+		
+		assertEquals(0.015462, m.m00, 0.00001);
+		assertEquals(0.002192, m.m01, 0.00001);
+	}
+
+}


### PR DESCRIPTION
A small patch to be able to parse the atom_sites category in mmcif. The category contains the same data as SCALE matrix records in PDB format. This can be useful to check the scale matrix is consistent with the standard reference frame, see https://github.com/eppic-team/owl/issues/4