### PR TITLE
chainId to chainName for dbref records

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/DBRef.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/DBRef.java
@@ -45,7 +45,7 @@ public class DBRef implements PDBRecord {
 
 	private Structure parent;
 	private String idCode;
-	private String chainId;
+	private String chainName;
 	private int seqbegin;
 	private char insertBegin;
 	private int seqEnd;
@@ -131,7 +131,7 @@ public class DBRef implements PDBRecord {
 //        DBREF 3EH2 A    2   767     UNP   P53992  SC24C_HUMAN   329   1094
 //        DBREF  3ETA A  990  1295  UNP    P06213   INSR_HUMAN    1017   1322
 		formatter.format("DBREF  %4s %1s %4d%1s %4d%1s %-6s %-8s %-12s%6d%1c%6d%1c            ",
-				idCode, chainId,seqbegin,insertBegin,seqEnd,insertEnd,
+				idCode, chainName,seqbegin,insertBegin,seqEnd,insertEnd,
 				database,dbAccession,dbIdCode,
 				dbSeqBegin,idbnsBegin,dbSeqEnd,idbnsEnd
 				);
@@ -193,22 +193,22 @@ public class DBRef implements PDBRecord {
 		this.idCode = idCode;
 	}
 
-	/** The chain ID of the corresponding chain.
+	/** The name of the corresponding chain.
 	 *
-	 * @return chainName the ID of the corresponding chain.
+	 * @return chainName the name of the corresponding chain.
 	 */
-	public String getChainId() {
-		return chainId;
+	public String getChainName() {
+		return chainName;
 	}
 
 
-	/** The chain ID of the corresponding chain.
+	/** The name of the corresponding chain.
 	 *
-	 * @param chainId the ID of the corresponding chain
-	 * @see #getChainId()
+	 * @param chainName the name of the corresponding chain
+	 * @see #getChainName()
 	 */
-	public void setChainId(String chainId) {
-		this.chainId = chainId;
+	public void setChainName(String chainName) {
+		this.chainName = chainName;
 	}
 
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -2154,7 +2154,7 @@ public class PDBFileParser  {
 
 		DBRef dbref = new DBRef();
 		String idCode      = line.substring(7,11);
-		String chainId     = line.substring(12,13);
+		String chainName     = line.substring(12,13);
 		String seqBegin    = line.substring(14,18);
 		String insertBegin = line.substring(18,19);
 		String seqEnd      = line.substring(20,24);
@@ -2173,7 +2173,7 @@ public class PDBFileParser  {
 			dbinsEnd       = " ";
 
 		dbref.setIdCode(idCode);
-		dbref.setChainId(chainId);
+		dbref.setChainName(chainName);
 		dbref.setSeqBegin(intFromString(seqBegin));
 		dbref.setInsertBegin(insertBegin.charAt(0));
 		dbref.setSeqEnd(intFromString(seqEnd));

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifConsumer.java
@@ -1736,7 +1736,7 @@ public class SimpleMMcifConsumer implements MMcifConsumer {
 		r.setDbAccession(sref.getPdbx_db_accession());
 		r.setDbIdCode(sref.getPdbx_db_accession());
 
-		r.setChainId(sref.getPdbx_strand_id());
+		r.setChainName(sref.getPdbx_strand_id());
 		StructRef structRef = getStructRef(sref.getRef_id());
 		if (structRef == null){
 			logger.info("could not find StructRef " + sref.getRef_id() + " for StructRefSeq " + sref);


### PR DESCRIPTION
A small consistency fix related to #469 (data model refactoring).
Chain ID in the DBREF records is defined by pdbx_strand_id, which refers to author's version of the chain id, which is now called "chain name" in biojava.