### PR TITLE
Fix for issue 631

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -22,8 +22,6 @@
  */
 package org.biojava.nbio.structure.test;
 
-import junit.framework.TestCase;
-
 import org.biojava.nbio.structure.*;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.io.FileParsingParameters;
@@ -31,18 +29,21 @@ import org.biojava.nbio.structure.io.PDBFileParser;
 import org.biojava.nbio.structure.io.mmcif.ChemCompGroupFactory;
 import org.biojava.nbio.structure.io.mmcif.ChemCompProvider;
 import org.biojava.nbio.structure.io.mmcif.DownloadChemCompProvider;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 import static org.junit.Assume.assumeNoException;
+import static org.junit.Assert.*;
 
-public class StructureToolsTest extends TestCase {
+public class StructureToolsTest {
 
 	Structure structure, structure2, structure3, structure4;
 
-	@Override
-	protected void setUp() throws IOException
+	@Before
+	public void setUp() throws IOException
 	{
 		InputStream inStream = this.getClass().getResourceAsStream("/5pti.pdb");
 		assertNotNull(inStream);
@@ -86,12 +87,13 @@ public class StructureToolsTest extends TestCase {
 		inStream.close();
 	}
 
-
+	@Test
 	public void testGetCAAtoms(){
 		Atom[] cas = StructureTools.getRepresentativeAtomArray(structure);
 		assertEquals("did not find the expected number of Atoms (58), but got " + cas.length,58,cas.length);
 	}
 
+	@Test
 	public void testGetAtomsConsistency() throws IOException, StructureException{
 
 		//Save the existing ChemCompProvider
@@ -121,11 +123,13 @@ public class StructureToolsTest extends TestCase {
 		ChemCompGroupFactory.setChemCompProvider(provider);
 	}
 
+	@Test
 	public void testGetNrAtoms(){
 		int length = StructureTools.getNrAtoms(structure);
 		assertEquals("did not find the expected number of Atoms (1087), but got " + length,1087,length);
 	}
 
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testGetSubRanges() throws StructureException {
 		String range;
@@ -263,6 +267,7 @@ public class StructureToolsTest extends TestCase {
 		} catch(IllegalArgumentException ex) {} //expected
 	}
 
+	@Test
 	public void testRevisedConvention() throws IOException, StructureException{
 
 		AtomCache cache = new AtomCache();
@@ -348,6 +353,7 @@ public class StructureToolsTest extends TestCase {
 	 * Test some subranges that we used to have problems with
 	 * @throws StructureException
 	 */
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testGetSubRangesExtended() throws StructureException {
 		String range;
@@ -444,6 +450,7 @@ public class StructureToolsTest extends TestCase {
 	 * Test insertion codes
 	 * @throws StructureException
 	 */
+	@Test
 	@SuppressWarnings("deprecation")
 	public void testGetSubRangesInsertionCodes() throws StructureException {
 		String range;
@@ -501,6 +508,7 @@ public class StructureToolsTest extends TestCase {
 		//TODO
 	}
 
+	@Test
 	public void testCAmmCIF() throws StructureException {
 
 		//Save the existing ChemCompProvider
@@ -537,5 +545,31 @@ public class StructureToolsTest extends TestCase {
 
 		ChemCompGroupFactory.setChemCompProvider(provider);
 	}
+	
+	@Test
+	public void testGetRepresentativeAtomsProtein() throws StructureException, IOException {
+		Structure s = StructureIO.getStructure("1smt");
+		Chain c = s.getChain(0);
+		Atom[] atoms = StructureTools.getRepresentativeAtomArray(c);
+		assertEquals(98,atoms.length);
+		
+		Chain clonedChain = (Chain)c.clone();
+		atoms = StructureTools.getRepresentativeAtomArray(clonedChain); 
+		assertEquals(98,atoms.length);
+	}
 
+	@Test
+	public void testGetRepresentativeAtomsDna() throws StructureException, IOException {
+	
+		Structure s = StructureIO.getStructure("2pvi");
+		Chain c = s.getChainByPDB("C");
+		Atom[] atoms = StructureTools.getRepresentativeAtomArray(c); // chain C (1st nucleotide chain)
+		// actually it should be 13, but at the moment one of the nucleotides is not caught correctly because it's non-standard
+		assertEquals(12,atoms.length);
+		
+		Chain clonedChain = (Chain)c.clone();
+		atoms = StructureTools.getRepresentativeAtomArray(clonedChain); // chain C (1st nucleotide chain)
+		assertEquals(12,atoms.length);
+		
+	}
 }

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -549,7 +549,7 @@ public class StructureToolsTest {
 	@Test
 	public void testGetRepresentativeAtomsProtein() throws StructureException, IOException {
 		Structure s = StructureIO.getStructure("1smt");
-		Chain c = s.getChain(0);
+		Chain c = s.getChainByIndex(0);
 		Atom[] atoms = StructureTools.getRepresentativeAtomArray(c);
 		assertEquals(98,atoms.length);
 		
@@ -562,7 +562,7 @@ public class StructureToolsTest {
 	public void testGetRepresentativeAtomsDna() throws StructureException, IOException {
 	
 		Structure s = StructureIO.getStructure("2pvi");
-		Chain c = s.getChainByPDB("C");
+		Chain c = s.getPolyChainByPDB("C");
 		Atom[] atoms = StructureTools.getRepresentativeAtomArray(c); // chain C (1st nucleotide chain)
 		// actually it should be 13, but at the moment one of the nucleotides is not caught correctly because it's non-standard
 		assertEquals(12,atoms.length);

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/StructureToolsTest.java
@@ -558,6 +558,11 @@ public class StructureToolsTest {
 		assertEquals(98,atoms.length);
 	}
 
+	/**
+	 * See https://github.com/biojava/biojava/issues/631
+	 * @throws StructureException
+	 * @throws IOException
+	 */
 	@Test
 	public void testGetRepresentativeAtomsDna() throws StructureException, IOException {
 	

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Calc.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Calc.java
@@ -777,6 +777,10 @@ public class Calc {
 	 * @return an Atom representing the Centroid of the set of atoms
 	 */
 	public static final Atom getCentroid(Atom[] atomSet) {
+		
+		// if we don't catch this case, the centroid returned is (NaN,NaN,NaN), which can cause lots of problems down the line
+		if (atomSet.length==0) 
+			throw new IllegalArgumentException("Atom array has length 0, can't calculate centroid!");
 
 		double[] coords = new double[3];
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/NucleotideImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/NucleotideImpl.java
@@ -93,5 +93,36 @@ public class NucleotideImpl extends HetatomImpl implements Group, Serializable, 
 
 	}
 
-	// no need to implement clone here, it's already in super class
+	// note we need to implement a clone here, despite there's one in super class already,
+	// that's due to issue https://github.com/biojava/biojava/issues/631 - JD 2017-01-21
+	@Override
+	public Object clone() {
+
+		NucleotideImpl n = new NucleotideImpl();
+		n.setPDBFlag(has3D());
+		n.setResidueNumber(getResidueNumber());
+
+		n.setPDBName(getPDBName());
+
+		// copy the atoms
+		for (Atom atom1 : atoms) {
+			Atom atom = (Atom) atom1.clone();
+			n.addAtom(atom);
+			atom.setGroup(n);
+		}
+
+		// copying the alt loc groups if present, otherwise they stay null
+		if (getAltLocs()!=null && !getAltLocs().isEmpty()) {
+			for (Group altLocGroup:this.getAltLocs()) {
+				Group nAltLocGroup = (Group)altLocGroup.clone();
+				n.addAltLoc(nAltLocGroup);
+			}
+		}
+		
+		if (chemComp!=null)
+			n.setChemComp(chemComp);
+
+
+		return n;
+	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/asa/AsaCalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/asa/AsaCalculator.java
@@ -449,7 +449,7 @@ public class AsaCalculator {
 					else if (atomCode.equals("CG")) return TETRAHEDRAL_CARBON_VDW;
 
 				default:
-					logger.warn("Unexpected carbon atom "+atomCode+" for aminoacid "+aa+", assigning its standard vdw radius");
+					logger.info("Unexpected carbon atom "+atomCode+" for aminoacid "+aa+", assigning its standard vdw radius");
 					return Element.C.getVDWRadius();
 				}
 			}
@@ -457,12 +457,8 @@ public class AsaCalculator {
 			// not any of the expected atoms
 		} else {
 			// non standard aas, (e.g. MSE, LLP) will always have this problem,
-			// thus we log at info level for them, at warn for others
-			if (amino.getChemComp()!=null && amino.getChemComp().isStandard()) {
-				logger.warn("Unexpected atom "+atomCode+" for aminoacid "+aa+ " ("+amino.getPDBName()+"), assigning its standard vdw radius");
-			} else {
-				logger.info("Unexpected atom "+atomCode+" for aminoacid "+aa+ " ("+amino.getPDBName()+"), assigning its standard vdw radius");
-			}
+			logger.info("Unexpected atom "+atomCode+" for aminoacid "+aa+ " ("+amino.getPDBName()+"), assigning its standard vdw radius");
+			
 
 			return atom.getElement().getVDWRadius();
 		}
@@ -487,7 +483,7 @@ public class AsaCalculator {
 
 		if (atom.getElement()==Element.O) return OXIGEN_VDW;
 
-		logger.warn("Unexpected atom "+atom.getName()+" for nucleotide "+nuc.getPDBName()+", assigning its standard vdw radius");
+		logger.info("Unexpected atom "+atom.getName()+" for nucleotide "+nuc.getPDBName()+", assigning its standard vdw radius");
 		return atom.getElement().getVDWRadius();
 	}
 


### PR DESCRIPTION
This solves #631, and also adds  an important check to `Calc.getCentroid()`. Together with some minor logging changes. 

I've also implemented the same fix for the 4.2.x branch, I'll merge it when this is merged.