### PR TITLE
NCS-aware CrystalBuilder object

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/xtal/TestCrystalBuilder.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/xtal/TestCrystalBuilder.java
@@ -28,7 +28,10 @@ import org.biojava.nbio.structure.contact.StructureInterfaceList;
 import org.biojava.nbio.structure.xtal.CrystalBuilder;
 import org.junit.Test;
 
+import javax.vecmath.Matrix4d;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -48,7 +51,7 @@ public class TestCrystalBuilder {
 
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()==0);
+		assertEquals(0,interfaces.size());
 
 	}
 
@@ -65,7 +68,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("1B8G");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()>1);
+		assertEquals(8,interfaces.size());
 
 
 	}
@@ -83,7 +86,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("2MFZ");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()==1);
+		assertEquals(1,interfaces.size());
 
 	}
 
@@ -100,8 +103,53 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("4MF8");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()>3);
+		assertEquals(17,interfaces.size());
 
+	}
+
+	@Test
+	public void test1AUY() throws IOException, StructureException {
+		// a virus with NCS operators
+		AtomCache cache = new AtomCache();
+		StructureIO.setAtomCache(cache);
+		cache.setUseMmCif(true);
+		Structure s1 = StructureIO.getStructure("1AUY");
+
+		Map<String,Matrix4d> chainNcsOps = new HashMap<>();
+		Map<String,String> chainOrigNames = new HashMap<>();
+
+		CrystalBuilder.expandNcsOps(s1,chainOrigNames,chainNcsOps);
+
+		CrystalBuilder cb = new CrystalBuilder(s1,chainOrigNames,chainNcsOps);
+		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
+		assertEquals(186,interfaces.size());
+		assertEquals(24,interfaces.getClustersNcs().size());
+
+		// kill the cell info to simulate incorrect and/or missing
+		s1.getCrystallographicInfo().setCrystalCell(null);
+		cb = new CrystalBuilder(s1,chainOrigNames,chainNcsOps);
+		interfaces = cb.getUniqueInterfaces(5.5);
+		//only interfaces within AU
+		assertEquals(132,interfaces.size());
+		assertEquals(12,interfaces.getClustersNcs().size());
+	}
+
+	@Test
+	public void test1A37() throws IOException, StructureException {
+		// a smaller structure with NCS operators
+		AtomCache cache = new AtomCache();
+		StructureIO.setAtomCache(cache);
+		cache.setUseMmCif(true);
+		Structure s1 = StructureIO.getStructure("1A37");
+
+		Map<String,Matrix4d> chainNcsOps = new HashMap<>();
+		Map<String,String> chainOrigNames = new HashMap<>();
+		CrystalBuilder.expandNcsOps(s1,chainOrigNames,chainNcsOps);
+
+		CrystalBuilder cb = new CrystalBuilder(s1,chainOrigNames,chainNcsOps);
+		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
+		assertEquals(17,interfaces.size());
+		assertEquals(14,interfaces.getClustersNcs().size());
 	}
 
 	@Test
@@ -120,7 +168,7 @@ public class TestCrystalBuilder {
 		Structure s1 = StructureIO.getStructure("2H2Z");
 		CrystalBuilder cb = new CrystalBuilder(s1);
 		StructureInterfaceList interfaces = cb.getUniqueInterfaces(5.5);
-		assertTrue(interfaces.size()>=3);
+		assertEquals(3,interfaces.size());
 
 	}
 	

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -2019,7 +2019,9 @@ public class StructureTools {
 	 * Expands the NCS operators in the given Structure adding new chains as needed.
 	 * The new chains are assigned ids of the form: original_chain_id+ncs_operator_index+"n"
 	 * @param structure
+	 * @deprecated use {@link org.biojava.nbio.structure.xtal.CrystalBuilder#expandNcsOps(Structure, Map, Map)} instead.
 	 */
+	@Deprecated
 	public static void expandNcsOps(Structure structure) {
 		PDBCrystallographicInfo xtalInfo = structure.getCrystallographicInfo();
 		if (xtalInfo ==null) return;
@@ -2051,7 +2053,7 @@ public class StructureTools {
 
 	/**
 	 * Auxiliary method to reset chain ids of residue numbers in a chain.
-	 * Used when cloning chains and resetting their ids: one needs to take care of 
+	 * Used when cloning chains and resetting their ids: one needs to take care of
 	 * resetting the ids within residue numbers too.
 	 * @param c
 	 * @param newChainName

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -2016,59 +2016,6 @@ public class StructureTools {
 	}
 
 	/**
-	 * Expands the NCS operators in the given Structure adding new chains as needed.
-	 * The new chains are assigned ids of the form: original_chain_id+ncs_operator_index+"n"
-	 * @param structure
-	 * @deprecated use {@link org.biojava.nbio.structure.xtal.CrystalBuilder#expandNcsOps(Structure, Map, Map)} instead.
-	 */
-	@Deprecated
-	public static void expandNcsOps(Structure structure) {
-		PDBCrystallographicInfo xtalInfo = structure.getCrystallographicInfo();
-		if (xtalInfo ==null) return;
-
-		if (xtalInfo.getNcsOperators()==null || xtalInfo.getNcsOperators().length==0) return;
-
-		List<Chain> chainsToAdd = new ArrayList<>();
-		int i = 0;
-		for (Matrix4d m:xtalInfo.getNcsOperators()) {
-			i++;
-
-			for (Chain c:structure.getChains()) {
-				Chain clonedChain = (Chain)c.clone();
-				String newChainId = c.getId()+i+"n";
-				String newChainName = c.getName()+i+"n";
-				clonedChain.setId(newChainId);
-				clonedChain.setName(newChainName);
-				setChainIdsInResidueNumbers(clonedChain, newChainName);
-				Calc.transform(clonedChain, m);
-				chainsToAdd.add(clonedChain);
-				c.getEntityInfo().addChain(clonedChain);
-			}
-		}
-
-		for (Chain c:chainsToAdd) {
-			structure.addChain(c);
-		}
-	}
-
-	/**
-	 * Auxiliary method to reset chain ids of residue numbers in a chain.
-	 * Used when cloning chains and resetting their ids: one needs to take care of
-	 * resetting the ids within residue numbers too.
-	 * @param c
-	 * @param newChainName
-	 */
-	private static void setChainIdsInResidueNumbers(Chain c, String newChainName) {
-		for (Group g:c.getAtomGroups()) {
-			g.setResidueNumber(newChainName, g.getResidueNumber().getSeqNum(), g.getResidueNumber().getInsCode());
-		}
-		for (Group g:c.getSeqResGroups()) {
-			if (g.getResidueNumber()==null) continue;
-			g.setResidueNumber(newChainName, g.getResidueNumber().getSeqNum(), g.getResidueNumber().getInsCode());
-		}
-	}
-
-	/**
 	 * Check to see if an Deuterated atom has a non deuterated brother in the group.
 	 * @param atom the input atom that is putatively deuterium
 	 * @param currentGroup the group the atom is in

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterfaceList.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterfaceList.java
@@ -195,6 +195,7 @@ public class StructureInterfaceList implements Serializable, Iterable<StructureI
 	 * 1. The chains forming the first interface are NCS-copies of the chains forming the second interface, in any order.
 	 * 2. Relative orientation of the chains is preserved, i.e. the contacts are identical.
 	 * @return list of {@link StructureInterfaceCluster} objects.
+	 * @since 5.0.0
 	 */
 	public List<StructureInterfaceCluster> getClustersNcs() {
 		return clustersNcs;
@@ -208,8 +209,8 @@ public class StructureInterfaceList implements Serializable, Iterable<StructureI
 	 * @param interfaceRef
 	 *          interfaceNew will be added to the cluster which contains interfaceRef.
 	 *          If interfaceRef is null, new cluster will be created for interfaceNew.
+	 * @since 5.0.0
 	 */
-
 	public void addNcsEquivalent(StructureInterface interfaceNew, StructureInterface interfaceRef) {
 
 		this.add(interfaceNew);
@@ -218,7 +219,6 @@ public class StructureInterfaceList implements Serializable, Iterable<StructureI
 		}
 
 		if (interfaceRef == null) {
-
 			StructureInterfaceCluster newCluster = new StructureInterfaceCluster();
 			newCluster.addMember(interfaceNew);
 			clustersNcs.add(newCluster);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
@@ -31,10 +31,7 @@ import org.slf4j.LoggerFactory;
 import javax.vecmath.Matrix4d;
 import javax.vecmath.Point3i;
 import javax.vecmath.Vector3d;
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-
+import java.util.*;
 
 
 /**
@@ -44,6 +41,7 @@ import java.util.List;
  * @author Jose Duarte
  *
  */
+
 public class CrystalBuilder {
 
 	// Default number of cell neighbors to try in interface search (in 3 directions of space).
@@ -80,64 +78,95 @@ public class CrystalBuilder {
 	private PDBCrystallographicInfo crystallographicInfo;
 	private int numPolyChainsAu;
 	private int numOperatorsSg;
+	private Map<String,Matrix4d> chainNcsOps = null;
+	private Map<String,String> chainOrigNames = null;
 
 	private static final Logger logger = LoggerFactory.getLogger(CrystalBuilder.class);
 
 	private int numCells;
 
-	private ArrayList<CrystalTransform> visited;
+	private ArrayList<CrystalTransform> visitedCrystalTransforms;
+	private Map<String,Map<Matrix4d,StructureInterface>> visitedNcsChainPairs = null;
 
-	private boolean isCrystallographic;
+	private boolean searchBeyondAU;
+	private Matrix4d[] ops;
 
-
+	/**
+	 * Special constructor for NCS-aware CrystalBuilder.
+	 * The output list of interfaces will be pre-clustered by NCS-equivalence.
+	 * Run {@link CrystalBuilder#expandNcsOps(Structure, Map, Map)} first to extend the AU
+	 * and get the equivalence information.
+	 * @param structure
+	 *          NCS-extended structure
+	 * @param chainOrigNames
+	 *          chain names mapped to the original chain names (pre-NCS extension)
+	 * @param chainNcsOps
+	 *          chain names mapped to the ncs operators that was used to generate them
+	 */
+	public CrystalBuilder(Structure structure, Map<String,String> chainOrigNames, Map<String,Matrix4d> chainNcsOps) {
+		this(structure);
+		this.chainOrigNames = chainOrigNames;
+		this.chainNcsOps = chainNcsOps;
+	}
 
 	public CrystalBuilder(Structure structure) {
 		this.structure = structure;
-
 		this.crystallographicInfo = structure.getCrystallographicInfo();
-
 		this.numPolyChainsAu = structure.getPolyChains().size();
-		this.numOperatorsSg = 1;
 
-
+		this.searchBeyondAU = false;
 		if (structure.isCrystallographic()) {
 
-			this.isCrystallographic = true;
+			this.searchBeyondAU = true;
 
 			// we need to check space group not null for the cases where the entry is crystallographic but
 			// the space group is not a standard one recognized by biojava, e.g. 1mnk (SG: 'I 21')
 			if (this.crystallographicInfo.isNonStandardSg()) {
 				logger.warn("Space group is non-standard, will only calculate asymmetric unit interfaces.");
-				this.isCrystallographic = false;
-
-			} else if (this.crystallographicInfo.getSpaceGroup()==null) { 			
-				// just in case we still check for space group null (a user pdb file could potentially be crystallographic and have no space group)			
-				logger.warn("Space group is null, will only calculate asymmetric unit interfaces.");
-				this.isCrystallographic = false;
-			} else {
-				this.numOperatorsSg = this.crystallographicInfo.getSpaceGroup().getMultiplicity();
+				this.searchBeyondAU = false;
 			}
-			
+
+			// just in case we still check for space group null (a user pdb file could potentially be crystallographic and have no space group)
+			if (this.crystallographicInfo.getSpaceGroup() == null) {
+				logger.warn("Space group is null, will only calculate asymmetric unit interfaces.");
+				this.searchBeyondAU = false;
+			}
+
 			// we need to check crystal cell not null for the rare cases where the entry is crystallographic but
 			// the crystal cell is not given, e.g. 2i68, 2xkm, 4bpq
-			if (this.crystallographicInfo.getCrystalCell()==null) {
+			if (this.crystallographicInfo.getCrystalCell() == null) {
 				logger.warn("Could not find a crystal cell definition, will only calculate asymmetric unit interfaces.");
-				this.isCrystallographic = false;
+				this.searchBeyondAU = false;
 			}
-			
+
 			// check for cases like 4hhb that are in a non-standard coordinate frame convention, see https://github.com/eppic-team/owl/issues/4
 			if (this.crystallographicInfo.isNonStandardCoordFrameConvention()) {
 				logger.warn("Non-standard coordinate frame convention, will only calculate asymmetric unit interfaces.");
-				this.isCrystallographic = false;
-				this.numOperatorsSg = 1; // we force here to 1 or otherwise it gets filled from sg above
+				this.searchBeyondAU = false;
 			}
+		}
 
+		if (this.searchBeyondAU) {
+			// explore the crystal
+			this.numOperatorsSg = this.crystallographicInfo.getSpaceGroup().getMultiplicity();
+			this.ops = this.crystallographicInfo.getTransformationsOrthonormal();
 		} else {
-			this.isCrystallographic = false;
+			// look for contacts within structure as given
+			this.numOperatorsSg = 1;
+			this.ops = new Matrix4d[1];
+			this.ops[0] = new Matrix4d(IDENTITY);
 		}
 
 		this.numCells = DEF_NUM_CELLS;
 
+	}
+
+
+	/**
+	 * @return true if this CrystalBuilder is NCS-aware.
+	 */
+	public boolean hasNcsOps() {
+		return chainNcsOps != null;
 	}
 
 	/**
@@ -149,10 +178,11 @@ public class CrystalBuilder {
 	}
 
 	private void initialiseVisited() {
-		visited = new ArrayList<CrystalTransform>();
+		visitedCrystalTransforms = new ArrayList<>();
+		if(this.hasNcsOps()) {
+			visitedNcsChainPairs = new HashMap<>();
+		}
 	}
-
-
 
 	/**
 	 * Returns the list of unique interfaces that the given Structure has upon
@@ -203,7 +233,6 @@ public class CrystalBuilder {
 
 		calcInterfacesCrystal(set, cutoff);
 
-
 		return set;
 	}
 
@@ -225,15 +254,6 @@ public class CrystalBuilder {
 		int skippedChainsNoOverlap = 0;
 		int skippedSelfEquivalent = 0;
 
-
-		Matrix4d[] ops = null;
-		if (isCrystallographic) {
-			ops = structure.getCrystallographicInfo().getTransformationsOrthonormal();
-		} else {
-			ops = new Matrix4d[1];
-			ops[0] = new Matrix4d(IDENTITY);
-		}
-
 		// The bounding boxes of all AUs of the unit cell
 		UnitCellBoundingBox bbGrid = new UnitCellBoundingBox(numOperatorsSg, numPolyChainsAu);;
 		// we calculate all the bounds of each of the asym units, those will then be reused and translated
@@ -241,7 +261,7 @@ public class CrystalBuilder {
 
 
 		// if not crystallographic there's no search to do in other cells, only chains within "AU" will be checked
-		if (!isCrystallographic) numCells = 0;
+		if (!searchBeyondAU) numCells = 0;
 
 		boolean verbose = logger.isDebugEnabled();
 
@@ -259,6 +279,7 @@ public class CrystalBuilder {
 			logger.debug("Total trials: "+(auTrials+trials));
 		}
 
+		List<Chain> polyChains = structure.getPolyChains();
 
 		for (int a=-numCells;a<=numCells;a++) {
 			for (int b=-numCells;b<=numCells;b++) {
@@ -266,9 +287,11 @@ public class CrystalBuilder {
 
 					Point3i trans = new Point3i(a,b,c);
 					Vector3d transOrth = new Vector3d(a,b,c);
-					if (a!=0 || b!=0 || c!=0)
+					if (a!=0 || b!=0 || c!=0) {
 						// we avoid doing the transformation for 0,0,0 (in case it's not crystallographic)
 						this.crystallographicInfo.getCrystalCell().transfToOrthonormal(transOrth);
+					}
+
 					UnitCellBoundingBox bbGridTrans = bbGrid.getTranslatedBbs(transOrth);
 
 					for (int n=0;n<numOperatorsSg;n++) {
@@ -283,11 +306,11 @@ public class CrystalBuilder {
 						// 2) we check if we didn't already see its equivalent symmetry operator partner
 						CrystalTransform tt = new CrystalTransform(this.crystallographicInfo.getSpaceGroup(), n);
 						tt.translate(trans);
-						if (isRedundant(tt)) {
+						if (isRedundantTransform(tt)) {
 							skippedRedundant++;
 							continue;
 						}
-						addVisited(tt);
+						addVisitedTransform(tt);
 
 
 						boolean selfEquivalent = false;
@@ -306,9 +329,8 @@ public class CrystalBuilder {
 						// Now that we know that boxes overlap and operator is not redundant, we have to go to the details
 						int contactsFound = 0;
 
-						List<Chain> polyChains = structure.getPolyChains();
-						
 						for (int j=0;j<numPolyChainsAu;j++) {
+
 							for (int i=0;i<numPolyChainsAu;i++) { // we only have to compare the original asymmetric unit to every full cell around
 
 								if(selfEquivalent && (j>i)) {
@@ -327,26 +349,31 @@ public class CrystalBuilder {
 									}
 									continue;
 								}
+
 								trialCount++;
 
 								// finally we've gone through all short-cuts and the 2 chains seem to be close enough:
 								// we do the calculation of contacts
-								Chain chainj = null;
 								Chain chaini = polyChains.get(i);
+								Chain chainj = polyChains.get(j);
 
-								if (n==0 && a==0 && b==0 && c==0) {
-									chainj = polyChains.get(j);
-								} else {
-									chainj = (Chain)polyChains.get(j).clone();
-									Matrix4d m = new Matrix4d(ops[n]);
-									translate(m, transOrth);
-									Calc.transform(chainj,m);
+								if (n!=0 || a!=0 || b!=0 || c!=0) {
+									Matrix4d mJCryst = new Matrix4d(ops[n]);
+									translate(mJCryst, transOrth);
+									chainj = (Chain)chainj.clone();
+									Calc.transform(chainj,mJCryst);
 								}
 
 								StructureInterface interf = calcContacts(chaini, chainj, cutoff, tt, builder);
+								if (interf == null) {
+									continue;
+								}
 
-								if (interf!=null) {
-									contactsFound++;
+								contactsFound++;
+								if(this.hasNcsOps()) {
+									StructureInterface interfNcsRef = findNcsRef(interf);
+									set.addNcsEquivalent(interf,interfNcsRef);
+								} else {
 									set.add(interf);
 								}
 							}
@@ -373,8 +400,93 @@ public class CrystalBuilder {
 		logger.debug("  skipped (not overlapping chains)    : "+skippedChainsNoOverlap);
 		logger.debug("  skipped (sym redundant op pairs)    : "+skippedRedundant);
 		logger.debug("  skipped (sym redundant self op)     : "+skippedSelfEquivalent);
-
 		logger.debug("Found "+set.size()+" interfaces.");
+	}
+
+
+	/**
+	 * Checks whether given interface is NCS-redundant, i.e., an identical interface between NCS copies of
+	 * these molecules has already been seen, and returns this (reference) interface.
+	 *
+	 * @param interf
+	 *          StructureInterface
+	 * @return  already seen interface that is NCS-equivalent to interf,
+	 *          null if such interface is not found.
+	 */
+	private StructureInterface findNcsRef(StructureInterface interf) {
+		if (!this.hasNcsOps()) {
+			return null;
+		}
+		String chainIName = interf.getMoleculeIds().getFirst();
+		String iOrigName = chainOrigNames.get(chainIName);
+
+		String chainJName = interf.getMoleculeIds().getSecond();
+		String jOrigName = chainOrigNames.get(chainJName);
+
+		Matrix4d mJCryst;
+		if(this.searchBeyondAU) {
+			mJCryst = interf.getTransforms().getSecond().getMatTransform();
+			mJCryst = crystallographicInfo.getCrystalCell().transfToOrthonormal(mJCryst);
+		} else {
+			mJCryst = IDENTITY;
+		}
+
+		// Let X1,...Xn be the original coords, before NCS transforms (M1...Mk)
+		// current chain i: M_i * X_i
+		// current chain j: Cn * M_j * X_j
+
+		// transformation to bring chain j near X_i: M_i^(-1) * Cn * M_j
+		// transformation to bring chain i near X_j: (Cn * M_j)^(-1) * M_i = (M_i^(-1) * Cn * M_j)^(-1)
+
+		if(chainNcsOps.get(chainIName) == null)
+			return null;
+		Matrix4d mChainIInv = new Matrix4d(chainNcsOps.get(chainIName));
+		mChainIInv.invert();
+
+		Matrix4d mJNcs = new Matrix4d(chainNcsOps.get(chainJName));
+
+		Matrix4d j2iNcsOrigin = new Matrix4d(mChainIInv);
+		j2iNcsOrigin.mul(mJCryst);
+		//overall transformation to bring current chainj from its NCS origin to i's
+		j2iNcsOrigin.mul(mJNcs);
+
+		//overall transformation to bring current chaini from its NCS origin to j's
+		Matrix4d i2jNcsOrigin = new Matrix4d(j2iNcsOrigin);
+		i2jNcsOrigin.invert();
+
+		String matchChainIdsIJ = iOrigName + jOrigName;
+		String matchChainIdsJI = jOrigName + iOrigName;
+
+		// same original chain names
+		Optional<Matrix4d> matchDirect =
+				visitedNcsChainPairs.computeIfAbsent(matchChainIdsIJ, k-> new HashMap<>()).entrySet().stream().
+					map(r->r.getKey()).
+					filter(r->r.epsilonEquals(j2iNcsOrigin,0.01)).
+					findFirst();
+
+		Matrix4d matchMatrix = matchDirect.orElse(null);
+		String matchChainIds = matchChainIdsIJ;
+
+		if(matchMatrix == null) {
+			// reversed original chain names with inverted transform
+			Optional<Matrix4d> matchInverse =
+					visitedNcsChainPairs.computeIfAbsent(matchChainIdsJI, k-> new HashMap<>()).entrySet().stream().
+					map(r->r.getKey()).
+					filter(r->r.epsilonEquals(i2jNcsOrigin,0.01)).
+					findFirst();
+			matchMatrix = matchInverse.orElse(null);
+			matchChainIds = matchChainIdsJI;
+		}
+
+		StructureInterface matchInterface = null;
+
+		if (matchMatrix == null) {
+			visitedNcsChainPairs.get(matchChainIdsIJ).put(j2iNcsOrigin,interf);
+		} else {
+			matchInterface = visitedNcsChainPairs.get(matchChainIds).get(matchMatrix);
+		}
+
+		return matchInterface;
 	}
 
 	private StructureInterface calcContacts(Chain chaini, Chain chainj, double cutoff, CrystalTransform tt, StringBuilder builder) {
@@ -399,8 +511,8 @@ public class CrystalBuilder {
 		}
 	}
 
-	private void addVisited(CrystalTransform tt) {
-		visited.add(tt);
+	private void addVisitedTransform(CrystalTransform tt) {
+		visitedCrystalTransforms.add(tt);
 	}
 
 	/**
@@ -410,9 +522,9 @@ public class CrystalBuilder {
 	 * @param tt
 	 * @return
 	 */
-	private boolean isRedundant(CrystalTransform tt) {
+	private boolean isRedundantTransform(CrystalTransform tt) {
 
-		Iterator<CrystalTransform> it = visited.iterator();
+		Iterator<CrystalTransform> it = visitedCrystalTransforms.iterator();
 		while (it.hasNext()) {
 			CrystalTransform v = it.next();
 
@@ -436,6 +548,79 @@ public class CrystalBuilder {
 		m.m03 = m.m03+translation.x;
 		m.m13 = m.m13+translation.y;
 		m.m23 = m.m23+translation.z;
+	}
+
+	/**
+	 * Apply the NCS operators in the given Structure adding new chains as needed.
+	 * All chains are (re)assigned ids of the form: original_chain_id+ncs_operator_index+"n".
+	 * @param structure
+	 *          the structure to expand
+	 * @param chainOrigNames
+	 *          new chain names mapped to the original chain names
+	 * @param chainNcsOps
+	 *          new chain names mapped to the ncs operators that was used to generate them
+	 */
+	public static void expandNcsOps(Structure structure, Map<String,String> chainOrigNames, Map<String,Matrix4d> chainNcsOps) {
+		PDBCrystallographicInfo xtalInfo = structure.getCrystallographicInfo();
+		if (xtalInfo ==null) return;
+
+		if (xtalInfo.getNcsOperators()==null || xtalInfo.getNcsOperators().length==0)
+			return;
+
+		List<Chain> chainsToAdd = new ArrayList<>();
+
+		Matrix4d identity = new Matrix4d();
+		identity.setIdentity();
+
+		Matrix4d[] ncsOps = xtalInfo.getNcsOperators();
+
+		for (Chain c:structure.getChains()) {
+			String cOrigId = c.getId();
+			String cOrigName = c.getName();
+
+			for (int iOperator = 0; iOperator < ncsOps.length; iOperator++) {
+				Matrix4d m = ncsOps[iOperator];
+
+				Chain clonedChain = (Chain)c.clone();
+				String newChainId = cOrigId+(iOperator+1)+"n";
+				String newChainName = cOrigName+(iOperator+1)+"n";
+				clonedChain.setId(newChainId);
+				clonedChain.setName(newChainName);
+
+				setChainIdsInResidueNumbers(clonedChain, newChainName);
+				Calc.transform(clonedChain, m);
+
+				chainsToAdd.add(clonedChain);
+				c.getEntityInfo().addChain(clonedChain);
+
+				chainOrigNames.put(newChainName,c.getId());
+				chainNcsOps.put(newChainName,m);
+			}
+			c.setName(cOrigName+0+"n");
+			c.setId(cOrigId+0+"n");
+
+			chainNcsOps.put(c.getName(),identity);
+			chainOrigNames.put(c.getName(),cOrigId);
+		}
+
+		chainsToAdd.forEach(structure::addChain);
+	}
+
+	/**
+	 * Auxiliary method to reset chain ids of residue numbers in a chain.
+	 * Used when cloning chains and resetting their ids: one needs to take care of
+	 * resetting the ids within residue numbers too.
+	 * @param c
+	 * @param newChainName
+	 */
+	private static void setChainIdsInResidueNumbers(Chain c, String newChainName) {
+		for (Group g:c.getAtomGroups()) {
+			g.setResidueNumber(newChainName, g.getResidueNumber().getSeqNum(), g.getResidueNumber().getInsCode());
+		}
+		for (Group g:c.getSeqResGroups()) {
+			if (g.getResidueNumber()==null) continue;
+			g.setResidueNumber(newChainName, g.getResidueNumber().getSeqNum(), g.getResidueNumber().getInsCode());
+		}
 	}
 
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
@@ -593,14 +593,12 @@ public class CrystalBuilder {
 				chainsToAdd.add(clonedChain);
 				c.getEntityInfo().addChain(clonedChain);
 
-				chainOrigNames.put(newChainName,c.getId());
+				chainOrigNames.put(newChainName,cOrigName);
 				chainNcsOps.put(newChainName,m);
 			}
-			c.setName(cOrigName+0+"n");
-			c.setId(cOrigId+0+"n");
 
-			chainNcsOps.put(c.getName(),identity);
-			chainOrigNames.put(c.getName(),cOrigId);
+			chainNcsOps.put(cOrigName,identity);
+			chainOrigNames.put(cOrigName,cOrigName);
 		}
 
 		chainsToAdd.forEach(structure::addChain);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
@@ -102,6 +102,7 @@ public class CrystalBuilder {
 	 *          chain names mapped to the original chain names (pre-NCS extension)
 	 * @param chainNcsOps
 	 *          chain names mapped to the ncs operators that was used to generate them
+	 * @since 5.0.0
 	 */
 	public CrystalBuilder(Structure structure, Map<String,String> chainOrigNames, Map<String,Matrix4d> chainNcsOps) {
 		this(structure);
@@ -164,6 +165,7 @@ public class CrystalBuilder {
 
 	/**
 	 * @return true if this CrystalBuilder is NCS-aware.
+	 * @since 5.0.0
 	 */
 	public boolean hasNcsOps() {
 		return chainNcsOps != null;
@@ -438,8 +440,6 @@ public class CrystalBuilder {
 		// transformation to bring chain j near X_i: M_i^(-1) * Cn * M_j
 		// transformation to bring chain i near X_j: (Cn * M_j)^(-1) * M_i = (M_i^(-1) * Cn * M_j)^(-1)
 
-		if(chainNcsOps.get(chainIName) == null)
-			return null;
 		Matrix4d mChainIInv = new Matrix4d(chainNcsOps.get(chainIName));
 		mChainIInv.invert();
 
@@ -559,6 +559,7 @@ public class CrystalBuilder {
 	 *          new chain names mapped to the original chain names
 	 * @param chainNcsOps
 	 *          new chain names mapped to the ncs operators that was used to generate them
+	 * @since 5.0.0
 	 */
 	public static void expandNcsOps(Structure structure, Map<String,String> chainOrigNames, Map<String,Matrix4d> chainNcsOps) {
 		PDBCrystallographicInfo xtalInfo = structure.getCrystallographicInfo();


### PR DESCRIPTION
Alternative solution to #728. 
Asymmetric unit extension is used with additional chains, as is currently done in biojava. The chain equivalence is tracked and passed on to the CrystalBuilder. As the result, it produces "clustered" list of interfaces based on NCS-equivalence (same original chains in the same relative position).

This change is not optimizing any calculations on its own (all redundant interfaces are still produced), but enables optimizations downstream by giving extra information. The client code must explicitly invoke this functionality and decide what to do with the chain/interface groups.