### PR TITLE
Catching early if the representative atom array is empty

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/Subunit.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/Subunit.java
@@ -57,7 +57,7 @@ public class Subunit {
 	 * Atoms were obtained.
 	 * 
 	 * @param repAtoms
-	 *            representative Atoms. It cannot be null
+	 *            representative Atoms. It cannot be null or empty
 	 * @param name
 	 *            String field that identifies the Subunit. It can be null
 	 * @param identifier
@@ -71,6 +71,9 @@ public class Subunit {
 		if (reprAtoms == null)
 			throw new IllegalArgumentException(
 					"Representative Atom Array of the Subunit is null");
+		if (reprAtoms.length==0)
+			throw new IllegalArgumentException(
+					"Representative Atom Array of the Subunit has 0 length");
 
 		this.reprAtoms = reprAtoms;
 		this.name = name;


### PR DESCRIPTION
A small improvement for error handling in quaternary symmetry detection. With this we catch early cases of empty arrays that produce many problems downstream.