### PR TITLE
Fix #552 maximum RMSD parameter to SmithWaterman3Daligner superpositions

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/align/AlignmentToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/align/AlignmentToolsTest.java
@@ -443,4 +443,5 @@ public class AlignmentToolsTest extends TestCase {
 			return true;
 		}
 	}
+	
 }

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/align/seq/TestSmithWaterman3Daligner.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/align/seq/TestSmithWaterman3Daligner.java
@@ -1,0 +1,67 @@
+package org.biojava.nbio.structure.test.align.seq;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureTools;
+import org.biojava.nbio.structure.align.model.AFPChain;
+import org.biojava.nbio.structure.align.seq.SmithWaterman3DParameters;
+import org.biojava.nbio.structure.align.seq.SmithWaterman3Daligner;
+import org.junit.Test;
+
+/**
+ * Test the superposition based on a sequence alignment on different cases.
+ * 
+ * @author Aleix Lafita
+ *
+ */
+public class TestSmithWaterman3Daligner {
+
+	/**
+	 * Test the changes in the alignment by the max RMSD parameter. Use the
+	 * chain A and B of hemoglobin, because they have very similar sequences,
+	 * but some columns of the alignment have to be removed for a better
+	 * superposition (lower RMSD).
+	 */
+	@Test
+	public void testMaxRMSD() throws StructureException, IOException {
+
+		Structure s1 = StructureTools.getStructure("1A3N.A");
+		Structure s2 = StructureTools.getStructure("1A3N.B");
+
+		Atom[] ca1 = StructureTools.getRepresentativeAtomArray(s1);
+		Atom[] ca2 = StructureTools.getRepresentativeAtomArray(s2);
+
+		SmithWaterman3Daligner aligner = new SmithWaterman3Daligner();
+		SmithWaterman3DParameters params = new SmithWaterman3DParameters();
+
+		// Use no restriction on the RMSD
+		params.setMaxRmsd(99.0);
+
+		AFPChain afpChain = aligner.align(ca1, ca2, params);
+
+		assertEquals("RMSD is wrong", 1.39, afpChain.getTotalRmsdOpt(), 0.005);
+		assertEquals("Length is wrong", 137, afpChain.getOptLength());
+		
+		// Restrict it to 1A RMSD (18 columns have to be dropped)
+		params.setMaxRmsd(1.0);
+
+		afpChain = aligner.align(ca1, ca2, params);
+
+		assertTrue("RMSD is above the threshold", afpChain.getTotalRmsdOpt() < 1.0);
+		assertEquals("Length is wrong", 119, afpChain.getOptLength());
+		
+		// Restrict it to 0A RMSD (the minimum length is relevant )
+		params.setMaxRmsd(0.0);
+		params.setMinLen(30);
+
+		afpChain = aligner.align(ca1, ca2, params);
+
+		assertEquals("Length shoild be the minimum possible", 30, afpChain.getOptLength());
+
+	}
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -45,7 +45,6 @@ import org.biojava.nbio.structure.contact.AtomContactSet;
 import org.biojava.nbio.structure.contact.Grid;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.PDBFileParser;
-import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.biojava.nbio.structure.io.util.FileDownloadUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3DParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3DParameters.java
@@ -68,7 +68,7 @@ public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 		List<String> params = new ArrayList<String>();
 		params.add("GapOpen");
 		params.add("GapExtend");
-		params.add("MaxRMSD");
+		params.add("MaxRmsd");
 		params.add("MinLen");
 		
 		return params;
@@ -90,7 +90,7 @@ public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 	public void reset() {
 		gapOpen = (short) 8;
 		gapExtend = (short) 1;
-		maxRmsd = 10.0;
+		maxRmsd = 99;
 		minLen = 30;
 
 	}
@@ -111,7 +111,7 @@ public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 		this.gapOpen = gapOpen;
 	}
 
-	public double getMaxRmsd() {
+	public Double getMaxRmsd() {
 		return maxRmsd;
 	}
 
@@ -119,7 +119,7 @@ public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 		this.maxRmsd = maxRmsd;
 	}
 
-	public int getMinLen() {
+	public Integer getMinLen() {
 		return minLen;
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3DParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3DParameters.java
@@ -29,98 +29,102 @@ import org.biojava.nbio.structure.align.ce.ConfigStrucAligParams;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SmithWaterman3DParameters implements ConfigStrucAligParams
-{
+public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 
+	private short gapOpen;    // gap opening penalty for sequence alignment
+	private short gapExtend;  // gap extension penalty for sequence alignment
+	private double maxRmsd;   // maximum RMSD of superposition allowed
+	private int minLen;       // minimum alignment length allowed
 
-	private short gapOpen ;
-	private short gapExtend ;
-
-	public SmithWaterman3DParameters(){
+	public SmithWaterman3DParameters() {
 		reset();
 	}
 
-
-
 	@Override
-	public List<String> getUserConfigHelp()
-	{
-		List<String> params =new ArrayList<String>();
+	public List<String> getUserConfigHelp() {
+		List<String> params = new ArrayList<String>();
 		params.add("The Gap open penalty");
-		params.add("The Gap Extension penalty");
-
-
-
+		params.add("The Gap extension penalty");
+		params.add("The maximum RMSD of superposition allowed");
+		params.add("The minimum alignment length allowed");
+		
 		// TODO Auto-generated method stub
 		return params;
 	}
 
 	@Override
-	public List<String> getUserConfigParameterNames()
-	{
-		List<String> params =new ArrayList<String>();
+	public List<String> getUserConfigParameterNames() {
+		List<String> params = new ArrayList<String>();
 		params.add("Gap Open");
 		params.add("Gap Extension");
-
-
+		params.add("Maximum RMSD");
+		params.add("Minimum Alignment Length");
+		
 		return params;
 	}
 
 	@Override
-	public List<String> getUserConfigParameters()
-	{
-		List<String> params =new ArrayList<String>();
+	public List<String> getUserConfigParameters() {
+		List<String> params = new ArrayList<String>();
 		params.add("GapOpen");
 		params.add("GapExtend");
-
+		params.add("MaxRMSD");
+		params.add("MinLen");
+		
 		return params;
 	}
 
 	@Override
 	@SuppressWarnings("rawtypes")
-	public List<Class> getUserConfigTypes()
-	{
+	public List<Class> getUserConfigTypes() {
 		List<Class> params = new ArrayList<Class>();
 		params.add(Short.class);
 		params.add(Short.class);
+		params.add(Double.class);
+		params.add(Integer.class);
 
 		return params;
 	}
 
 	@Override
-	public void reset()
-	{
+	public void reset() {
 		gapOpen = (short) 8;
 		gapExtend = (short) 1;
+		maxRmsd = 10.0;
+		minLen = 30;
 
 	}
 
-
-	public Short getGapExtend()
-	{
+	public Short getGapExtend() {
 		return gapExtend;
 	}
 
-
-
-	public void setGapExtend(Short gapExtend)
-	{
+	public void setGapExtend(Short gapExtend) {
 		this.gapExtend = gapExtend;
 	}
-
-
 
 	public Short getGapOpen() {
 		return gapOpen;
 	}
 
-
-
 	public void setGapOpen(Short gapOpen) {
 		this.gapOpen = gapOpen;
 	}
 
+	public double getMaxRmsd() {
+		return maxRmsd;
+	}
 
+	public void setMaxRmsd(Double maxRmsd) {
+		this.maxRmsd = maxRmsd;
+	}
 
+	public int getMinLen() {
+		return minLen;
+	}
+
+	public void setMinLen(Integer minLen) {
+		this.minLen = minLen;
+	}
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3Daligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3Daligner.java
@@ -71,8 +71,7 @@ public class SmithWaterman3Daligner extends AbstractStructureAlignment implement
 
 	/**
 	 *  version history:
-	 *  1.1 - Added more parameters to the command line, including maximum RMSD 
-	 *  		and minimum length
+	 *  1.1 - Added a maxRMSD and minLen parameters
 	 *  1.0 - Initial version
 	 */
 	private static final String version = "1.1";
@@ -147,7 +146,7 @@ public class SmithWaterman3Daligner extends AbstractStructureAlignment implement
 		afpChain = convert(ca1,ca2,pair, smithWaterman);
 		
 		// Perform an iterative dropping of the columns
-		while (afpChain.getAlnLength() > params.getMinLen()
+		while (afpChain.getOptLength() > params.getMinLen()
 				&& afpChain.getTotalRmsdOpt() > params.getMaxRmsd()) {
 			afpChain = AlignmentTools.deleteHighestDistanceColumn(afpChain, ca1, ca2);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3Daligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3Daligner.java
@@ -20,7 +20,6 @@
  */
 package org.biojava.nbio.structure.align.seq;
 
-
 import org.biojava.nbio.alignment.Alignments;
 import org.biojava.nbio.alignment.Alignments.PairwiseSequenceAlignerType;
 import org.biojava.nbio.alignment.SimpleGapPenalty;
@@ -41,6 +40,7 @@ import org.biojava.nbio.structure.align.ce.ConfigStrucAligParams;
 import org.biojava.nbio.structure.align.ce.UserArgumentProcessor;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.util.AFPAlignmentDisplay;
+import org.biojava.nbio.structure.align.util.AlignmentTools;
 import org.biojava.nbio.structure.align.util.ConfigurationException;
 import org.biojava.nbio.core.exceptions.CompoundNotFoundException;
 import org.biojava.nbio.core.sequence.ProteinSequence;
@@ -50,10 +50,17 @@ import org.biojava.nbio.core.sequence.template.Compound;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-/** provides a 3D superimposition based on the sequence alignment
- *
+/**
+ * Provides a 3D superimposition of two structures based on their sequence
+ * alignment.
+ * <p>
+ * This algorithm includes a final step to iteratively drop columns of the
+ * alignment until a maximum RMSD threshold of the superimposition, or the
+ * minimum alignment length theshold, are fulfilled, similar to what pymol align
+ * algorithm does.
+ * 
  * @author Andreas Prlic
+ * @author Aleix Lafita
  *
  */
 public class SmithWaterman3Daligner extends AbstractStructureAlignment implements StructureAlignment {
@@ -64,11 +71,12 @@ public class SmithWaterman3Daligner extends AbstractStructureAlignment implement
 
 	/**
 	 *  version history:
-	 *  1.1 - Added more parameters to the command line, including -maxOptRMSD
+	 *  1.1 - Added more parameters to the command line, including maximum RMSD 
+	 *  		and minimum length
 	 *  1.0 - Initial version
 	 */
 	private static final String version = "1.1";
-	SmithWaterman3DParameters params;
+	private SmithWaterman3DParameters params;
 
 	public static void main(String[] args) throws ConfigurationException {
 		//args = new String[]{"-pdb1","1cdg.A","-pdb2","1tim.A","-pdbFilePath","/tmp/","-show3d","-printFatCat"};
@@ -101,44 +109,48 @@ public class SmithWaterman3Daligner extends AbstractStructureAlignment implement
 		AFPChain afpChain = new AFPChain(algorithmName);
 
 
-			// covert input to sequences
-			String seq1 = StructureTools.convertAtomsToSeq(ca1);
-			String seq2 = StructureTools.convertAtomsToSeq(ca2);
+		// covert input to sequences
+		String seq1 = StructureTools.convertAtomsToSeq(ca1);
+		String seq2 = StructureTools.convertAtomsToSeq(ca2);
 
-			ProteinSequence s1 = null;
-			ProteinSequence s2 = null;
+		ProteinSequence s1 = null;
+		ProteinSequence s2 = null;
 
-			try {
-				s1 = new ProteinSequence(seq1);
-				s2 = new ProteinSequence(seq2);
-			} catch (CompoundNotFoundException e){
+		try {
+			s1 = new ProteinSequence(seq1);
+			s2 = new ProteinSequence(seq2);
+		} catch (CompoundNotFoundException e){
 
-				throw new StructureException(e.getMessage(),e);
-			}
+			throw new StructureException(e.getMessage(),e);
+		}
 
-			// default blosum62
-			SubstitutionMatrix<AminoAcidCompound> matrix = SubstitutionMatrixHelper.getBlosum65();
+		// default blosum62
+		SubstitutionMatrix<AminoAcidCompound> matrix = SubstitutionMatrixHelper.getBlosum65();
 
-			GapPenalty penalty = new SimpleGapPenalty();
+		GapPenalty penalty = new SimpleGapPenalty();
 
-			penalty.setOpenPenalty(params.getGapOpen());
-			penalty.setExtensionPenalty(params.getGapExtend());
+		penalty.setOpenPenalty(params.getGapOpen());
+		penalty.setExtensionPenalty(params.getGapExtend());
 
-			PairwiseSequenceAligner<ProteinSequence, AminoAcidCompound> smithWaterman =
-				Alignments.getPairwiseAligner(s1, s2, PairwiseSequenceAlignerType.LOCAL, penalty, matrix);
+		PairwiseSequenceAligner<ProteinSequence, AminoAcidCompound> smithWaterman =
+			Alignments.getPairwiseAligner(s1, s2, PairwiseSequenceAlignerType.LOCAL, penalty, matrix);
 
-			SequencePair<ProteinSequence, AminoAcidCompound> pair = smithWaterman.getPair();
+		SequencePair<ProteinSequence, AminoAcidCompound> pair = smithWaterman.getPair();
 
-			if (pair.getTarget().toString().isEmpty() || pair.getQuery().toString().isEmpty()) {
-				throw new StructureException("Empty alignment for sequences "+s1+" and "+s2);
-			}
+		if (pair.getTarget().toString().isEmpty() || pair.getQuery().toString().isEmpty()) {
+			throw new StructureException("Empty alignment for sequences "+s1+" and "+s2);
+		}
 
-			logger.debug("Smith-Waterman alignment is: "+pair.toString(100));
+		logger.debug("Smith-Waterman alignment is: "+pair.toString(100));
 
-			// convert to a 3D alignment...
-			afpChain = convert(ca1,ca2,pair, smithWaterman);
-
-
+		// convert to a 3D alignment...
+		afpChain = convert(ca1,ca2,pair, smithWaterman);
+		
+		// Perform an iterative dropping of the columns
+		while (afpChain.getAlnLength() > params.getMinLen()
+				&& afpChain.getTotalRmsdOpt() > params.getMaxRmsd()) {
+			afpChain = AlignmentTools.deleteHighestDistanceColumn(afpChain, ca1, ca2);
+		}
 
 		return afpChain;
 	}
@@ -332,7 +344,5 @@ public class SmithWaterman3Daligner extends AbstractStructureAlignment implement
 			throw new IllegalArgumentException("provided parameter object is not of type SmithWaterman3DParameters");
 		params = (SmithWaterman3DParameters)parameters;
 	}
-
-
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWatermanUserArgumentProcessor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWatermanUserArgumentProcessor.java
@@ -20,19 +20,19 @@
  */
 package org.biojava.nbio.structure.align.seq;
 
-
 import org.biojava.nbio.structure.align.StructureAlignment;
 import org.biojava.nbio.structure.align.ce.AbstractUserArgumentProcessor;
 import org.biojava.nbio.structure.align.ce.StartupParameters;
-
-
 
 public class SmithWatermanUserArgumentProcessor extends AbstractUserArgumentProcessor{
 
 
 	protected static class SmithWatermanStartupParams extends StartupParameters {
+		
 		private short gapOpen;
 		private short gapExtend;
+		private double maxRmsd;
+		private int minLen;
 
 		public SmithWatermanStartupParams() {
 			super();
@@ -54,12 +54,30 @@ public class SmithWatermanUserArgumentProcessor extends AbstractUserArgumentProc
 			this.gapExtend = gapExtend;
 		}
 
+		
+		public double getMaxRmsd() {
+			return maxRmsd;
+		}
+
+		public void setMaxRmsd(double maxRmsd) {
+			this.maxRmsd = maxRmsd;
+		}
+
+		public int getMinLen() {
+			return minLen;
+		}
+
+		public void setMinLen(int minLen) {
+			this.minLen = minLen;
+		}
+
 		@Override
 		public String toString() {
 			StringBuilder builder = new StringBuilder();
 			builder.append("SmithWatermanStartupParams [gapOpen=")
 			.append(gapOpen).append(", gapExtend=").append(gapExtend)
-			.append("]");
+			.append("]").append(", maxRmsd=").append(maxRmsd)
+			.append(", minLen=").append(minLen).append("]");
 			return builder.toString();
 		}
 	}
@@ -77,13 +95,15 @@ public class SmithWatermanUserArgumentProcessor extends AbstractUserArgumentProc
 		StructureAlignment alignment = getAlgorithm();
 
 		SmithWaterman3DParameters p = (SmithWaterman3DParameters) alignment.getParameters();
-		SmithWatermanStartupParams startup = (SmithWatermanStartupParams)params;
+		SmithWatermanStartupParams startup = (SmithWatermanStartupParams) params;
 
 		if ( p == null)
 			p = new SmithWaterman3DParameters();
 
 		p.setGapExtend(startup.getGapExtend());
 		p.setGapOpen(startup.getGapOpen());
+		p.setMaxRmsd(startup.getMaxRmsd());
+		p.setMinLen(startup.getMinLen());
 
 		return p;
 	}
@@ -100,7 +120,5 @@ public class SmithWatermanUserArgumentProcessor extends AbstractUserArgumentProc
 	protected StartupParameters getStartupParametersInstance() {
 		return new SmithWatermanStartupParams();
 	}
-
-
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
@@ -1425,11 +1425,16 @@ public class AlignmentTools {
 
 		for (int b = 0; b < optAln.length; b++) {
 			for (int p = 0; p < optAln[b][0].length; p++) {
+				Atom ca2clone = ca2[optAln[b][1][p]];
+				Calc.rotate(ca2clone, afpChain.getBlockRotationMatrix()[b]);
+				Calc.shift(ca2clone, afpChain.getBlockShiftVector()[b]);
+				
 				double distance = Calc.getDistance(ca1[optAln[b][0][p]],
-						ca2[optAln[b][1][p]]);
+						ca2clone);
 				if (distance > maxDistance) {
 					maxBlock = b;
 					maxPos = p;
+					maxDistance = distance;
 				}
 			}
 		}
@@ -1479,8 +1484,8 @@ public class AlignmentTools {
 			if (p == pos)
 				continue;
 
-			newPos0[position] = optAln[block][0][position];
-			newPos1[position] = optAln[block][1][position];
+			newPos0[position] = optAln[block][0][p];
+			newPos1[position] = optAln[block][1][p];
 
 			position++;
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
@@ -1462,7 +1462,7 @@ public class AlignmentTools {
 					"Block index requested (%d) is higher than the total number of AFPChain blocks (%d).",
 					block, afpChain.getBlockNum()));
 		}
-		if (afpChain.getBlockSize()[block] <= pos) {
+		if (afpChain.getOptAln()[block][0].length <= pos) {
 			throw new IndexOutOfBoundsException(String.format(
 					"Position index requested (%d) is higher than the total number of aligned position in the AFPChain block (%d).",
 					block, afpChain.getBlockSize()[block]));

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
@@ -1398,4 +1398,96 @@ public class AlignmentTools {
 		}
 		
 	}
+	
+	/**
+	 * Find the alignment position with the highest atomic distance between the
+	 * equivalent atomic positions of the arrays and remove it from the
+	 * alignment.
+	 * 
+	 * @param afpChain
+	 *            original alignment, will be modified
+	 * @param ca1
+	 *            atom array, will not be modified
+	 * @param ca2
+	 *            atom array, will not be modified
+	 * @return the original alignment, with the alignment position at the
+	 *         highest distance removed
+	 * @throws StructureException
+	 */
+	public static AFPChain deleteHighestDistanceColumn(AFPChain afpChain,
+			Atom[] ca1, Atom[] ca2) throws StructureException {
+
+		int[][][] optAln = afpChain.getOptAln();
+
+		int maxBlock = 0;
+		int maxPos = 0;
+		double maxDistance = Double.MIN_VALUE;
+
+		for (int b = 0; b < optAln.length; b++) {
+			for (int p = 0; p < optAln[b][0].length; p++) {
+				double distance = Calc.getDistance(ca1[optAln[b][0][p]],
+						ca2[optAln[b][1][p]]);
+				if (distance > maxDistance) {
+					maxBlock = b;
+					maxPos = p;
+				}
+			}
+		}
+
+		return deleteColumn(afpChain, ca1, ca2, maxBlock, maxPos);
+	}
+
+	/**
+	 * Delete an alignment position from the original alignment object.
+	 * 
+	 * @param afpChain
+	 *            original alignment, will be modified
+	 * @param ca1
+	 *            atom array, will not be modified
+	 * @param ca2
+	 *            atom array, will not be modified
+	 * @param block
+	 *            block of the alignment position
+	 * @param pos
+	 *            position index in the block
+	 * @return the original alignment, with the alignment position removed
+	 * @throws StructureException
+	 */
+	public static AFPChain deleteColumn(AFPChain afpChain, Atom[] ca1,
+			Atom[] ca2, int block, int pos) throws StructureException {
+
+		// Check validity of the inputs
+		if (afpChain.getBlockNum() <= block) {
+			throw new IndexOutOfBoundsException(String.format(
+					"Block index requested (%d) is higher than the total number of AFPChain blocks (%d).",
+					block, afpChain.getBlockNum()));
+		}
+		if (afpChain.getBlockSize()[block] <= pos) {
+			throw new IndexOutOfBoundsException(String.format(
+					"Position index requested (%d) is higher than the total number of aligned position in the AFPChain block (%d).",
+					block, afpChain.getBlockSize()[block]));
+		}
+		
+		int[][][] optAln = afpChain.getOptAln();
+
+		int[] newPos0 = new int[optAln[block][0].length - 1];
+		int[] newPos1 = new int[optAln[block][1].length - 1];
+
+		int position = 0;
+		for (int p = 0; p < optAln[block][0].length; p++) {
+
+			if (p == pos)
+				continue;
+
+			newPos0[position] = optAln[block][0][position];
+			newPos1[position] = optAln[block][1][position];
+
+			position++;
+		}
+
+		optAln[block][0] = newPos0;
+		optAln[block][1] = newPos1;
+
+		return AlignmentTools.replaceOptAln(optAln, afpChain, ca1, ca2);
+	}
 }


### PR DESCRIPTION
Implement the feature requested in #552. The sequence alignment from SmithWaterman is reduced until one of the two, minimum length or maximum RMSD, is fulfilled, in order to produce higher quality superposition outcomes.