### PR TITLE
Fixed bug in parameter input

### DIFF
--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ParameterGUI.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ParameterGUI.java
@@ -285,15 +285,45 @@ public class ParameterGUI extends JFrame{
 			Object data = null;
 
 			if ( type == Integer.class){
-				data = Integer.parseInt(value);
+				try  
+				  {  
+					data = Integer.parseInt(value);  
+				  }  
+				  catch(NumberFormatException nfe)  
+				  {  
+				  }
 			} else if ( type == Double.class){
-				data = Double.parseDouble(value);
+				try  
+				  {  
+					data = Double.parseDouble(value);  
+				  }  
+				  catch(NumberFormatException nfe)  
+				  {  
+				  }
 			} else if ( type == Float.class) {
-				data = Float.parseFloat(value);
+				try  
+				  {  
+					data = Float.parseFloat(value); 
+				  }  
+				  catch(NumberFormatException nfe)  
+				  {  
+				  }
 			} else if ( type == Boolean.class) {
-				data = Boolean.parseBoolean(value);
+				try  
+				  {  
+					data = Boolean.parseBoolean(value); 
+				  }  
+				  catch(NumberFormatException nfe)  
+				  {  
+				  }
 			} else if ( type == Short.class) {
-				data = Short.parseShort(value);
+				try  
+				  {  
+					data = Short.parseShort(value); 
+				  }  
+				  catch(NumberFormatException nfe)  
+				  {  
+				  }
 			} else if ( type == String[].class) {
 				data = value.split(" ");
 			} else if ( type.isEnum() ) {


### PR DESCRIPTION
For a course at university (ESOF) we were supposed to find a bug in your project and solve it.
In the Alignment GUI (pairwise structure alignment), when choosing the parameters for the alignment algorithm, if the user writes letters instead of numbers in any of the parameters, after pressing “Apply”, the program retrieves a number format exception. This happens because the setValue method has an if cycle to convert the input string (value) to the variable type that the corresponding parameter is supposed to have (type). However, it is not prepared to deal with an invalid output, so we added a try-catch statement to the parsing and now in the console it only appears the message saying "Could not set value "value" for field "field"".