### PR TITLE
Fix for CRYST1 parsing issue

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -1468,9 +1468,9 @@ public class PDBFileParser  {
 	 * </pre>
 	 */
 	private void pdb_CRYST1_Handler(String line) {
-		// for badly formatted files (e.g. phenix-produced ones), there's no z and the min length is 63
-		if (line.length() < 63) {
-			logger.warn("CRYST1 record has fewer than 63 columns: will ignore it");
+		// for badly formatted files (e.g. phenix-produced ones), there's no z and the min length is 58 (e.g. for SG 'P 1')
+		if (line.length() < 58) {
+			logger.warn("CRYST1 record has fewer than 58 columns: will ignore it");
 			return;
 		}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -413,11 +413,11 @@ public class TestNonDepositedFiles {
 	/**
 	 * Some PDB files coming from phenix or other software can have a CRYST1 line without z and not padded with white-spaces 
 	 * for the space group column.
-	 * @throws Exception
+	 * @throws IOException
 	 * @since 5.0.0
 	 */
 	@Test
-	public void testCryst1Parsing() throws Exception {
+	public void testCryst1Parsing() throws IOException {
 		String cryst1Line = "CRYST1   11.111   11.111  111.111  70.00  80.00  60.00 P 1";
 		Structure s;
 		PDBFileParser pdbPars = new PDBFileParser();

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -23,6 +23,7 @@ package org.biojava.nbio.structure.io;
 import static org.junit.Assert.*;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -407,6 +408,23 @@ public class TestNonDepositedFiles {
 		assertNotNull("Got null when looking for water-only chain with asym id E", cAsymId);
 		assertSame(c, cAsymId);
 		
+	}
+	
+	/**
+	 * Some PDB files coming from phenix or other software can have a CRYST1 line without z and not padded with white-spaces 
+	 * for the space group column.
+	 * @throws Exception
+	 * @since 5.0.0
+	 */
+	@Test
+	public void testCryst1Parsing() throws Exception {
+		String cryst1Line = "CRYST1   11.111   11.111  111.111  70.00  80.00  60.00 P 1";
+		Structure s;
+		PDBFileParser pdbPars = new PDBFileParser();
+		try(InputStream is = new ByteArrayInputStream(cryst1Line.getBytes()) ) {
+			s = pdbPars.parsePDBFile(is);
+		}
+		assertEquals("P 1", s.getPDBHeader().getCrystallographicInfo().getSpaceGroup().getShortSymbol());
 	}
 
 	


### PR DESCRIPTION
Fixing PDB parsing issue. In some PDB files, valid CRYST1 records can be 58 columns only