### PR TITLE
Inject NCS operators into SpaceGroup

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/xtal/TestCrystalBuilder.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/xtal/TestCrystalBuilder.java
@@ -114,6 +114,13 @@ public class TestCrystalBuilder {
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
 		assertEquals(12,interfaces.size());
+		// kill the cell info to simulate incorrect and/or missing
+		s1.getCrystallographicInfo().setCrystalCell(null);
+		cb = new CrystalBuilder(s1);
+		interfaces = cb.getUniqueInterfaces(5.5);
+		//same number of interfaces should be found
+		// from ncs operators
+		assertEquals(12,interfaces.size());
 	}
 
 	@Test

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/xtal/TestCrystalBuilder.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/xtal/TestCrystalBuilder.java
@@ -105,6 +105,30 @@ public class TestCrystalBuilder {
 	}
 
 	@Test
+	public void test1AUY() throws IOException, StructureException {
+		// a virus with NCS operators
+		AtomCache cache = new AtomCache();
+		StructureIO.setAtomCache(cache);
+		cache.setUseMmCif(true);
+		Structure s1 = StructureIO.getStructure("1AUY");
+		CrystalBuilder cb = new CrystalBuilder(s1);
+		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
+		assertTrue(interfaces.size()==12);
+	}
+
+	@Test
+	public void test1A37() throws IOException, StructureException {
+		// a smaller structure with NCS operators
+		AtomCache cache = new AtomCache();
+		StructureIO.setAtomCache(cache);
+		cache.setUseMmCif(true);
+		Structure s1 = StructureIO.getStructure("1A37");
+		CrystalBuilder cb = new CrystalBuilder(s1);
+		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
+		assertTrue(interfaces.size()==14);
+	}
+
+	@Test
 	public void test2H2Z() throws IOException, StructureException {
 
 		// a crystallographic structure C 1 2 1.

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/xtal/TestCrystalBuilder.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/xtal/TestCrystalBuilder.java
@@ -48,7 +48,7 @@ public class TestCrystalBuilder {
 
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()==0);
+		assertEquals(0,interfaces.size());
 
 	}
 
@@ -65,7 +65,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("1B8G");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()>1);
+		assertEquals(8,interfaces.size());
 
 
 	}
@@ -83,7 +83,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("2MFZ");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()==1);
+		assertEquals(1,interfaces.size());
 
 	}
 
@@ -100,7 +100,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("4MF8");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()>3);
+		assertEquals(17,interfaces.size());
 
 	}
 
@@ -113,7 +113,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("1AUY");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()==12);
+		assertEquals(12,interfaces.size());
 	}
 
 	@Test
@@ -125,7 +125,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("1A37");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()==14);
+		assertEquals(14,interfaces.size());
 	}
 
 	@Test
@@ -144,7 +144,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("2H2Z");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()>=3);
+		assertEquals(3,interfaces.size());
 
 	}
 	

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBCrystallographicInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBCrystallographicInfo.java
@@ -170,7 +170,7 @@ public class PDBCrystallographicInfo implements Serializable {
 	}
 
 	/**
-	 * Get the NCS operators.
+	 * Get the NCS operators in orthonormal basis by default.
 	 * Some PDB files contain NCS operators necessary to create the full AU.
 	 * Usually this happens for viral proteins.
 	 * See http://www.wwpdb.org/documentation/format33/sect8.html#MTRIXn .
@@ -180,7 +180,30 @@ public class PDBCrystallographicInfo implements Serializable {
 	 * @return the operators or null if no operators present
 	 */
 	public Matrix4d[] getNcsOperators() {
-		return ncsOperators;
+		return getNcsOperators(true);
+	}
+
+	/**
+	 * Get the NCS operators.
+	 * @param orthonormalBasis
+	 *        if true, return the NCS operators as they are recorded.
+	 *        If false, convert them to the crystal basis first.
+	 * @return the operators or null if no operators present
+	 */
+	public Matrix4d[] getNcsOperators(boolean orthonormalBasis) {
+		if(orthonormalBasis) {
+			return ncsOperators;
+		}
+
+		if(ncsOperators==null || ncsOperators.length == 0) {
+			return null;
+		}
+
+		Matrix4d[] ncsOperatorsCrystal = new Matrix4d[ncsOperators.length];
+		for(int i=0;i<ncsOperators.length;i++) {
+			ncsOperatorsCrystal[i] = cell.transfToCrystal(ncsOperators[i]);
+		}
+		return ncsOperatorsCrystal;
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBCrystallographicInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBCrystallographicInfo.java
@@ -169,6 +169,29 @@ public class PDBCrystallographicInfo implements Serializable {
 		return transfs;
 	}
 
+
+	/**
+	 * Gets all symmetry transformation operators corresponding to this structure's space group
+	 * (including the identity, at index 0) expressed in the crystal basis. Using PDB axes
+	 * convention (NCODE=1).
+	 * @return an array of size {@link SpaceGroup#getNumOperators()}
+	 */
+	public Matrix4d[] getTransformationsCrystal() {
+		Matrix4d[] transfs = new Matrix4d[this.getSpaceGroup().getNumOperators()];
+		for (int i=0;i<this.getSpaceGroup().getNumOperators();i++) {
+			transfs[i] = this.getSpaceGroup().getTransformation(i);
+		}
+		return transfs;
+	}
+
+	/**
+	 * @return true if the PDB structure file contains NCS operators,
+	 *         false otherwise
+	 */
+	public boolean hasNcsOperators() {
+		return ncsOperators!= null && ncsOperators.length>0;
+	}
+
 	/**
 	 * Get the NCS operators in orthonormal basis by default.
 	 * Some PDB files contain NCS operators necessary to create the full AU.
@@ -198,7 +221,9 @@ public class PDBCrystallographicInfo implements Serializable {
 		if(ncsOperators==null || ncsOperators.length == 0) {
 			return null;
 		}
-
+		if(cell==null) {
+			throw new IllegalArgumentException("Cannot transform to the crystal basis if there is no cell.");
+		}
 		Matrix4d[] ncsOperatorsCrystal = new Matrix4d[ncsOperators.length];
 		for(int i=0;i<ncsOperators.length;i++) {
 			ncsOperatorsCrystal[i] = cell.transfToCrystal(ncsOperators[i]);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -2018,8 +2018,10 @@ public class StructureTools {
 	/**
 	 * Expands the NCS operators in the given Structure adding new chains as needed.
 	 * The new chains are assigned ids of the form: original_chain_id+ncs_operator_index+"n"
+	 * @deprecated use {@link SpaceGroup#extendNCS()} instead.
 	 * @param structure
 	 */
+	@Deprecated
 	public static void expandNcsOps(Structure structure) {
 		PDBCrystallographicInfo xtalInfo = structure.getCrystallographicInfo();
 		if (xtalInfo ==null) return;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
@@ -110,14 +110,23 @@ public class CrystalBuilder {
 				logger.warn("Space group is non-standard, will only calculate asymmetric unit interfaces.");
 				this.isCrystallographic = false;
 
-			} else if (this.crystallographicInfo.getSpaceGroup()==null) { 			
+			} else if (this.crystallographicInfo.getSpaceGroup()==null) {
 				// just in case we still check for space group null (a user pdb file could potentially be crystallographic and have no space group)			
 				logger.warn("Space group is null, will only calculate asymmetric unit interfaces.");
 				this.isCrystallographic = false;
 			} else {
 				this.numOperatorsSg = this.crystallographicInfo.getSpaceGroup().getMultiplicity();
 			}
-			
+
+			Matrix4d[] ncsOperators = this.crystallographicInfo.getNcsOperators(false);
+
+			if (ncsOperators != null && ncsOperators.length > 0) {
+				SpaceGroup sg = new SpaceGroup(this.crystallographicInfo.getSpaceGroup());
+				sg.extendNCS(ncsOperators);
+				this.crystallographicInfo.setSpaceGroup(sg);
+				this.numOperatorsSg = this.crystallographicInfo.getSpaceGroup().getMultiplicity();
+			}
+
 			// we need to check crystal cell not null for the rare cases where the entry is crystallographic but
 			// the crystal cell is not given, e.g. 2i68, 2xkm, 4bpq
 			if (this.crystallographicInfo.getCrystalCell()==null) {
@@ -228,7 +237,7 @@ public class CrystalBuilder {
 
 		Matrix4d[] ops = null;
 		if (isCrystallographic) {
-			ops = structure.getCrystallographicInfo().getTransformationsOrthonormal();
+			ops = crystallographicInfo.getTransformationsOrthonormal();
 		} else {
 			ops = new Matrix4d[1];
 			ops[0] = new Matrix4d(IDENTITY);


### PR DESCRIPTION
NCS is currently handled by duplicating chains in StructureTools::expandNcsOps, which is not optimal for further analysis (e.g., interface duplications in CrystalBuilder).

My suggestion is to combine them with the SpaceGroup transformations. The benefit of this approach is that a unit cell traversal is consistent for a client code, whether we have NCS or not. The drawback is that a SpaceGroup object is not guaranteed to be a true crystallographic space group anymore.

I also added a couple of tests for structures with NCS operators into TestCrystalBuilder.