### PR TITLE
fix maven surefire plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
 					<version>2.5.2</version>
 				</plugin>
 				<plugin>
-					<groupId>org.apache.maven</groupId>
+					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.21.0</version>
 				</plugin>
@@ -356,7 +356,7 @@
 
 			<!-- give more memory for junit tests -->
 			<plugin>
-				<groupId>org.apache.maven</groupId>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<argLine>-Xmx1500M</argLine>


### PR DESCRIPTION
See http://maven.apache.org/surefire/maven-surefire-plugin/usage.html
Currently surefire version 2.17 is silently pulled for an inexplicable reason, which causes it to ignore parameters in the pom file.