### PR TITLE
Make secondary structure objects serializable

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/BetaBridge.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/BetaBridge.java
@@ -20,6 +20,8 @@
  */
 package org.biojava.nbio.structure.secstruc;
 
+import java.io.Serializable;
+
 /**
  * Container that represents a beta Bridge between two residues. It contains the
  * two partner indices and the type of the bridge. For consistency, partner1 is
@@ -28,8 +30,10 @@ package org.biojava.nbio.structure.secstruc;
  * @author Aleix Lafita
  *
  */
-public class BetaBridge {
+public class BetaBridge implements Serializable {
 
+	private static final long serialVersionUID = -5097435425455958487L;
+	
 	BridgeType type;
 	int partner1;
 	int partner2;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/HBond.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/HBond.java
@@ -18,6 +18,8 @@
  */
 package org.biojava.nbio.structure.secstruc;
 
+import java.io.Serializable;
+
 /**
  * Container that represents a hidrogen bond. It contains the energy of the bond
  * in cal/mol and the partner index.
@@ -26,8 +28,10 @@ package org.biojava.nbio.structure.secstruc;
  * @author Aleix Lafita
  *
  */
-public class HBond {
+public class HBond implements Serializable {
 
+	private static final long serialVersionUID = 8246764841329431337L;
+	
 	private double energy;
 	private int partner;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/Ladder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/Ladder.java
@@ -20,6 +20,8 @@
  */
 package org.biojava.nbio.structure.secstruc;
 
+import java.io.Serializable;
+
 /**
  * A Ladder is a set of one or more consecutive bridges of identical type. A
  * Bridge is a Ladder of length one.
@@ -28,8 +30,10 @@ package org.biojava.nbio.structure.secstruc;
  * @author Aleix Lafita
  *
  */
-public class Ladder {
+public class Ladder implements Serializable  {
 
+	private static final long serialVersionUID = -1658305503250364409L;
+	
 	int from; // start of the first strand
 	int to; // end of the first strand
 	int lfrom; // start of the second strand

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucElement.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucElement.java
@@ -20,6 +20,8 @@
  */
 package org.biojava.nbio.structure.secstruc;
 
+import java.io.Serializable;
+
 import org.biojava.nbio.structure.ResidueNumber;
 import org.biojava.nbio.structure.ResidueRangeAndLength;
 
@@ -31,8 +33,10 @@ import org.biojava.nbio.structure.ResidueRangeAndLength;
  * @since 4.1.1
  *
  */
-public class SecStrucElement {
+public class SecStrucElement implements Serializable  {
 
+	private static final long serialVersionUID = -8485685793171396131L;
+	
 	private SecStrucType type;
 	private ResidueRangeAndLength range;
 	private int index;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucInfo.java
@@ -20,6 +20,8 @@
  */
 package org.biojava.nbio.structure.secstruc;
 
+import java.io.Serializable;
+
 import org.biojava.nbio.structure.Group;
 
 /**
@@ -31,7 +33,9 @@ import org.biojava.nbio.structure.Group;
  * @since 4.1.1
  *
  */
-public class SecStrucInfo {
+public class SecStrucInfo implements Serializable {
+
+	private static final long serialVersionUID = 4516925175715607227L;
 
 	/** Secondary strucuture assigned by the PDB author */
 	public static final String PDB_AUTHOR_ASSIGNMENT = "PDB_AUTHOR_ASSIGNMENT";

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucState.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucState.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
  */
 public class SecStrucState extends SecStrucInfo {
 
+	private static final long serialVersionUID = -5549430890272724340L;
+
 	private static final Logger logger = LoggerFactory
 			.getLogger(SecStrucState.class);
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestStructureSerialization.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestStructureSerialization.java
@@ -32,7 +32,7 @@ import java.io.ObjectOutputStream;
 import static org.junit.Assert.*;
 
 /**
- * Test the serialization of BioJava structure objects.
+ * Test the serialization and deserialization of BioJava structure objects.
  * 
  * @author Aleix Lafita
  *
@@ -43,6 +43,7 @@ public class TestStructureSerialization {
 	public void testSerializeStructure() throws IOException, StructureException, ClassNotFoundException {
 
 		PDBFileReader reader = new PDBFileReader();
+		reader.getFileParsingParameters().setParseSecStruc(true);
 		Structure sin = reader.getStructure("src/test/resources/2gox.pdb");
 
 		// Serialize the structure object and keep it in memory
@@ -58,7 +59,7 @@ public class TestStructureSerialization {
 		Structure sout = (Structure) objectIn.readObject();
 		objectIn.close();
 		
-		// Test some properties of the structures
+		// Test properties of the structures before and after serialization
 		assertEquals(sin.nrModels(), sout.nrModels());
 		assertEquals(sin.getChains().size(), sout.getChains().size());
 		assertEquals(sin.getName(), sout.getName());

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestStructureSerialization.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestStructureSerialization.java
@@ -64,5 +64,8 @@ public class TestStructureSerialization {
 		assertEquals(sin.getChains().size(), sout.getChains().size());
 		assertEquals(sin.getName(), sout.getName());
 		
+		// Test equal string representations
+		assertEquals(sin.toString(), sout.toString());
+		
 	}
 }


### PR DESCRIPTION
This PR implements Serializable in the SecStruc objects that are stored in a Structure and adds the secondary structure to the serialized structure in the test.

The problem was reported by @lukeczapla in #673 and was missing from #676 