### PR TITLE
Removing jgrapht library warnings, UndirectedGraph -> Graph

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.vecmath.Matrix4d;
 import javax.vecmath.Point3d;
 
 import org.biojava.nbio.structure.align.util.AtomCache;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryParameters.java
@@ -166,7 +166,7 @@ public class QuatSymmetryParameters implements Serializable {
 	 *            symmetry search
 	 * @return true, if the number of combinations
 	 */
-	public boolean isLocalLimitsExceeded(Set combinations) {
+	public boolean isLocalLimitsExceeded(Set<?> combinations) {
 		if(combinations.size()>maximumLocalCombinations) {
 			return true;
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/Stoichiometry.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/Stoichiometry.java
@@ -63,6 +63,7 @@ public class Stoichiometry {
 	private List<SubunitCluster> orderedClusters = new ArrayList<>();
 
 	/** Prevent instantiation **/
+	@SuppressWarnings("unused")
 	private Stoichiometry() {
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymmIterative.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymmIterative.java
@@ -44,7 +44,7 @@ import org.biojava.nbio.structure.secstruc.SecStrucType;
 import org.biojava.nbio.structure.symmetry.internal.CESymmParameters.RefineMethod;
 import org.biojava.nbio.structure.symmetry.internal.CESymmParameters.SymmetryType;
 import org.biojava.nbio.structure.symmetry.utils.SymmetryTools;
-import org.jgrapht.UndirectedGraph;
+import org.jgrapht.Graph;
 import org.jgrapht.alg.ConnectivityInspector;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.SimpleGraph;
@@ -75,7 +75,7 @@ public class CeSymmIterative {
 			.getLogger(CeSymmIterative.class);
 
 	private CESymmParameters params;
-	private UndirectedGraph<Integer, DefaultEdge> alignGraph; // cumulative
+	private Graph<Integer, DefaultEdge> alignGraph; // cumulative
 	private List<CeSymmResult> levels; // symmetry at each level
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/GraphComponentOrderDetector.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/GraphComponentOrderDetector.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.symmetry.utils.SymmetryTools;
-import org.jgrapht.UndirectedGraph;
+import org.jgrapht.Graph;
 import org.jgrapht.alg.ConnectivityInspector;
 import org.jgrapht.graph.DefaultEdge;
 
@@ -50,7 +50,7 @@ public class GraphComponentOrderDetector implements OrderDetector {
 			throws RefinerFailedException {
 
 		// Construct the alignment graph with jgrapht
-		UndirectedGraph<Integer, DefaultEdge> graph = SymmetryTools
+		Graph<Integer, DefaultEdge> graph = SymmetryTools
 				.buildSymmetryGraph(selfAlignment);
 
 		// Find the maximally connected components of the graph

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/GraphComponentRefiner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/GraphComponentRefiner.java
@@ -34,7 +34,7 @@ import org.biojava.nbio.structure.align.model.AFPChain;
 import org.biojava.nbio.structure.align.multiple.MultipleAlignment;
 import org.biojava.nbio.structure.align.util.AlignmentTools;
 import org.biojava.nbio.structure.symmetry.utils.SymmetryTools;
-import org.jgrapht.UndirectedGraph;
+import org.jgrapht.Graph;
 import org.jgrapht.alg.ConnectivityInspector;
 import org.jgrapht.graph.DefaultEdge;
 
@@ -59,7 +59,7 @@ public class GraphComponentRefiner implements SymmetryRefiner {
 			throws StructureException, RefinerFailedException {
 
 		// Construct the alignment graph with jgrapht
-		UndirectedGraph<Integer, DefaultEdge> graph = SymmetryTools
+		Graph<Integer, DefaultEdge> graph = SymmetryTools
 				.buildSymmetryGraph(selfAlignment);
 
 		// Find the maximally connected components of the graph

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
@@ -65,7 +65,7 @@ import org.biojava.nbio.structure.symmetry.core.QuatSymmetryParameters;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryResults;
 import org.biojava.nbio.structure.symmetry.internal.CeSymmResult;
 import org.biojava.nbio.structure.symmetry.internal.SymmetryAxes;
-import org.jgrapht.UndirectedGraph;
+import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.SimpleGraph;
 import org.slf4j.Logger;
@@ -474,10 +474,10 @@ public class SymmetryTools {
 	 *
 	 * @return alignment Graph
 	 */
-	public static UndirectedGraph<Integer, DefaultEdge> buildSymmetryGraph(
+	public static Graph<Integer, DefaultEdge> buildSymmetryGraph(
 			AFPChain selfAlignment) {
 
-		UndirectedGraph<Integer, DefaultEdge> graph = new SimpleGraph<Integer, DefaultEdge>(
+		Graph<Integer, DefaultEdge> graph = new SimpleGraph<Integer, DefaultEdge>(
 				DefaultEdge.class);
 
 		for (int i = 0; i < selfAlignment.getOptAln().length; i++) {


### PR DESCRIPTION
Another cleanup for the 5 release. UndirectedGraph was deprecated in jgrapht. 

Also removed a couple of warnings elsewhere.
