### PR TITLE
Check for null when accessing insertion codes. This fixes #761.

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/BondMaker.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/BondMaker.java
@@ -362,9 +362,11 @@ public class BondMaker {
 			chainId2 = conn.getPtnr2_label_asym_id();
 
 			String insCode1 = "";
-			if (!conn.getPdbx_ptnr1_PDB_ins_code().equals("?")) insCode1 = conn.getPdbx_ptnr1_PDB_ins_code();
+			if (conn.getPdbx_ptnr1_PDB_ins_code() != null &&
+			        !conn.getPdbx_ptnr1_PDB_ins_code().equals("?")) insCode1 = conn.getPdbx_ptnr1_PDB_ins_code();
 			String insCode2 = "";
-			if (!conn.getPdbx_ptnr2_PDB_ins_code().equals("?")) insCode2 = conn.getPdbx_ptnr2_PDB_ins_code();
+			if (conn.getPdbx_ptnr2_PDB_ins_code() != null &&
+			        !conn.getPdbx_ptnr2_PDB_ins_code().equals("?")) insCode2 = conn.getPdbx_ptnr2_PDB_ins_code();
 
 			String seqId1 = conn.getPtnr1_auth_seq_id();
 			String seqId2 = conn.getPtnr2_auth_seq_id();


### PR DESCRIPTION
Check for missing insertion codes, for example, these are missing in mmcif files created by PDB-REDO.