### PR TITLE
Fix354 paolo

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hit.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hit.java
@@ -22,6 +22,7 @@ package org.biojava.nbio.core.search.io;
 
 import java.util.Iterator;
 import java.util.List;
+import org.biojava.nbio.core.sequence.template.Compound;
 import org.biojava.nbio.core.sequence.template.Sequence;
 
 /**
@@ -35,7 +36,7 @@ import org.biojava.nbio.core.sequence.template.Sequence;
  * @author Paolo Pavan
  */
 
-public abstract class Hit implements Iterable<Hsp>{
+public abstract class Hit implements Iterable<Hsp<?,?>>{
     private final int hitNum;
     private final String hitId;
     private final String hitDef;
@@ -44,12 +45,12 @@ public abstract class Hit implements Iterable<Hsp>{
      * the length of the hit sequence
      */
     private final int hitLen;
-    private final List<Hsp> hsps;
-    private Sequence hitSequence;
+    private final List<Hsp<?,?>> hsps;
+    private final Sequence<?> hitSequence;
     
     
 
-    public Hit(int hitNum, String hitId, String hitDef, String hitAccession, int hitLen, List<Hsp> hsps, Sequence hitSequence) {
+    public Hit(int hitNum, String hitId, String hitDef, String hitAccession, int hitLen, List<Hsp<?,?>> hsps, Sequence<?> hitSequence) {
         this.hitNum = hitNum;
         this.hitId = hitId;
         this.hitDef = hitDef;
@@ -115,13 +116,13 @@ public abstract class Hit implements Iterable<Hsp>{
      * it was used before the parsing with SearchIO
      * @return Sequence object
      */
-    public Sequence getHitSequence() {
+    public Sequence<?> getHitSequence() {
         return hitSequence;
     }
     
     @Override
-    public Iterator<Hsp> iterator() {
-        return new Iterator<Hsp>() {
+    public Iterator<Hsp<?,?>> iterator() {
+        return new Iterator<Hsp<?,?>>() {
             int current = 0;
             @Override
             public boolean hasNext() {
@@ -129,7 +130,7 @@ public abstract class Hit implements Iterable<Hsp>{
             }
 
             @Override
-            public Hsp next() {
+            public Hsp<?,?> next() {
                 return hsps.get(current++);
             }
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
@@ -32,6 +32,7 @@ import org.biojava.nbio.core.sequence.ProteinSequence;
 import org.biojava.nbio.core.sequence.RNASequence;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompoundSet;
 import org.biojava.nbio.core.sequence.compound.DNACompoundSet;
+import org.biojava.nbio.core.sequence.compound.RNACompoundSet;
 import org.biojava.nbio.core.sequence.template.Compound;
 import org.biojava.nbio.core.sequence.template.Sequence;
 import org.slf4j.Logger;
@@ -137,7 +138,7 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
             if (sequence instanceof DNASequence) 
                 returnSeq = new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
             else if (sequence instanceof RNASequence)
-                returnSeq = new RNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
+                returnSeq = new RNASequence(sequenceString, RNACompoundSet.getRNACompoundSet());
             else if (sequence instanceof ProteinSequence)
                 returnSeq = new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
             else if (sequence == null){

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
@@ -71,6 +71,8 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
     private Double percentageIdentity = null;
     private Integer mismatchCount = null;
     private SimpleSequencePair<S, C> returnAln;
+    private S sequence;
+    private C compound;
 
     @Override
     public int hashCode() {
@@ -132,12 +134,23 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         String sequenceString = gappedSequenceString.replace("-", "");
         
         try {
-            if (sequenceString.matches("^[ACTG]+$")) 
+            if (sequence instanceof DNASequence) 
                 returnSeq = new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
-            else if (sequenceString.matches("^[ACUG]+$"))
+            else if (sequence instanceof RNASequence)
                 returnSeq = new RNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
-            else
+            else if (sequence instanceof ProteinSequence)
                 returnSeq = new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
+            else if (sequence == null){
+                // try to guess
+                if (sequenceString.matches("^[ACTG]+$")) 
+                    returnSeq = new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
+                else if (sequenceString.matches("^[ACUG]+$"))
+                    returnSeq = new RNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
+                else
+                    returnSeq = new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
+            }
+            // else it is a non considered case
+            else throw new IllegalStateException();
         } catch (CompoundNotFoundException ex) {
             logger.error("Unexpected error, could not find compound when creating Sequence object from Hsp", ex);
         }
@@ -242,7 +255,7 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         return null;
     }
 
-    public Hsp(int hspNum, double hspBitScore, int hspScore, double hspEvalue, int hspQueryFrom, int hspQueryTo, int hspHitFrom, int hspHitTo, int hspQueryFrame, int hspHitFrame, int hspIdentity, int hspPositive, int hspGaps, int hspAlignLen, String hspQseq, String hspHseq, String hspIdentityString, Double percentageIdentity, Integer mismatchCount) {
+    public Hsp(int hspNum, double hspBitScore, int hspScore, double hspEvalue, int hspQueryFrom, int hspQueryTo, int hspHitFrom, int hspHitTo, int hspQueryFrame, int hspHitFrame, int hspIdentity, int hspPositive, int hspGaps, int hspAlignLen, String hspQseq, String hspHseq, String hspIdentityString, Double percentageIdentity, Integer mismatchCount, S sequence, C compound) {
         this.hspNum = hspNum;
         this.hspBitScore = hspBitScore;
         this.hspScore = hspScore;
@@ -262,6 +275,8 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         this.hspIdentityString = hspIdentityString;
         this.percentageIdentity = percentageIdentity; 
         this.mismatchCount = mismatchCount;
+        this.sequence = sequence;
+        this.compound = compound;
         
         // sanity check
         if (percentageIdentity != null && (percentageIdentity < 0 || percentageIdentity >1))

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
@@ -75,8 +75,6 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
      * Singleton, lazy computed
     **/
     private SimpleSequencePair<S, C> returnAln;
-    private final S sequence;
-    private final C compound;
 
     @Override
     public int hashCode() {
@@ -141,23 +139,14 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         
         try {
             // these casting are unavoidable risky operations due to the guess made on sequence string.
-            if (sequence instanceof DNASequence) 
+            // try to guess:
+            if (sequenceString.matches("^[ACTG]+$")) 
                 returnSeq = (S) new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
-            else if (sequence instanceof RNASequence)
+            else if (sequenceString.matches("^[ACUG]+$"))
                 returnSeq = (S) new RNASequence(sequenceString, RNACompoundSet.getRNACompoundSet());
-            else if (sequence instanceof ProteinSequence)
+            else
                 returnSeq = (S) new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
-            else if (sequence == null){
-                // try to guess
-                if (sequenceString.matches("^[ACTG]+$")) 
-                    returnSeq = (S) new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
-                else if (sequenceString.matches("^[ACUG]+$"))
-                    returnSeq = (S) new RNASequence(sequenceString, RNACompoundSet.getRNACompoundSet());
-                else
-                    returnSeq = (S) new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
-            }
-            // else it is a non considered case
-            else throw new IllegalStateException();
+            
         } catch (CompoundNotFoundException ex) {
             logger.error("Unexpected error, could not find compound when creating Sequence object from Hsp", ex);
         }
@@ -262,7 +251,7 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         return null;
     }
 
-    public Hsp(int hspNum, double hspBitScore, int hspScore, double hspEvalue, int hspQueryFrom, int hspQueryTo, int hspHitFrom, int hspHitTo, int hspQueryFrame, int hspHitFrame, int hspIdentity, int hspPositive, int hspGaps, int hspAlignLen, String hspQseq, String hspHseq, String hspIdentityString, Double percentageIdentity, Integer mismatchCount, S sequence, C compound) {
+    public Hsp(int hspNum, double hspBitScore, int hspScore, double hspEvalue, int hspQueryFrom, int hspQueryTo, int hspHitFrom, int hspHitTo, int hspQueryFrame, int hspHitFrame, int hspIdentity, int hspPositive, int hspGaps, int hspAlignLen, String hspQseq, String hspHseq, String hspIdentityString, Double percentageIdentity, Integer mismatchCount) {
         this.hspNum = hspNum;
         this.hspBitScore = hspBitScore;
         this.hspScore = hspScore;
@@ -282,8 +271,6 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         this.hspIdentityString = hspIdentityString;
         this.percentageIdentity = percentageIdentity; 
         this.mismatchCount = mismatchCount;
-        this.sequence = sequence;
-        this.compound = compound;
         
         // sanity check
         if (percentageIdentity != null && (percentageIdentity < 0 || percentageIdentity >1))

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
@@ -69,9 +69,12 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
     private final String hspQseq;
     private final String hspHseq;
     private final String hspIdentityString;
-    private final Double percentageIdentity = null;
-    private final Integer mismatchCount = null;
-    private final SimpleSequencePair<S, C> returnAln;
+    private final Double percentageIdentity;
+    private final Integer mismatchCount;
+    /**
+     * Singleton, lazy computed
+    **/
+    private SimpleSequencePair<S, C> returnAln;
     private final S sequence;
     private final C compound;
 
@@ -128,27 +131,30 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         return returnAln;
     }
     
-    private Sequence getSequence(String gappedSequenceString){
+    @SuppressWarnings("unchecked")
+    private Sequence<C> getSequence(String gappedSequenceString){
         if (gappedSequenceString == null) return null;
         
-        Sequence returnSeq = null;
+        //Sequence<C> returnSeq = null;
+        S returnSeq = null;
         String sequenceString = gappedSequenceString.replace("-", "");
         
         try {
+            // these casting are unavoidable risky operations due to the guess made on sequence string.
             if (sequence instanceof DNASequence) 
-                returnSeq = new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
+                returnSeq = (S) new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
             else if (sequence instanceof RNASequence)
-                returnSeq = new RNASequence(sequenceString, RNACompoundSet.getRNACompoundSet());
+                returnSeq = (S) new RNASequence(sequenceString, RNACompoundSet.getRNACompoundSet());
             else if (sequence instanceof ProteinSequence)
-                returnSeq = new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
+                returnSeq = (S) new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
             else if (sequence == null){
                 // try to guess
                 if (sequenceString.matches("^[ACTG]+$")) 
-                    returnSeq = new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
+                    returnSeq = (S) new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
                 else if (sequenceString.matches("^[ACUG]+$"))
-                    returnSeq = new RNASequence(sequenceString, RNACompoundSet.getRNACompoundSet());
+                    returnSeq = (S) new RNASequence(sequenceString, RNACompoundSet.getRNACompoundSet());
                 else
-                    returnSeq = new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
+                    returnSeq = (S) new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
             }
             // else it is a non considered case
             else throw new IllegalStateException();
@@ -270,7 +276,7 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         this.hspIdentity = hspIdentity;
         this.hspPositive = hspPositive;
         this.hspGaps = hspGaps;
-        this.hspIdentity = hspAlignLen;
+        this.hspAlignLen = hspAlignLen;
         this.hspQseq = hspQseq;
         this.hspHseq = hspHseq;
         this.hspIdentityString = hspIdentityString;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
@@ -52,28 +52,28 @@ import org.slf4j.LoggerFactory;
 
 public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
     private static final Logger logger = LoggerFactory.getLogger(Hsp.class);
-    private Integer hspNum;
-    private Double hspBitScore;
-    private Integer hspScore;
-    private Double hspEvalue;
-    private Integer hspQueryFrom;
-    private Integer hspQueryTo;
-    private Integer hspHitFrom;
-    private Integer hspHitTo;
-    private Integer hspQueryFrame;
-    private Integer hspHitFrame;
-    private Integer hspIdentity;
-    private Integer hspPositive;
-    private Integer hspGaps;
-    private Integer hspAlignLen;
-    private String hspQseq;
-    private String hspHseq;
-    private String hspIdentityString;
-    private Double percentageIdentity = null;
-    private Integer mismatchCount = null;
-    private SimpleSequencePair<S, C> returnAln;
-    private S sequence;
-    private C compound;
+    private final Integer hspNum;
+    private final Double hspBitScore;
+    private final Integer hspScore;
+    private final Double hspEvalue;
+    private final Integer hspQueryFrom;
+    private final Integer hspQueryTo;
+    private final Integer hspHitFrom;
+    private final Integer hspHitTo;
+    private final Integer hspQueryFrame;
+    private final Integer hspHitFrame;
+    private final Integer hspIdentity;
+    private final Integer hspPositive;
+    private final Integer hspGaps;
+    private final Integer hspAlignLen;
+    private final String hspQseq;
+    private final String hspHseq;
+    private final String hspIdentityString;
+    private final Double percentageIdentity = null;
+    private final Integer mismatchCount = null;
+    private final SimpleSequencePair<S, C> returnAln;
+    private final S sequence;
+    private final C compound;
 
     @Override
     public int hashCode() {
@@ -84,8 +84,8 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
         return hash;
     }
     /**
-     * Experimental.
-     * Wants to implement conceptual comparisons of search results.
+     * 
+     * implements comparison of HSP alignments.
      * Fields unrelated to search are deliberately not considered.
      * 
      * In HSP case, alignment representation strings are considered.

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
@@ -146,7 +146,7 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
                 if (sequenceString.matches("^[ACTG]+$")) 
                     returnSeq = new DNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
                 else if (sequenceString.matches("^[ACUG]+$"))
-                    returnSeq = new RNASequence(sequenceString, DNACompoundSet.getDNACompoundSet());
+                    returnSeq = new RNASequence(sequenceString, RNACompoundSet.getRNACompoundSet());
                 else
                     returnSeq = new ProteinSequence(sequenceString, AminoAcidCompoundSet.getAminoAcidCompoundSet());
             }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Result.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Result.java
@@ -39,20 +39,20 @@ import org.biojava.nbio.core.sequence.template.Sequence;
  */
 
 public abstract class Result implements Iterable<Hit>{
-    private String program;
-    private String version;
-    private String reference;
-    private String dbFile;
+    private final String program;
+    private final String version;
+    private final String reference;
+    private final String dbFile;
 
-    private HashMap<String,String> programSpecificParameters;
+    private final HashMap<String,String> programSpecificParameters;
     
-    private int iterationNumber;
-    private String queryID;
-    private String queryDef;
-    private int queryLength;
-    private Sequence querySequence;
-    private List<Hit> hits;
-    private int hitCounter = -1;
+    private final int iterationNumber;
+    private final String queryID;
+    private final String queryDef;
+    private final int queryLength;
+    private final Sequence<?> querySequence;
+    private final List<Hit> hits;
+    private final int hitCounter = -1;
 
     public Result(String program, String version, String reference, String dbFile, HashMap<String, String> programSpecificParameters, int iterationNumber, String queryID, String queryDef, int queryLength, List<Hit> hits, Sequence querySequence) {
         this.program = program;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/ResultFactory.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/ResultFactory.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.List;
+import org.biojava.nbio.core.sequence.template.Compound;
 import org.biojava.nbio.core.sequence.template.Sequence;
 
 /**
@@ -35,7 +36,7 @@ import org.biojava.nbio.core.sequence.template.Sequence;
  * @author Paolo Pavan
  */
 
-public interface ResultFactory {
+public interface ResultFactory <S extends Sequence<C>, C extends Compound>{
     /**
      * returns a list of file extensions associated to this ResultFactory
      * 
@@ -66,11 +67,11 @@ public interface ResultFactory {
      * They will be associated back to the query during the construction of the Result object.
      * @param sequences 
      */
-    void setQueryReferences(List<Sequence> sequences);
+    void setQueryReferences(List<S> sequences);
     /**
      * Specify the collection of sequences objects used as database in the Search run. 
      * They will be associated back to the Hit during the construction of the Hit object.
      * @param sequences 
      */
-    void setDatabaseReferences(List<Sequence> sequences);
+    void setDatabaseReferences(List<S> sequences);
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastHitBuilder.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastHitBuilder.java
@@ -23,6 +23,7 @@ package org.biojava.nbio.core.search.io.blast;
 
 import org.biojava.nbio.core.search.io.Hsp;
 import java.util.List;
+import org.biojava.nbio.core.sequence.template.Compound;
 import org.biojava.nbio.core.sequence.template.Sequence;
 
 /**
@@ -33,49 +34,49 @@ import org.biojava.nbio.core.sequence.template.Sequence;
  * 
  * @author Paolo Pavan
  */
-public class BlastHitBuilder {
+public class BlastHitBuilder<S extends Sequence<C>, C extends Compound> {
     private int hitNum;
     private String hitId;
     private String hitDef;
     private String hitAccession;
     private int hitLen;
-    private Sequence hitSequence;
-    private List<Hsp> hsps;
+    private Sequence<?> hitSequence;
+    private List<Hsp<?,?>> hsps;
 
     public BlastHitBuilder() {
     }
 
-    public BlastHitBuilder setHitNum(int hitNum) {
+    public BlastHitBuilder<S,C> setHitNum(int hitNum) {
         this.hitNum = hitNum;
         return this;
     }
 
-    public BlastHitBuilder setHitId(String hitId) {
+    public BlastHitBuilder<S,C> setHitId(String hitId) {
         this.hitId = hitId;
         return this;
     }
 
-    public BlastHitBuilder setHitDef(String hitDef) {
+    public BlastHitBuilder<S,C> setHitDef(String hitDef) {
         this.hitDef = hitDef;
         return this;
     }
 
-    public BlastHitBuilder setHitAccession(String hitAccession) {
+    public BlastHitBuilder<S,C> setHitAccession(String hitAccession) {
         this.hitAccession = hitAccession;
         return this;
     }
 
-    public BlastHitBuilder setHitLen(int hitLen) {
+    public BlastHitBuilder<S,C> setHitLen(int hitLen) {
         this.hitLen = hitLen;
         return this;
     }
     
-    public BlastHitBuilder setHitSequence(Sequence s) {
+    public BlastHitBuilder<S,C> setHitSequence(Sequence<?> s) {
         this.hitSequence = s;
         return this;
     }
 
-    public BlastHitBuilder setHsps(List<Hsp> hsps) {
+    public BlastHitBuilder<S,C> setHsps(List<Hsp<?,?>> hsps) {
         this.hsps = hsps;
         return this;
     }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastHspBuilder.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastHspBuilder.java
@@ -20,6 +20,9 @@
  */
 package org.biojava.nbio.core.search.io.blast;
 
+import org.biojava.nbio.core.sequence.template.Compound;
+import org.biojava.nbio.core.sequence.template.Sequence;
+
 /**
  * Designed by Paolo Pavan.
  * You may want to find my contacts on Github and LinkedIn for code info 
@@ -29,7 +32,7 @@ package org.biojava.nbio.core.search.io.blast;
  * @author Paolo Pavan
  */
 
-public class BlastHspBuilder {
+public class BlastHspBuilder<S extends Sequence<C>, C extends Compound> {
     private int hspNum;
     private double hspBitScore;
     private int hspScore;
@@ -49,6 +52,8 @@ public class BlastHspBuilder {
     private String hspIdentityString;
     private Double percentageIdentity;
     private Integer mismatchCount;
+    private S sequence;
+    private C compound;
 
     public BlastHspBuilder() {
     }
@@ -147,8 +152,19 @@ public class BlastHspBuilder {
         this.mismatchCount = mismatchCount;
         return this;
     }
+
+    public BlastHspBuilder setSequence(S sequence) {
+        this.sequence = sequence;
+        return this;
+    }
+
+    public BlastHspBuilder setCompound(C compound) {
+        this.compound = compound;
+        return this;
+    }
+    
     public BlastHsp createBlastHsp() {
-        return new BlastHsp(hspNum, hspBitScore, hspScore, hspEvalue, hspQueryFrom, hspQueryTo, hspHitFrom, hspHitTo, hspQueryFrame, hspHitFrame, hspIdentity, hspPositive, hspGaps, hspAlignLen, hspQseq, hspHseq, hspIdentityString, percentageIdentity, mismatchCount);
+        return new BlastHsp(hspNum, hspBitScore, hspScore, hspEvalue, hspQueryFrom, hspQueryTo, hspHitFrom, hspHitTo, hspQueryFrame, hspHitFrame, hspIdentity, hspPositive, hspGaps, hspAlignLen, hspQseq, hspHseq, hspIdentityString, percentageIdentity, mismatchCount, sequence, compound);
     }
     
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastHspBuilder.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastHspBuilder.java
@@ -52,8 +52,6 @@ public class BlastHspBuilder<S extends Sequence<C>, C extends Compound> {
     private String hspIdentityString;
     private Double percentageIdentity;
     private Integer mismatchCount;
-    private S sequence;
-    private C compound;
 
     public BlastHspBuilder() {
     }
@@ -152,19 +150,9 @@ public class BlastHspBuilder<S extends Sequence<C>, C extends Compound> {
         this.mismatchCount = mismatchCount;
         return this;
     }
-
-    public BlastHspBuilder<S,C> setSequence(S sequence) {
-        this.sequence = sequence;
-        return this;
-    }
-
-    public BlastHspBuilder<S,C> setCompound(C compound) {
-        this.compound = compound;
-        return this;
-    }
     
     public BlastHsp<S,C> createBlastHsp() {
-        return new BlastHsp<S,C>(hspNum, hspBitScore, hspScore, hspEvalue, hspQueryFrom, hspQueryTo, hspHitFrom, hspHitTo, hspQueryFrame, hspHitFrame, hspIdentity, hspPositive, hspGaps, hspAlignLen, hspQseq, hspHseq, hspIdentityString, percentageIdentity, mismatchCount, sequence, compound);
+        return new BlastHsp<S,C>(hspNum, hspBitScore, hspScore, hspEvalue, hspQueryFrom, hspQueryTo, hspHitFrom, hspHitTo, hspQueryFrame, hspHitFrame, hspIdentity, hspPositive, hspGaps, hspAlignLen, hspQseq, hspHseq, hspIdentityString, percentageIdentity, mismatchCount);
     }
     
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastHspBuilder.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastHspBuilder.java
@@ -58,113 +58,113 @@ public class BlastHspBuilder<S extends Sequence<C>, C extends Compound> {
     public BlastHspBuilder() {
     }
 
-    public BlastHspBuilder setHspNum(int hspNum) {
+    public BlastHspBuilder<S,C> setHspNum(int hspNum) {
         this.hspNum = hspNum;
         return this;
     }
 
-    public BlastHspBuilder setHspBitScore(double hspBitScore) {
+    public BlastHspBuilder<S,C> setHspBitScore(double hspBitScore) {
         this.hspBitScore = hspBitScore;
         return this;
     }
 
-    public BlastHspBuilder setHspScore(int hspScore) {
+    public BlastHspBuilder<S,C> setHspScore(int hspScore) {
         this.hspScore = hspScore;
         return this;
     }
 
-    public BlastHspBuilder setHspEvalue(double hspEvalue) {
+    public BlastHspBuilder<S,C> setHspEvalue(double hspEvalue) {
         this.hspEvalue = hspEvalue;
         return this;
     }
 
-    public BlastHspBuilder setHspQueryFrom(int hspQueryFrom) {
+    public BlastHspBuilder<S,C> setHspQueryFrom(int hspQueryFrom) {
         this.hspQueryFrom = hspQueryFrom;
         return this;
     }
 
-    public BlastHspBuilder setHspQueryTo(int hspQueryTo) {
+    public BlastHspBuilder<S,C> setHspQueryTo(int hspQueryTo) {
         this.hspQueryTo = hspQueryTo;
         return this;
     }
 
-    public BlastHspBuilder setHspHitFrom(int hspHitFrom) {
+    public BlastHspBuilder<S,C> setHspHitFrom(int hspHitFrom) {
         this.hspHitFrom = hspHitFrom;
         return this;
     }
 
-    public BlastHspBuilder setHspHitTo(int hspHitTo) {
+    public BlastHspBuilder<S,C> setHspHitTo(int hspHitTo) {
         this.hspHitTo = hspHitTo;
         return this;
     }
 
-    public BlastHspBuilder setHspQueryFrame(int hspQueryFrame) {
+    public BlastHspBuilder<S,C> setHspQueryFrame(int hspQueryFrame) {
         this.hspQueryFrame = hspQueryFrame;
         return this;
     }
 
-    public BlastHspBuilder setHspHitFrame(int hspHitFrame) {
+    public BlastHspBuilder<S,C> setHspHitFrame(int hspHitFrame) {
         this.hspHitFrame = hspHitFrame;
         return this;
     }
 
-    public BlastHspBuilder setHspIdentity(int hspIdentity) {
+    public BlastHspBuilder<S,C> setHspIdentity(int hspIdentity) {
         this.hspIdentity = hspIdentity;
         return this;
     }
 
-    public BlastHspBuilder setHspPositive(int hspPositive) {
+    public BlastHspBuilder<S,C> setHspPositive(int hspPositive) {
         this.hspPositive = hspPositive;
         return this;
     }
 
-    public BlastHspBuilder setHspGaps(int hspGaps) {
+    public BlastHspBuilder<S,C> setHspGaps(int hspGaps) {
         this.hspGaps = hspGaps;
         return this;
     }
 
-    public BlastHspBuilder setHspAlignLen(int hspAlignLen) {
+    public BlastHspBuilder<S,C> setHspAlignLen(int hspAlignLen) {
         this.hspAlignLen = hspAlignLen;
         return this;
     }
 
-    public BlastHspBuilder setHspQseq(String hspQseq) {
+    public BlastHspBuilder<S,C> setHspQseq(String hspQseq) {
         this.hspQseq = hspQseq;
         return this;
     }
 
-    public BlastHspBuilder setHspHseq(String hspHseq) {
+    public BlastHspBuilder<S,C> setHspHseq(String hspHseq) {
         this.hspHseq = hspHseq;
         return this;
     }
 
-    public BlastHspBuilder setHspIdentityString(String hspIdentityString) {
+    public BlastHspBuilder<S,C> setHspIdentityString(String hspIdentityString) {
         this.hspIdentityString = hspIdentityString;
         return this;
     }
 
-    public BlastHspBuilder setPercentageIdentity(Double percentageIdentity) {
+    public BlastHspBuilder<S,C> setPercentageIdentity(Double percentageIdentity) {
         this.percentageIdentity = percentageIdentity;
         return this;
     }
 
-    public BlastHspBuilder setMismatchCount(Integer mismatchCount) {
+    public BlastHspBuilder<S,C> setMismatchCount(Integer mismatchCount) {
         this.mismatchCount = mismatchCount;
         return this;
     }
 
-    public BlastHspBuilder setSequence(S sequence) {
+    public BlastHspBuilder<S,C> setSequence(S sequence) {
         this.sequence = sequence;
         return this;
     }
 
-    public BlastHspBuilder setCompound(C compound) {
+    public BlastHspBuilder<S,C> setCompound(C compound) {
         this.compound = compound;
         return this;
     }
     
-    public BlastHsp createBlastHsp() {
-        return new BlastHsp(hspNum, hspBitScore, hspScore, hspEvalue, hspQueryFrom, hspQueryTo, hspHitFrom, hspHitTo, hspQueryFrame, hspHitFrame, hspIdentity, hspPositive, hspGaps, hspAlignLen, hspQseq, hspHseq, hspIdentityString, percentageIdentity, mismatchCount, sequence, compound);
+    public BlastHsp<S,C> createBlastHsp() {
+        return new BlastHsp<S,C>(hspNum, hspBitScore, hspScore, hspEvalue, hspQueryFrom, hspQueryTo, hspHitFrom, hspHitTo, hspQueryFrame, hspHitFrame, hspIdentity, hspPositive, hspGaps, hspAlignLen, hspQseq, hspHseq, hspIdentityString, percentageIdentity, mismatchCount, sequence, compound);
     }
     
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastTabularParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastTabularParser.java
@@ -35,6 +35,7 @@ import org.biojava.nbio.core.search.io.Hit;
 import org.biojava.nbio.core.search.io.Hsp;
 import org.biojava.nbio.core.search.io.Result;
 import org.biojava.nbio.core.search.io.ResultFactory;
+import org.biojava.nbio.core.sequence.template.Compound;
 import org.biojava.nbio.core.sequence.template.Sequence;
 
 /**
@@ -46,7 +47,7 @@ import org.biojava.nbio.core.sequence.template.Sequence;
  * @author Paolo Pavan
  */
 
-public class BlastTabularParser implements ResultFactory {
+public class BlastTabularParser <S extends Sequence<C>, C extends Compound> implements ResultFactory  <S,C> {
     private final String blastReference = 
             "Zheng Zhang, Scott Schwartz, Lukas Wagner, and Webb Miller (2000), A greedy algorithm for aligning DNA sequences&quot;, J Comput Biol 2000; 7(1-2):203-14.";
     /**
@@ -131,7 +132,7 @@ public class BlastTabularParser implements ResultFactory {
                 while (currentQueryId.equals(queryId) && lineNumber < fileLinesCount){
                     BlastHitBuilder hitBuilder = new BlastHitBuilder();
                     
-                    List<Hsp> hsps = new ArrayList<Hsp>();
+                    List<Hsp<S,C>> hsps = new ArrayList<Hsp<S,C>>();
                     
                     String currentSubjectId=subjectId;
                     while (currentSubjectId.equals(subjectId) && lineNumber < fileLinesCount){
@@ -140,7 +141,7 @@ public class BlastTabularParser implements ResultFactory {
                             lineNumber++;
                             continue;
                         }
-                        BlastHspBuilder hspBuilder = new BlastHspBuilder();
+                        BlastHspBuilder<S,C> hspBuilder = new BlastHspBuilder<S,C>();
                         hspBuilder
                             .setHspAlignLen(new Integer(alnLength))
                             .setHspGaps(new Integer(gapOpenCount))
@@ -227,7 +228,7 @@ public class BlastTabularParser implements ResultFactory {
      * @param sequences 
      */
     @Override
-    public void setQueryReferences(List<Sequence> sequences) {
+    public void setQueryReferences(List<S> sequences) {
         throw new UnsupportedOperationException("Not supported for this parser.");
     }
     /**
@@ -237,7 +238,7 @@ public class BlastTabularParser implements ResultFactory {
      * @param sequences 
      */
     @Override
-    public void setDatabaseReferences(List<Sequence> sequences) {
+    public void setDatabaseReferences(List<S> sequences) {
         throw new UnsupportedOperationException("Not supported for this parser.");
     }
      /**

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastXMLParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastXMLParser.java
@@ -194,25 +194,6 @@ public class BlastXMLParser <S extends Sequence<C>, C extends Compound> implemen
                                 .setHspHseq(hspHitSeq)
                                 .setHspIdentityString(XMLHelper.selectSingleElement(hspElement, "Hsp_midline").getTextContent());
                             
-                            S s;
-                            CompoundSet c;
-                            String querySequenceString = hspQuerySeq.replace("-", "");
-                            try {
-                                if (isDNA) {
-                                    c = DNACompoundSet.getDNACompoundSet();
-                                    s = (S)new DNASequence(hspQuerySeq, c);
-                                } else {
-                                    c = AminoAcidCompoundSet.getAminoAcidCompoundSet();
-                                    s = (S)new ProteinSequence(hspQuerySeq, c);
-                                }
-                                
-                                blastHspBuilder.setSequence(s);
-                                //blastHspBuilder.setCompound(c); // ???????
-                            } catch (CompoundNotFoundException e){
-                                logger.error("Compoundset not found error for HSP num "+hspNum
-                                        +". It will not be set by blast parser and I will try to continue.");
-                            }
-
                             hspsCollection.add(blastHspBuilder.createBlastHsp());
                         }
                     }
@@ -280,8 +261,8 @@ public class BlastXMLParser <S extends Sequence<C>, C extends Compound> implemen
 
 
 class BlastHsp<S extends Sequence<C>, C extends Compound> extends org.biojava.nbio.core.search.io.Hsp<S,C> {
-    public BlastHsp(int hspNum, double hspBitScore, int hspScore, double hspEvalue, int hspQueryFrom, int hspQueryTo, int hspHitFrom, int hspHitTo, int hspQueryFrame, int hspHitFrame, int hspIdentity, int hspPositive, int hspGaps, int hspAlignLen, String hspQseq, String hspHseq, String hspIdentityString, Double percentageIdentity, Integer mismatchCount, S s, C c) {
-        super(hspNum, hspBitScore, hspScore, hspEvalue, hspQueryFrom, hspQueryTo, hspHitFrom, hspHitTo, hspQueryFrame, hspHitFrame, hspIdentity, hspPositive, hspGaps, hspAlignLen, hspQseq, hspHseq, hspIdentityString, percentageIdentity, mismatchCount, s, c);
+    public BlastHsp(int hspNum, double hspBitScore, int hspScore, double hspEvalue, int hspQueryFrom, int hspQueryTo, int hspHitFrom, int hspHitTo, int hspQueryFrame, int hspHitFrame, int hspIdentity, int hspPositive, int hspGaps, int hspAlignLen, String hspQseq, String hspHseq, String hspIdentityString, Double percentageIdentity, Integer mismatchCount) {
+        super(hspNum, hspBitScore, hspScore, hspEvalue, hspQueryFrom, hspQueryTo, hspHitFrom, hspHitTo, hspQueryFrame, hspHitFrame, hspIdentity, hspPositive, hspGaps, hspAlignLen, hspQseq, hspHseq, hspIdentityString, percentageIdentity, mismatchCount);
     }
     
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/search/io/HspTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/search/io/HspTest.java
@@ -20,9 +20,12 @@
  */
 package org.biojava.nbio.core.search.io;
 
+import org.biojava.nbio.core.alignment.SimpleSequencePair;
 import org.biojava.nbio.core.alignment.template.SequencePair;
 import org.biojava.nbio.core.search.io.blast.BlastHspBuilder;
 import org.biojava.nbio.core.sequence.DNASequence;
+import org.biojava.nbio.core.sequence.ProteinSequence;
+import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
 import org.biojava.nbio.core.sequence.compound.NucleotideCompound;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -218,6 +221,55 @@ public class HspTest {
         String result = aln.toString();
         
         assertEquals(expResult, result);
+        
+        // test for type checking
+        Hsp<DNASequence,NucleotideCompound> o1 = new BlastHspBuilder()
+                .setHspNum(1)
+                .setHspBitScore(377.211)
+                .setHspEvalue(8.04143e-093)
+                .setHspQueryFrom(1)
+                .setHspQueryTo(224)
+                .setHspHitFrom(1035)
+                .setHspHitTo(811)
+                .setHspQueryFrame(-1)
+                .setHspIdentity(213)
+                .setHspPositive(213)
+                .setHspGaps(5)
+                .setHspAlignLen(227)
+                .setHspQseq("CTGACGACAGCCATGCACCACCTGTCTCGACTTTCCCCCGAAGGGCACCTAATGTATCTCTACCTCGTTAGTCGGATGTCAAGACCTGGTAAGGTTTTTTCGCGTATCTTCGAATTAAACCACATACTCCACTGCTTGTGCGG-CCCCCGTCAATTCCTTTGAGTTTCAACCTTGCGGCCGTACTCCC-AGGTGGA-TACTTATTGTGTTAACTCCGGCACGGAAGG")
+                .setHspHseq("CTGACGACAACCATGCACCACCTGTCTCAACTTTCCCC-GAAGGGCACCTAATGTATCTCTACTTCGTTAGTTGGATGTCAAGACCTGGTAAGGTT-CTTCGCGTTGCTTCGAATTAAACCACATACTCCACTGCTTGTGCGGGCCCCCGTCAATTCCTTTGAGTTTCAACCTTGCGGTCGTACTCCCCAGGTGGATTACTTATTGTGTTAACTCCGGCACAGAAGG")
+                .setHspIdentityString("||||||||| |||||||||||||||||| ||||||||| |||||||||||||||||||||||| |||||||| |||||||||||||||||||||||  |||||||  |||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||| ||||||||| ||||||| |||||||||||||||||||||||| |||||")
+                .setSequence(new DNASequence())
+                .setCompound(new NucleotideCompound("C", null, "G"))
+                .createBlastHsp();
+        
+        
+        SequencePair<DNASequence,NucleotideCompound> alignment1 = o1.getAlignment();
+        
+        
+        // test for not specified sequence type at construction time
+        Hsp<DNASequence,NucleotideCompound> o2 = new BlastHspBuilder()
+                .setHspNum(1)
+                .setHspBitScore(377.211)
+                .setHspEvalue(8.04143e-093)
+                .setHspQueryFrom(1)
+                .setHspQueryTo(224)
+                .setHspHitFrom(1035)
+                .setHspHitTo(811)
+                .setHspQueryFrame(-1)
+                .setHspIdentity(213)
+                .setHspPositive(213)
+                .setHspGaps(5)
+                .setHspAlignLen(227)
+                .setHspQseq("CTGACGACAGCCATGCACCACCTGTCTCGACTTTCCCCCGAAGGGCACCTAATGTATCTCTACCTCGTTAGTCGGATGTCAAGACCTGGTAAGGTTTTTTCGCGTATCTTCGAATTAAACCACATACTCCACTGCTTGTGCGG-CCCCCGTCAATTCCTTTGAGTTTCAACCTTGCGGCCGTACTCCC-AGGTGGA-TACTTATTGTGTTAACTCCGGCACGGAAGG")
+                .setHspHseq("CTGACGACAACCATGCACCACCTGTCTCAACTTTCCCC-GAAGGGCACCTAATGTATCTCTACTTCGTTAGTTGGATGTCAAGACCTGGTAAGGTT-CTTCGCGTTGCTTCGAATTAAACCACATACTCCACTGCTTGTGCGGGCCCCCGTCAATTCCTTTGAGTTTCAACCTTGCGGTCGTACTCCCCAGGTGGATTACTTATTGTGTTAACTCCGGCACAGAAGG")
+                .setHspIdentityString("||||||||| |||||||||||||||||| ||||||||| |||||||||||||||||||||||| |||||||| |||||||||||||||||||||||  |||||||  |||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||| ||||||||| ||||||| |||||||||||||||||||||||| |||||")
+                .createBlastHsp();
+        // why?
+        SequencePair<DNASequence,NucleotideCompound> alignment2 = o2.getAlignment();
+        
+        //new SimpleSequencePair<ProteinSequence,AminoAcidCompound>(new DNASequence("ACGT"), new DNASequence("ACGT"));
+        //new SimpleSequencePair;
     }
     
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/search/io/HspTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/search/io/HspTest.java
@@ -26,6 +26,7 @@ import org.biojava.nbio.core.search.io.blast.BlastHspBuilder;
 import org.biojava.nbio.core.sequence.DNASequence;
 import org.biojava.nbio.core.sequence.ProteinSequence;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
+import org.biojava.nbio.core.sequence.compound.AminoAcidCompoundSet;
 import org.biojava.nbio.core.sequence.compound.NucleotideCompound;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -243,9 +244,18 @@ public class HspTest {
                 .setCompound(new NucleotideCompound("C", null, "G"))
                 .createBlastHsp();
         
+        // this returns the alignment of the correct type:
+        SequencePair<DNASequence,NucleotideCompound> aln1 = o1.getAlignment();
+        String result1 = aln1.toString();
+        assertEquals(expResult, result1);
         
-        SequencePair<DNASequence,NucleotideCompound> alignment1 = o1.getAlignment();
+        // this is still valid:
+        SequencePair aln2 = o1.getAlignment();
+        String result2 = aln2.toString();
+        assertEquals(expResult, result2);
         
+        // the next does not compile. It is type safe:
+        //SequencePair<ProteinSequence,AminoAcidCompound> alignment4 = o1.getAlignment();
         
         // test for not specified sequence type at construction time
         Hsp<DNASequence,NucleotideCompound> o2 = new BlastHspBuilder()
@@ -265,11 +275,11 @@ public class HspTest {
                 .setHspHseq("CTGACGACAACCATGCACCACCTGTCTCAACTTTCCCC-GAAGGGCACCTAATGTATCTCTACTTCGTTAGTTGGATGTCAAGACCTGGTAAGGTT-CTTCGCGTTGCTTCGAATTAAACCACATACTCCACTGCTTGTGCGGGCCCCCGTCAATTCCTTTGAGTTTCAACCTTGCGGTCGTACTCCCCAGGTGGATTACTTATTGTGTTAACTCCGGCACAGAAGG")
                 .setHspIdentityString("||||||||| |||||||||||||||||| ||||||||| |||||||||||||||||||||||| |||||||| |||||||||||||||||||||||  |||||||  |||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||| ||||||||| ||||||| |||||||||||||||||||||||| |||||")
                 .createBlastHsp();
-        // why?
-        SequencePair<DNASequence,NucleotideCompound> alignment2 = o2.getAlignment();
         
-        //new SimpleSequencePair<ProteinSequence,AminoAcidCompound>(new DNASequence("ACGT"), new DNASequence("ACGT"));
-        //new SimpleSequencePair;
+        // this returns the alignment of the correct type because guessed by HSP class:
+        SequencePair<DNASequence,NucleotideCompound> aln3 = o2.getAlignment();
+        String result3 = aln3.toString();
+        assertEquals(expResult, result3);
     }
     
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/search/io/HspTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/search/io/HspTest.java
@@ -240,8 +240,6 @@ public class HspTest {
                 .setHspQseq("CTGACGACAGCCATGCACCACCTGTCTCGACTTTCCCCCGAAGGGCACCTAATGTATCTCTACCTCGTTAGTCGGATGTCAAGACCTGGTAAGGTTTTTTCGCGTATCTTCGAATTAAACCACATACTCCACTGCTTGTGCGG-CCCCCGTCAATTCCTTTGAGTTTCAACCTTGCGGCCGTACTCCC-AGGTGGA-TACTTATTGTGTTAACTCCGGCACGGAAGG")
                 .setHspHseq("CTGACGACAACCATGCACCACCTGTCTCAACTTTCCCC-GAAGGGCACCTAATGTATCTCTACTTCGTTAGTTGGATGTCAAGACCTGGTAAGGTT-CTTCGCGTTGCTTCGAATTAAACCACATACTCCACTGCTTGTGCGGGCCCCCGTCAATTCCTTTGAGTTTCAACCTTGCGGTCGTACTCCCCAGGTGGATTACTTATTGTGTTAACTCCGGCACAGAAGG")
                 .setHspIdentityString("||||||||| |||||||||||||||||| ||||||||| |||||||||||||||||||||||| |||||||| |||||||||||||||||||||||  |||||||  |||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||| ||||||||| ||||||| |||||||||||||||||||||||| |||||")
-                .setSequence(new DNASequence())
-                .setCompound(new NucleotideCompound("C", null, "G"))
                 .createBlastHsp();
         
         // this returns the alignment of the correct type:

--- a/biojava-core/src/test/java/org/biojava/nbio/core/search/io/HspTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/search/io/HspTest.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.*;
 
 public class HspTest {
     
-    Hsp hspImpl = new BlastHspBuilder()
+    Hsp<DNASequence,NucleotideCompound> hspImpl = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setHspNum(1)
                 .setHspBitScore(377.211)
                 .setHspEvalue(8.04143e-093)
@@ -59,7 +59,7 @@ public class HspTest {
                 .setHspIdentityString("||||||||| |||||||||||||||||| ||||||||| |||||||||||||||||||||||| |||||||| |||||||||||||||||||||||  |||||||  |||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||| ||||||||| ||||||| |||||||||||||||||||||||| |||||")
                 .createBlastHsp();
     
-    Hsp uncompleteHsp = new BlastHspBuilder()
+    Hsp<DNASequence,NucleotideCompound> uncompleteHsp = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setPercentageIdentity(100.00/100)
                 .setHspAlignLen(48)
                 .setMismatchCount(0)
@@ -101,7 +101,7 @@ public class HspTest {
         int expResult;
         int result;
         
-        instance = new BlastHspBuilder()
+        instance = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setHspNum(1)
                 .setHspBitScore(377.211)
                 .setHspEvalue(8.04143e-093)
@@ -123,7 +123,7 @@ public class HspTest {
         result = instance.hashCode();
         assertEquals(expResult, result);
         
-        instance = new BlastHspBuilder()
+        instance = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setPercentageIdentity(100.00/100)
                 .setHspAlignLen(48)
                 .setMismatchCount(0)
@@ -140,7 +140,7 @@ public class HspTest {
         result = instance.hashCode();
         assertEquals(expResult, result);
         
-        Hsp uncompleteHsp2 = new BlastHspBuilder()
+        Hsp<DNASequence,NucleotideCompound> uncompleteHsp2 = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setPercentageIdentity(100.00/100)
                 .setHspAlignLen(48)
                 .setMismatchCount(0)
@@ -163,7 +163,7 @@ public class HspTest {
     public void testEquals() {
         System.out.println("equals");
         Object o;
-        o = new BlastHspBuilder()
+        o = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setHspNum(1)
                 .setHspBitScore(377.211)
                 .setHspEvalue(8.04143e-093)
@@ -180,13 +180,13 @@ public class HspTest {
                 .setHspHseq("CTGACGACAACCATGCACCACCTGTCTCAACTTTCCCC-GAAGGGCACCTAATGTATCTCTACTTCGTTAGTTGGATGTCAAGACCTGGTAAGGTT-CTTCGCGTTGCTTCGAATTAAACCACATACTCCACTGCTTGTGCGGGCCCCCGTCAATTCCTTTGAGTTTCAACCTTGCGGTCGTACTCCCCAGGTGGATTACTTATTGTGTTAACTCCGGCACAGAAGG")
                 .setHspIdentityString("||||||||| |||||||||||||||||| ||||||||| |||||||||||||||||||||||| |||||||| |||||||||||||||||||||||  |||||||  |||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||| ||||||||| ||||||| |||||||||||||||||||||||| |||||")
                 .createBlastHsp();
-        Hsp instance = hspImpl;
+        Hsp<DNASequence,NucleotideCompound> instance = hspImpl;
         
         assertEquals(o, instance);
         
         // example of Hsp retrieved from uncomplete report.
         // (Those HSP may come from a tabular format, for example)
-        o = new BlastHspBuilder()
+        o = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setPercentageIdentity(100.00/100)
                 .setHspAlignLen(48)
                 .setMismatchCount(0)
@@ -224,7 +224,7 @@ public class HspTest {
         assertEquals(expResult, result);
         
         // test for type checking
-        Hsp<DNASequence,NucleotideCompound> o1 = new BlastHspBuilder()
+        Hsp<DNASequence,NucleotideCompound> o1 = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setHspNum(1)
                 .setHspBitScore(377.211)
                 .setHspEvalue(8.04143e-093)
@@ -248,7 +248,7 @@ public class HspTest {
         assertEquals(expResult, result1);
         
         // this is still valid:
-        SequencePair aln2 = o1.getAlignment();
+        SequencePair<DNASequence,NucleotideCompound> aln2 = o1.getAlignment();
         String result2 = aln2.toString();
         assertEquals(expResult, result2);
         
@@ -256,7 +256,7 @@ public class HspTest {
         //SequencePair<ProteinSequence,AminoAcidCompound> alignment4 = o1.getAlignment();
         
         // test for not specified sequence type at construction time
-        Hsp<DNASequence,NucleotideCompound> o2 = new BlastHspBuilder()
+        Hsp<DNASequence,NucleotideCompound> o2 = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setHspNum(1)
                 .setHspBitScore(377.211)
                 .setHspEvalue(8.04143e-093)

--- a/biojava-core/src/test/java/org/biojava/nbio/core/search/io/SearchIOTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/search/io/SearchIOTest.java
@@ -23,6 +23,8 @@ package org.biojava.nbio.core.search.io;
 import java.io.File;
 import java.net.URL;
 import org.biojava.nbio.core.search.io.blast.BlastXMLParser;
+import org.biojava.nbio.core.sequence.DNASequence;
+import org.biojava.nbio.core.sequence.compound.NucleotideCompound;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -84,7 +86,7 @@ public class SearchIOTest {
         URL resourceURL = getClass().getResource(resource);
         File file = new File(resourceURL.getFile());
         
-        ResultFactory blastResultFactory = new BlastXMLParser();
+        ResultFactory<DNASequence,NucleotideCompound> blastResultFactory = new BlastXMLParser<DNASequence,NucleotideCompound>();
         final SearchIO instance;
         try {
             instance = new SearchIO(file, blastResultFactory);
@@ -102,7 +104,7 @@ public class SearchIOTest {
         URL resourceURL = getClass().getResource(resource);
         File file = new File(resourceURL.getFile());
         
-        ResultFactory blastResultFactory = new BlastXMLParser();
+        ResultFactory<DNASequence,NucleotideCompound> blastResultFactory = new BlastXMLParser<DNASequence,NucleotideCompound>();
         final SearchIO instance;
         try {
             instance = new SearchIO(file, blastResultFactory, 10e-10);

--- a/biojava-core/src/test/java/org/biojava/nbio/core/search/io/blast/BlastXMLParserTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/search/io/blast/BlastXMLParserTest.java
@@ -27,6 +27,10 @@ import java.util.List;
 import org.biojava.nbio.core.search.io.Hit;
 import org.biojava.nbio.core.search.io.Hsp;
 import org.biojava.nbio.core.search.io.Result;
+import org.biojava.nbio.core.sequence.DNASequence;
+import org.biojava.nbio.core.sequence.ProteinSequence;
+import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
+import org.biojava.nbio.core.sequence.compound.NucleotideCompound;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -67,7 +71,7 @@ public class BlastXMLParserTest {
     public void testSetFile() {
         System.out.println("setFile");
         File f = null;
-        BlastXMLParser instance = new BlastXMLParser();
+        BlastXMLParser<ProteinSequence,AminoAcidCompound> instance = new BlastXMLParser<ProteinSequence,AminoAcidCompound>();
         instance.setFile(f);
     }
 
@@ -82,7 +86,7 @@ public class BlastXMLParserTest {
         URL resourceURL = getClass().getResource(resource);
         File file = new File(resourceURL.getFile());
         
-        BlastXMLParser instance = new BlastXMLParser();
+        BlastXMLParser<DNASequence,NucleotideCompound> instance = new BlastXMLParser<DNASequence,NucleotideCompound>();
         instance.setFile(file);
         
         //instance.setQueryReferences(null);
@@ -90,7 +94,7 @@ public class BlastXMLParserTest {
         List<Result> result = instance.createObjects(1e-10);
         
         // test with random manual selected results
-        BlastHsp hsp1hit1res1 = new BlastHspBuilder()
+        BlastHsp<DNASequence,NucleotideCompound> hsp1hit1res1 = new BlastHspBuilder<DNASequence,NucleotideCompound>()
                 .setHspNum(1)
                 .setHspBitScore(2894.82)
                 .setHspScore(1567)
@@ -109,10 +113,11 @@ public class BlastXMLParserTest {
                 .setHspHseq("TTAAATTGAGAGTTTGATCCTGGCTCAGGATGAACGCTGGTGGCGTGCCTAATACATGCAAGTCGTACGCTAGCCGCTGAATTGATCCTTCGGGTGAAGTGAGGCAATGACTAGAGTGGCGAACTGGTGAGTAACACGTAAGAAACCTGCCCTTTAGTGGGGGATAACATTTGGAAACAGATGCTAATACCGCGTAACAACAAATCACACATGTGATCTGTTTGAAAGGTCCTTTTGGATCGCTAGAGGATGGTCTTGCGGCGTATTAGCTTGTTGGTAGGGTAGAAGCCTACCAAGGCAATGATGCGTAGCCGAGTTGAGAGACTGGCCGGCCACATTGGGACTGAGACACTGCCCAAACTCCTACGGGAGGCTGCAGTAGGGAATTTTCCGCAATGCACGAAAGTGTGACGGAGCGACGCCGCGTGTGTGATGAAGGCTTTCGGGTCGTAAAGCACTGTTGTAAGGGAAGAATAACTGAATTCAGAGAAAGTTTTCAGCTTGACGGTACCTTACCAGAAAGGGATGGCTAAATACGTGCCAGCAGCCGCGGTAATACGTATGTCCCGAGCGTTATCCGGATTTATTGGGCGTAAAGCGAGCGCAGACGGTTTATTAAGTCTGATGTGAAATCCCGAGGCCCAACCTCGGAACTGCATTGGAAACTGATTTACTTGAGTGCGATAGAGGCAAGTGGAACTCCATGTGTAGCGGTGAAATGCGTAGATATGTGGAAGAACACCAGTGGCGAAAGCGGCTTGCTAGATCGTAACTGACGTTGAGGCTCGAAAGTATGGGTAGCAAACGGGATTAGATACCCCGGTAGTCCATACCGTAAACGATGGGTGCTAGTTGTTAAGAGGTTTCCGCCTCCTAGTGACGTAGCAAACGCATTAAGCACCCCGCCTGAGGAGTACGGCCGCAAGGCTAAAACTTAAAGGAATTGACGGGGACCCGCACAAGCGGTGGAGCATGTGGTTTAATTCGAAGATACGCGAAAAACCTTACCAGGTCTTGACATACCAATGATCGCTTTTGTAATGAAAGCTTTTCTTCGGAACATTGGATACAGGTGGTGCATGGTCGTCGTCAGCTCGTGTCGTGAGATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTTGTTATTAGTTGCCAGCATTTAGTTGGGCACTCTAATGAGACTGCCGGTGATAAACCGGAGGAAGGTGGGGACGACGTCAGATCATCATGCCCCTTATGACCTGGGCAACACACGTGCTACAATGGGAAGTACAACGAGTCGCAAACCGGCGACGGTAAGCTAATCTCTTAAAACTTCTCTCAGTTCGGACTGGAGTCTGCAACTCGACTCCACGAAGGCGGAATCGCTAGTAATCGCGAATCAGCATGTCGCGGTGAATACGTTCCCGGGTCTTGTACACACCGCCCGTCAAATCATGGGAGTCGGAAGTACCCAAAGTCGCTTGGCTAACTTTTAGAGGCCGGTGCCTAAGGTAAAATCGATGACTGGGATTAAGTCGTAACAAGGTAGCCGTAGGAGAACCTGCGGCTGGATCACCTCCTTTCT")
                 .setHspIdentityString("|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||")
                 .createBlastHsp();
-        List<Hsp> hsplist = new ArrayList<Hsp>();
+        List<Hsp<DNASequence,NucleotideCompound>> hsplist = new ArrayList<Hsp<DNASequence,NucleotideCompound>>();
         hsplist.add(hsp1hit1res1);
         hsplist.add(hsp1hit1res1);
         
+        // do not type
         BlastHit hit1res1 = new BlastHitBuilder()
                 .setHitNum(1)
                 .setHitId("gnl|BL_ORD_ID|2006")
@@ -136,7 +141,7 @@ public class BlastXMLParserTest {
         
         Result expRes1 = result.get(0);
         Hit expHit1res1 = expRes1.iterator().next();
-        Hsp expHsp1hit1res1 = expHit1res1.iterator().next();
+        Hsp<?,?> expHsp1hit1res1 = expHit1res1.iterator().next();
         
         // result not testable without all hits and hsp
         //assertEquals(expRes1, res1);


### PR DESCRIPTION
#354 #607 
Dear all,
I am working at this solution: I have increased general type checking and made data structures invariants with the purpose of enforcing the safety of the framework. I mean that in this way the type checking can be done only in the actual parser.
I am trying to avoid to parametrize the Hit and Result class because they don't deal with any sequence. The purpose is to safely deal with @sbliven doubt when he mentioned SPI in the main SearchIO class. In my opinion this can be safely done because at the parser side the HSP collection is typed during its construction and then it is plugged as it is in the Hit object. Since the data structure is invariant I think that this should be enough to enforce the whole system safety. As a second enforcement level I have also package restricted the access to the BlastHsp, BlastHit and BlastResult classes (and their own Builders) so that no other class except the parser may construct these data structures and may become the only delegated entity to correctly assemble the whole.