### PR TITLE
Trimming zeroes in optimised alignment

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPOptimizer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPOptimizer.java
@@ -64,7 +64,6 @@ public class AFPOptimizer
 
 		if(optAln == null)      {
 			optAln     = new int[maxTra+1][2][minLen];
-			afpChain.setOptAln(optAln);
 			optLen     = new int[maxTra+1];
 			afpChain.setOptLen(optLen);
 			optRmsd    = new double[maxTra+1];
@@ -143,6 +142,17 @@ public class AFPOptimizer
 
 		long optEnd = System.currentTimeMillis();
 		if(debug)       System.out.println("complete AlignOpt " + (optEnd-optStart) +"\n");
+
+		if(optLength < minLen) {
+			int[][][] optAln_trim = new int[maxTra + 1][2][optLength];
+			for (i = 0; i < maxTra + 1; i ++) {
+				System.arraycopy(optAln[i][0], 0, optAln_trim[i][0], 0, optLength);
+				System.arraycopy(optAln[i][1], 0, optAln_trim[i][1], 0, optLength);
+			}
+			afpChain.setOptAln(optAln_trim);
+		} else {
+			afpChain.setOptAln(optAln);
+		}
 
 		afpChain.setBlockNum(blockNum);
 		afpChain.setOptLength(optLength);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/align/TestAlignmentConsistency.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/align/TestAlignmentConsistency.java
@@ -1,0 +1,61 @@
+package org.biojava.nbio.structure.align;
+
+import junit.framework.TestCase;
+import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureTools;
+import org.biojava.nbio.structure.align.ce.CeMain;
+import org.biojava.nbio.structure.align.fatcat.FatCatRigid;
+import org.biojava.nbio.structure.align.model.AFPChain;
+import org.biojava.nbio.structure.align.util.AtomCache;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestAlignmentConsistency extends TestCase {
+
+	// Check that indices of the aligned residues are unique
+	public void testDuplicateIndices() throws IOException, StructureException {
+		String[] algorithmIDs = {CeMain.algorithmName, FatCatRigid.algorithmName};
+
+		AtomCache cache = new AtomCache();
+
+		// 3j47 is a bunch of a-helices, so there are many valid ways to align chains
+		// structurally between each other.
+		List<Chain> chains = cache.getStructure("3j47").getChains();
+
+		for(String algorithmID:algorithmIDs) {
+			StructureAlignment algorithm = StructureAlignmentFactory.getAlgorithm(algorithmID);
+			System.out.println("Testing "+algorithmID);
+			for (int c1 = 0; c1<chains.size()-1;c1++) {
+				for (int c2=chains.size()-1;c2>c1;c2--) {
+					Atom[] ca1 = StructureTools.getAtomCAArray(chains.get(c1));
+					Atom[] ca2 = StructureTools.getAtomCAArray(chains.get(c2));
+
+					AFPChain afpChain_fc = algorithm.align(ca1, ca2);
+					assertEquals(1,afpChain_fc.getOptAln().length);
+
+					int[][] optAln = afpChain_fc.getOptAln()[0];
+					// two chains aligned
+					assertEquals(2,optAln.length);
+
+					//same number of aligned residues between the chains
+					assertEquals(optAln[0].length,optAln[1].length);
+
+					// no indices duplicated in the alignments
+					for (int[] optAlnSeq : optAln) {
+						long count_unique = Arrays.stream(optAlnSeq).distinct().count();
+						long count_all = optAlnSeq.length;
+						assertEquals(count_unique, count_all);
+					}
+
+				}
+			}
+
+		}
+
+	}
+
+}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/align/TestAlignmentConsistency.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/align/TestAlignmentConsistency.java
@@ -1,6 +1,5 @@
 package org.biojava.nbio.structure.align;
 
-import junit.framework.TestCase;
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.StructureException;
@@ -9,14 +8,17 @@ import org.biojava.nbio.structure.align.ce.CeMain;
 import org.biojava.nbio.structure.align.fatcat.FatCatRigid;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.util.AtomCache;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-public class TestAlignmentConsistency extends TestCase {
+public class TestAlignmentConsistency {
 
 	// Check that indices of the aligned residues are unique
+	@Test
 	public void testDuplicateIndices() throws IOException, StructureException {
 		String[] algorithmIDs = {CeMain.algorithmName, FatCatRigid.algorithmName};
 


### PR DESCRIPTION
If optimized alignment is shorter than the initial one, trailing zeros will remain.
As zero is a valid residue index, this may lead to broken logic when the alignment is processed further down the line, e.g., in subunit clustering for pseudo-symmetry. Sometimes it'll crash with large assemblies.

Not easy to write a reproducing example, as the alignment method is not customizable and is set to CE at the moment.  The smallest structure I found that would break a fatcat-based subunit clustering is 3J47 (without this fix). 