### PR TITLE
Fix the GuiWrapper class

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/AbstractUserArgumentProcessor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/AbstractUserArgumentProcessor.java
@@ -578,8 +578,9 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 	 * @throws NoSuchMethodException If an error occurs when invoking jmol
 	 * @throws InvocationTargetException If an error occurs when invoking jmol
 	 * @throws IllegalAccessException If an error occurs when invoking jmol
+	 * @throws StructureException 
 	 */
-	private void checkWriteFile( AFPChain afpChain, Atom[] ca1, Atom[] ca2, boolean dbsearch) throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException
+	private void checkWriteFile( AFPChain afpChain, Atom[] ca1, Atom[] ca2, boolean dbsearch) throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, IllegalAccessException, StructureException
 			{
 		String output = null;
 		if ( params.isOutputPDB()){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/GuiWrapper.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/GuiWrapper.java
@@ -153,32 +153,6 @@ public class GuiWrapper {
 
 	}
 
-	/**
-	 *
-	 * @param afpChain
-	 * @param ca1
-	 * @param ca2
-	 * @return
-	 * @throws ClassNotFoundException If an error occurs when invoking jmol
-	 * @throws NoSuchMethodException If an error occurs when invoking jmol
-	 * @throws InvocationTargetException If an error occurs when invoking jmol
-	 * @throws IllegalAccessException If an error occurs when invoking jmol
-	 */
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public static Group[] prepareGroupsForDisplay(AFPChain afpChain, Atom[] ca1,
-			Atom[] ca2)
-					throws ClassNotFoundException, NoSuchMethodException,
-					InvocationTargetException, IllegalAccessException{
-		Class c = Class.forName(strucAlignmentDisplay);
-
-		Method display = c.getMethod("prepareGroupsForDisplay", new Class[]{AFPChain.class, Atom[].class,
-				Atom[].class});
-
-		Object groups = display.invoke(null, afpChain,ca1,ca2);
-
-		return (Group[]) groups;
-	}
-
 	@SuppressWarnings({ "rawtypes", "unchecked", "unused" })
 	public static Atom[] getAtomArray(Atom[] ca, List<Group> hetatoms, List<Group> nucs)
 			throws ClassNotFoundException, NoSuchMethodException,

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AFPAlignmentDisplay.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AFPAlignmentDisplay.java
@@ -387,17 +387,18 @@ public class AFPAlignmentDisplay
 	 * @throws NoSuchMethodException If an error occurs when invoking jmol
 	 * @throws InvocationTargetException If an error occurs when invoking jmol
 	 * @throws IllegalAccessException If an error occurs when invoking jmol
+	 * @throws StructureException 
 	 */
 	public static Structure createArtificalStructure(AFPChain afpChain, Atom[] ca1,
 													 Atom[] ca2) throws ClassNotFoundException, NoSuchMethodException,
-			InvocationTargetException, IllegalAccessException
+			InvocationTargetException, IllegalAccessException, StructureException
 	{
 
 		if ( afpChain.getNrEQR() < 1){
 			return GuiWrapper.getAlignedStructure(ca1, ca2);
 		}
 
-		Group[] twistedGroups = GuiWrapper.prepareGroupsForDisplay(afpChain,ca1, ca2);
+		Group[] twistedGroups = AlignmentTools.prepareGroupsForDisplay(afpChain,ca1, ca2);
 
 		List<Atom> twistedAs = new ArrayList<Atom>();
 


### PR DESCRIPTION
Fix for #594

The method `prepareGroupsForDisplay` had been moved to `AlignmentTools` in the `structure` module, but the references were not updated.