### PR TITLE
clustering methods reorganised

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/cluster/TestSubunitClustererExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/cluster/TestSubunitClustererExamples.java
@@ -83,7 +83,7 @@ public class TestSubunitClustererExamples {
 		assertEquals(clusters.get(1).getClustererMethod(),
 				SubunitClustererMethod.SEQUENCE);
 
-		params.setClustererMethod(SubunitClustererMethod.STRUCTURE);
+		params.setClustererMethod(SubunitClustererMethod.SEQUENCE_STRUCTURE);
 		params.setRMSDThreshold(3.0);
 
 		clusters = SubunitClusterer.cluster(s, params);
@@ -116,7 +116,7 @@ public class TestSubunitClustererExamples {
 		assertEquals(clusters.get(0).getClustererMethod(),
 				SubunitClustererMethod.SEQUENCE);
 
-		params.setClustererMethod(SubunitClustererMethod.STRUCTURE);
+		params.setClustererMethod(SubunitClustererMethod.SEQUENCE_STRUCTURE);
 		params.setStructureCoverageThreshold(0.8);
 		params.setInternalSymmetry(true);
 		params.setRMSDThreshold(3.0);

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -274,7 +274,7 @@ public class TestQuatSymmetryDetectorExamples {
 
 		// Internal symmetry analysis, use structural clustering
 		SubunitClustererParameters cp = new SubunitClustererParameters();
-		cp.setClustererMethod(SubunitClustererMethod.STRUCTURE);
+		cp.setClustererMethod(SubunitClustererMethod.SEQUENCE_STRUCTURE);
 		cp.setInternalSymmetry(true);
 		cp.setStructureCoverageThreshold(0.75); // Lower coverage for internal symm
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClusterer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClusterer.java
@@ -68,61 +68,62 @@ public class SubunitClusterer {
 		for (Subunit s : subunits)
 			clusters.add(new SubunitCluster(s));
 
-		// Now merge clusters by SEQUENCE
-		for (int c1 = 0; c1 < clusters.size(); c1++) {
-			for (int c2 = clusters.size() - 1; c2 > c1; c2--) {
-				try {
-					if (clusters.get(c1).mergeSequence(clusters.get(c2),params)) {
-						clusters.remove(c2);
-					}
+		if (params.getClustererMethod() == SubunitClustererMethod.SEQUENCE ||
+				params.getClustererMethod() == SubunitClustererMethod.SEQUENCE_STRUCTURE) {
+			// Now merge clusters by SEQUENCE
+			for (int c1 = 0; c1 < clusters.size(); c1++) {
+				for (int c2 = clusters.size() - 1; c2 > c1; c2--) {
+					try {
+						if (clusters.get(c1).mergeSequence(clusters.get(c2), params)) {
+							clusters.remove(c2);
+						}
 
-				} catch (CompoundNotFoundException e) {
-					logger.warn("Could not merge by Sequence. {}",
-							e.getMessage());
-				}
-			}
-		}
-		if (params.getClustererMethod() == SubunitClustererMethod.SEQUENCE) {
-			return SubunitClusterUtils.orderByStoichiometry(clusters);
-		}
-
-		// Now merge clusters by STRUCTURE
-		for (int c1 = 0; c1 < clusters.size(); c1++) {
-			for (int c2 = clusters.size() - 1; c2 > c1; c2--) {
-				try {
-					if (clusters.get(c1).mergeStructure(clusters.get(c2),params)) {
-						clusters.remove(c2);
+					} catch (CompoundNotFoundException e) {
+						logger.warn("Could not merge by Sequence. {}",
+								e.getMessage());
 					}
-				} catch (StructureException e) {
-					logger.warn("Could not merge by Structure. {}", e.getMessage());
 				}
 			}
 		}
 
-		if (!params.isInternalSymmetry()) {
-			return SubunitClusterUtils.orderByStoichiometry(clusters);
-		}
-
-		// Now divide clusters by their INTERNAL SYMMETRY
-		for (int c = 0; c < clusters.size(); c++) {
-			try {
-				clusters.get(c).divideInternally(params);
-			} catch (StructureException e) {
-				logger.warn("Error analyzing internal symmetry. {}",
-						e.getMessage());
+		if (params.getClustererMethod() == SubunitClustererMethod.STRUCTURE ||
+				params.getClustererMethod() == SubunitClustererMethod.SEQUENCE_STRUCTURE) {
+			// Now merge clusters by STRUCTURE
+			for (int c1 = 0; c1 < clusters.size(); c1++) {
+				for (int c2 = clusters.size() - 1; c2 > c1; c2--) {
+					try {
+						if (clusters.get(c1).mergeStructure(clusters.get(c2), params)) {
+							clusters.remove(c2);
+						}
+					} catch (StructureException e) {
+						logger.warn("Could not merge by Structure. {}", e.getMessage());
+					}
+				}
 			}
 		}
 
-		// After internal symmetry merge again by structural similarity
-		// Use case: C8 propeller with 3 chains with 3+3+2 repeats each
-		for (int c1 = 0; c1 < clusters.size(); c1++) {
-			for (int c2 = clusters.size() - 1; c2 > c1; c2--) {
+		if (params.isInternalSymmetry()) {
+			// Now divide clusters by their INTERNAL SYMMETRY
+			for (int c = 0; c < clusters.size(); c++) {
 				try {
-					if (clusters.get(c1).mergeStructure(clusters.get(c2),params))
-						clusters.remove(c2);
+					clusters.get(c).divideInternally(params);
 				} catch (StructureException e) {
-					logger.warn("Could not merge by Structure. {}",
+					logger.warn("Error analyzing internal symmetry. {}",
 							e.getMessage());
+				}
+			}
+
+			// After internal symmetry merge again by structural similarity
+			// Use case: C8 propeller with 3 chains with 3+3+2 repeats each
+			for (int c1 = 0; c1 < clusters.size(); c1++) {
+				for (int c2 = clusters.size() - 1; c2 > c1; c2--) {
+					try {
+						if (clusters.get(c1).mergeStructure(clusters.get(c2), params))
+							clusters.remove(c2);
+					} catch (StructureException e) {
+						logger.warn("Could not merge by Structure. {}",
+								e.getMessage());
+					}
 				}
 			}
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClustererMethod.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClustererMethod.java
@@ -24,13 +24,21 @@ public enum SubunitClustererMethod {
 	 * coordinates of its Atom representatives of the {@link Subunit} to
 	 * calculate sequence and structure alignments.
 	 * <p>
+	 * Two {@link Subunit} with sufficient structural similarity and coverage
+	 * are clustered together.
+	 */
+	STRUCTURE,
+	/**
+	 * The SEQUENCE_STRUCTURE clustering method uses the residue sequence and the
+	 * coordinates of its Atom representatives of the {@link Subunit} to
+	 * calculate sequence and structure alignments.
+	 * <p>
 	 * Two {@link Subunit} with sufficient sequence identity and coverage are
 	 * clustered together. Additionally, two {@link Subunit} with sufficient
 	 * structural similarity and coverage are clustered together. If the
 	 * sequence and structure clustering differ, the cluster contains
 	 * pseudosymmetry (by definition).
 	 */
-	STRUCTURE
-
+	SEQUENCE_STRUCTURE
 }
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClustererParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClustererParameters.java
@@ -49,7 +49,7 @@ public class SubunitClustererParameters implements Serializable {
 	private double structureCoverageThreshold = 0.75;
 	private double tmThreshold = 0.5;
 
-	private SubunitClustererMethod clustererMethod = SubunitClustererMethod.STRUCTURE;
+	private SubunitClustererMethod clustererMethod = SubunitClustererMethod.SEQUENCE_STRUCTURE;
 
 	private String superpositionAlgorithm = CeMain.algorithmName;
 	private boolean optimizeAlignment = true;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
@@ -755,7 +755,6 @@ public class SymmetryTools {
 		cp.setClustererMethod(SubunitClustererMethod.STRUCTURE);
 		cp.setRMSDThreshold(10.0);
 		cp.setStructureCoverageThreshold(0.0);
-		cp.setSequenceIdentityThreshold(1.1); // avoid using sequence cluster
 
 		QuatSymmetryParameters sp = new QuatSymmetryParameters();
 


### PR DESCRIPTION
Behaviour of SubunitClustererMethod.STRUCTURE can be confusing, as it always attempts clustering by sequence first, which may be undesirable. There is a 'hacky' way to ignore sequence clustering results, like is done here https://github.com/biojava/biojava/blob/f80f8bd3cc28cb5805f16f8b39d910eb0dba84b2/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java#L758
but there is no way to not do it at all.
I suggest to split SubunitClustererMethod.STRUCTURE into two:
1) SubunitClustererMethod.STRUCTURE (cluster by structure only)
2) SubunitClustererMethod.SEQUENCE_STRUCTURE (new default, retains behaviour of current SubunitClustererMethod.STRUCTURE)
