### PR TITLE
Fixes for quaternary symmetry code

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -87,12 +87,13 @@ public class TestQuatSymmetryDetectorExamples {
 		// D3 symmetry non pseudosymmetric
 		assertEquals("D3", symmetry.getSymmetry());
 		assertEquals("A6B6", symmetry.getStoichiometry());
+		assertFalse(symmetry.isPseudoStoichiometric());
+
 
 	}
 
 	/**
 	 * Hemoglobin has both symmetry and pseudosymmetry: 4HHB
-	 * TODO pseudosymmetry in hemoglobin fails
 	 * 
 	 * @throws StructureException
 	 * @throws IOException
@@ -121,6 +122,7 @@ public class TestQuatSymmetryDetectorExamples {
 		// D2 pseudo-symmetry
 		assertEquals("D2", symmetry.getSymmetry());
 		assertEquals("A4", symmetry.getStoichiometry());
+		assertTrue(symmetry.isPseudoStoichiometric());
 	}
 
 	/**

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -234,4 +234,27 @@ public class TestQuatSymmetryDetectorExamples {
 		assertEquals("A5", results.get(0).getStoichiometry());
 
 	}
+	
+	/**
+	 * A structure with very similar entities (clustering at 95% seq id): 4DZ8
+	 * @throws IOException
+	 * @throws StructureException
+	 */
+	@Test
+	public void testPseudoIdentity95() throws IOException, StructureException {
+		Structure pdb = StructureIO.getStructure("BIO:4DZ8:1");
+
+		SubunitClustererParameters cp = new SubunitClustererParameters();
+		cp.setClustererMethod(SubunitClustererMethod.IDENTITY);
+		QuatSymmetryParameters symmParams = new QuatSymmetryParameters();
+
+		QuatSymmetryResults symmetry = QuatSymmetryDetector.calcGlobalSymmetry(
+				pdb, symmParams, cp);
+
+		assertEquals("C2", symmetry.getSymmetry());
+		assertEquals("A2", symmetry.getStoichiometry());
+		assertFalse(symmetry.isPseudoStoichiometric());
+		assertEquals(SubunitClustererMethod.IDENTITY, symmetry.getSubunitClusters().get(0).getClustererMethod());
+		
+	}
 }

--- a/biojava-structure-gui/src/main/java/demo/DemoQuatSymmetryJmol.java
+++ b/biojava-structure-gui/src/main/java/demo/DemoQuatSymmetryJmol.java
@@ -94,7 +94,7 @@ public class DemoQuatSymmetryJmol {
 		String title = name + ": " + results.getStoichiometry()
 				+ ", " + results.getSymmetry();
 
-		if (results.isPseudosymmetric())
+		if (results.isPseudoStoichiometric())
 			title += ", pseudosymmetric";
 
 		if (results.isLocal())

--- a/biojava-structure/src/main/java/demo/DemoSymmetry.java
+++ b/biojava-structure/src/main/java/demo/DemoSymmetry.java
@@ -45,7 +45,7 @@ public class DemoSymmetry {
 		
 		
 		
-		System.out.println(globalResults.getSymmetry() + (globalResults.isPseudosymmetric()?"(pseudo)":""));
+		System.out.println(globalResults.getSymmetry() + (globalResults.isPseudoStoichiometric()?"(pseudo)":""));
 		
 		System.out.println("There are "+globalResults.getSubunitClusters().size()+" subunit clusters");
 		int i = 1;
@@ -68,7 +68,7 @@ public class DemoSymmetry {
 		
 		
 		
-		System.out.println(globalResults.getSymmetry() + (globalResults.isPseudosymmetric()?"(pseudo)":""));
+		System.out.println(globalResults.getSymmetry() + (globalResults.isPseudoStoichiometric()?"(pseudo)":""));
 		
 		System.out.println("There are "+globalResults.getSubunitClusters().size()+" subunit clusters");
 		i = 1;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
@@ -145,6 +145,29 @@ public class SubunitCluster {
 
 	/**
 	 * Merges the other SubunitCluster into this one if their representatives
+	 * sequences are more than 0.95 identical on 0.95 of coverage.
+	 * <p>
+	 * The sequence alignment is performed using Smith Waterman, default linear
+	 * {@link SimpleGapPenalty} and BLOSUM62 as scoring matrix.
+	 * 
+	 * @param other
+	 *            SubunitCluster
+	 * @return true if the SubunitClusters were merged, false otherwise
+	 * @throws CompoundNotFoundException
+	 */
+	public boolean mergeIdentity95(SubunitCluster other) throws CompoundNotFoundException {
+		boolean merged = mergeSequence(other, 0.95, 0.95,
+				PairwiseSequenceAlignerType.LOCAL, new SimpleGapPenalty(),
+				SubstitutionMatrixHelper.getBlosum62());
+		
+		if (merged) {
+			this.method = SubunitClustererMethod.IDENTITY;
+		}
+		return merged;
+	}
+
+	/**
+	 * Merges the other SubunitCluster into this one if their representatives
 	 * sequences are similar (higher sequence identity and coverage than the
 	 * thresholds).
 	 * <p>

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClusterUtils.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClusterUtils.java
@@ -56,7 +56,7 @@ public class SubunitClusterUtils {
 
 	/**
 	 * A pseudostoichiometric {@link SubunitCluster} was obtained using the
-	 * {@link SubunitClustererMethod#STRUCTURE} similarity.
+	 * {@link SubunitClustererMethod#STRUCTURE} or {@link SubunitClustererMethod#SEQUENCE} similarity.
 	 * 
 	 * @param clusters
 	 * @return true if any of the clusters is pseudostoichiometric, false
@@ -65,7 +65,8 @@ public class SubunitClusterUtils {
 	public static boolean isPseudoStoichiometric(List<SubunitCluster> clusters) {
 
 		for (SubunitCluster c : clusters) {
-			if (c.getClustererMethod() == SubunitClustererMethod.STRUCTURE)
+			if (c.getClustererMethod() == SubunitClustererMethod.STRUCTURE ||
+				c.getClustererMethod() == SubunitClustererMethod.SEQUENCE)
 				return true;
 		}
 		return false;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClusterer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClusterer.java
@@ -68,16 +68,22 @@ public class SubunitClusterer {
 		for (Subunit s : subunits)
 			clusters.add(new SubunitCluster(s));
 
-		// Now merge clusters by IDENTITY
+		// Now merge clusters by 95% IDENTITY
 		for (int c1 = 0; c1 < clusters.size(); c1++) {
 			for (int c2 = clusters.size() - 1; c2 > c1; c2--) {
-				if (clusters.get(c1).mergeIdentical(clusters.get(c2)))
-					clusters.remove(c2);
+				try {
+					if (clusters.get(c1).mergeIdentity95(clusters.get(c2)))
+						clusters.remove(c2);
+				} catch (CompoundNotFoundException e) {
+					logger.warn("Could not merge by Identity95. {}",
+							e.getMessage());
+				}
 			}
 		}
 
 		if (params.getClustererMethod() == SubunitClustererMethod.IDENTITY)
 			return clusters;
+		
 
 		// Now merge clusters by SEQUENCE similarity
 		for (int c1 = 0; c1 < clusters.size(); c1++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryDetector.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryDetector.java
@@ -282,10 +282,6 @@ public class QuatSymmetryDetector {
 
 		String symmetry = results.getSymmetry();
 
-		// asymmetric structures cannot be pseudosymmetric
-		if (symmetry.equals("C1"))
-			results.setPseudosymmetric(false);
-
 		// Check structures with Cn symmetry (n = 1, ...) for helical symmetry
 		if (symmetry.startsWith("C")) {
 			HelixSolver hc = new HelixSolver(subunits,

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryResults.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryResults.java
@@ -56,7 +56,6 @@ public class QuatSymmetryResults {
 	private SymmetryPerceptionMethod method;
 	private RotationGroup rotationGroup;
 	private HelixLayers helixLayers;
-	private boolean pseudosymmetric = false;
 
 	// TODO we should unify rotational and roto-translational results
 
@@ -210,26 +209,6 @@ public class QuatSymmetryResults {
 		this.local = local;
 	}
 
-	/**
-	 * A symmetry result is pseudosymmetric when using pseudostoichiometry
-	 * extended the symmetry over the
-	 * 
-	 * @return true is pseudosymmetric, false otherwise
-	 */
-	public boolean isPseudosymmetric() {
-		return pseudosymmetric;
-	}
-
-	/**
-	 * A symmetry result is pseudosymmetric when using pseudostoichiometry
-	 * extended the symmetry over the
-	 * 
-	 * @param pseudosymmetric true if pseudosymmetric, false otherwise
-	 */
-	public void setPseudosymmetric(boolean pseudosymmetric) {
-		this.pseudosymmetric = pseudosymmetric;
-	}
-	
 	public Structure getStructure() {
 		return structure;
 	}


### PR DESCRIPTION
As discussed in #708, this removes isPseudoSymmetric and keeps only isPseudoStoichiometric. Also slightly changes the implementation of isPseudoStoichiometric.