### PR TITLE
Fix NonstandardProteinCompoundTest failure

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/UniprotProxySequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/UniprotProxySequenceReader.java
@@ -88,7 +88,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	private static final String TREMBLID_PATTERN = "[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2}";
 	public static final Pattern UP_AC_PATTERN = Pattern.compile("(" + SPID_PATTERN + "|" + TREMBLID_PATTERN + ")");
 
-	private static String uniprotbaseURL = "http://www.uniprot.org"; //"http://pir.uniprot.org";
+	private static String uniprotbaseURL = "https://www.uniprot.org"; //"http://pir.uniprot.org";
 	private static String uniprotDirectoryCache = null;
 	private String sequence;
 	private CompoundSet<C> compoundSet;
@@ -414,6 +414,61 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 		fw.write(sb.toString());
 		fw.close();
 	}
+	
+	/**
+	 * Open a URL connection.
+	 * 
+	 * Follows redirects.
+	 * @param url
+	 * @throws IOException 
+	 */
+	private static HttpURLConnection openURLConnection(URL url) throws IOException {
+		// This method should be moved to a utility class in BioJava 5.0
+		
+		final int timeout = 5000;
+		final String useragent = "BioJava";
+		
+		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+		conn.setRequestProperty("User-Agent", useragent);
+		conn.setInstanceFollowRedirects(true);
+		conn.setConnectTimeout(timeout);
+		conn.setReadTimeout(timeout);
+
+		int status = conn.getResponseCode();
+		while (status == HttpURLConnection.HTTP_MOVED_TEMP
+				|| status == HttpURLConnection.HTTP_MOVED_PERM
+				|| status == HttpURLConnection.HTTP_SEE_OTHER) {
+			// Redirect!
+			String newUrl = conn.getHeaderField("Location");
+
+			if(newUrl.equals(url.toString())) {
+				throw new IOException("Cyclic redirect detected at "+newUrl);
+			}
+			
+			// Preserve cookies
+			String cookies = conn.getHeaderField("Set-Cookie");
+
+			// open the new connection again
+			url = new URL(newUrl);
+			conn.disconnect();
+			conn = (HttpURLConnection) url.openConnection();
+			if(cookies != null) {
+				conn.setRequestProperty("Cookie", cookies);
+			}
+			conn.addRequestProperty("User-Agent", useragent);
+			conn.setInstanceFollowRedirects(true);
+			conn.setConnectTimeout(timeout);
+			conn.setReadTimeout(timeout);
+			conn.connect();
+			
+			status = conn.getResponseCode();
+			
+			logger.info("Redirecting from {} to {}", url, newUrl);
+		}
+		conn.connect();
+		
+		return conn;
+	}
 
 	private StringBuilder fetchUniprotXML(String uniprotURL)
 			throws IOException, CompoundNotFoundException {
@@ -423,11 +478,9 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 		int attempt = 5;
 		List<String> errorCodes = new ArrayList<String>();
 		while(attempt > 0) {
-			HttpURLConnection uniprotConnection = (HttpURLConnection) uniprot.openConnection();
-			uniprotConnection.setRequestProperty("User-Agent", "BioJava");
-			uniprotConnection.connect();
+			HttpURLConnection uniprotConnection = openURLConnection(uniprot);
 			int statusCode = uniprotConnection.getResponseCode();
-			if (statusCode == 200) {
+			if (statusCode == HttpURLConnection.HTTP_OK) {
 				BufferedReader in = new BufferedReader(
 						new InputStreamReader(
 						uniprotConnection.getInputStream()));


### PR DESCRIPTION
Uniprot now redirects to https. This fixes the URL, as well as adds code to do the redirect.

I couldn't find any existing code to follow redirects, but it would be useful to apply this to all downloads. The redirect code is a private static function in 4.2. In the 5.0 branch it would make sense to make it a utility method (e.g core/utils/FileDownloadUtils) and apply it everywhere we open HttpUrlConnections.