### PR TITLE
Fix for large coordinates to avoid ',' grouping character in coordina…

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FileConvert.java
@@ -68,12 +68,14 @@ public class FileConvert {
 		d3.setMaximumIntegerDigits(4);
 		d3.setMinimumFractionDigits(3);
 		d3.setMaximumFractionDigits(3);
+		d3.setGroupingUsed(false);
 	}
 	public static DecimalFormat d2 = (DecimalFormat)NumberFormat.getInstance(Locale.US);
 	static {
 		d2.setMaximumIntegerDigits(3);
 		d2.setMinimumFractionDigits(2);
 		d2.setMaximumFractionDigits(2);
+		d2.setGroupingUsed(false);
 	}
 
 	private static final String newline = System.getProperty("line.separator");

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestWriteLargeCoordinatePDB.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestWriteLargeCoordinatePDB.java
@@ -1,0 +1,49 @@
+package org.biojava.nbio.structure.io;
+
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.align.util.AtomCache;
+import org.junit.Test;
+
+public class TestWriteLargeCoordinatePDB {
+	
+	// This test checks that 'grouping' characters such as commas are not
+	// incorrectly introduced into formatted PDB coordinate fields.
+	// See FileConvert.d3 formatter.
+	@Test
+	public void TestWrite5D9Q() throws IOException, StructureException {
+
+		AtomCache cache = new AtomCache();
+		cache.setUseMmCif(false);
+
+		FileParsingParameters params = new FileParsingParameters();
+		params.setHeaderOnly(false);
+		cache.setFileParsingParams(params);
+
+		StructureIO.setAtomCache(cache);
+
+		// Example structure with large coordinates in PDB file.
+		Structure sPDB = StructureIO.getStructure("5D9Q");
+		
+		// If 48 column for a ATOM/HETATM has a comma, fail.
+		for (Group g : sPDB.getChain("K").getAtomGroups()) {
+			for (Atom a : g.getAtoms()) {
+				if (a.toPDB().contains(",")) {
+					fail("Comma present in ATOM/HETATM record.");
+				}
+			}
+		}
+		
+		//try (PrintWriter p = new PrintWriter(new FileWriter(new File("/tmp/test.pdb")))) {
+		//	p.print(sPDB.toPDB());
+		//}
+	}
+	
+}


### PR DESCRIPTION
I found an issue with PDB:5D9Q, which has coordinates > 1000 for the ATOM/HETATM records.

When you write out the PDB using Structure.toPDB(), the ATOM and HETATM records will have a 'grouping' character of a comma introduced at the thousand's place in the number.  This will break the PDB format.  It is valid to have coordinates of this size and the PDB writer should be able to handle these larger coordinates.