### PR TITLE
ignore chains that do not have representative atoms

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
@@ -72,8 +72,9 @@ public class SubunitExtractor {
 			// Only take protein chains
 			if (c.isProtein()) {
 				Atom[] ca = StructureTools.getRepresentativeAtomArray(c);
-				logger.debug("Chain " + c.getId() + "; CA Atoms: "
-						+ ca.length + "; SEQRES: " + c.getSeqResSequence());
+				logger.debug("Chain " + c.getId() + "; CA Atoms: " + ca.length + "; SEQRES: " + c.getSeqResSequence());
+				if (ca.length==0)
+					continue;
 				subunits.add(new Subunit(ca, c.getName(), null, structure));
 			}
 		}


### PR DESCRIPTION
There are structures like 5M32 or 4LKE with synthetic constructs that do not have CA atoms, e.g. 4LKE chain G. Symmetry calculation fails for these structures. 