### PR TITLE
Travis config to cache pdb dirs across builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,15 @@ sudo: required
 cache:
   directories:
    - "$HOME/.m2"
+   - "$HOME/pdb_cache"
 before_install:
  - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
  - if [ ! -z "$GPG_OWNERTRUST"  ]; then echo $GPG_OWNERTRUST  | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
 after_success:
  - '[[ $TRAVIS_BRANCH == "master" ]] && { mvn deploy --settings travis-settings.xml -DskipTests=true -B ; };'
 env:
+  - PDB_DIR=$HOME/pdb_cache
+  - PDB_CACHE_DIR=$HOME/pdb_cache
   global:
   - secure: MkIoyU3GmlgDRhO0n1lDKvZ/k0myVY3IsFTRNUFjaBBpohLyOBrs5L8gYmfnHYHB/LvJsP6EWA6i0wCchy8hU/2pn66T12K1+WZHyqCe7RRz2kgcvVgMXTsHgvVyZ3dERcBfEDeZENzEYCYADaysT+A73ofWdJemOqfa7IFEb80=
   - secure: it5av1icAvJn/6UI0aWS23m+En0ij1hCiPKw1QIbDLCE3oJOE4nHR8qINcnontH4XUQYTkmekStDkXj0WVVgp08zArj9o018XBtadYY+15h2QZBBAIpYb3UdlJoQfkcAx8yCv59BMd/u6DhMtcKSTHptVWvsLAS7YGW5hR6ZNYA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
 after_success:
  - '[[ $TRAVIS_BRANCH == "master" ]] && { mvn deploy --settings travis-settings.xml -DskipTests=true -B ; };'
 env:
-  - PDB_DIR=$HOME/pdb_cache
-  - PDB_CACHE_DIR=$HOME/pdb_cache
   global:
   - secure: MkIoyU3GmlgDRhO0n1lDKvZ/k0myVY3IsFTRNUFjaBBpohLyOBrs5L8gYmfnHYHB/LvJsP6EWA6i0wCchy8hU/2pn66T12K1+WZHyqCe7RRz2kgcvVgMXTsHgvVyZ3dERcBfEDeZENzEYCYADaysT+A73ofWdJemOqfa7IFEb80=
   - secure: it5av1icAvJn/6UI0aWS23m+En0ij1hCiPKw1QIbDLCE3oJOE4nHR8qINcnontH4XUQYTkmekStDkXj0WVVgp08zArj9o018XBtadYY+15h2QZBBAIpYb3UdlJoQfkcAx8yCv59BMd/u6DhMtcKSTHptVWvsLAS7YGW5hR6ZNYA=
+  - PDB_DIR=$HOME/pdb_cache
+  - PDB_CACHE_DIR=$HOME/pdb_cache

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
@@ -688,7 +688,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 			name = DEFAULT_PDB_FILE_SERVER;
 			logger.debug("Using default PDB file server {}",name);
 		} else {
-			if (!name.startsWith("http://") && !name.startsWith("ftp://")) {
+			if (!name.startsWith("http://") && !name.startsWith("ftp://") && !name.startsWith("https://")) {
 				logger.warn("Server name {} read from system property {} does not have a leading protocol string. Adding http:// to it", name, PDB_FILE_SERVER_PROPERTY);
 				name = "http://"+name;
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsChainToUniprotMapping.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsChainToUniprotMapping.java
@@ -66,7 +66,7 @@ public class SiftsChainToUniprotMapping {
 
 	static {
 		try {
-			DEFAULT_URL = new URL("ftp://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_uniprot.tsv.gz");
+			DEFAULT_URL = new URL("http://ftp.ebi.ac.uk/pub/databases/msd/sifts/flatfiles/tsv/pdb_chain_uniprot.tsv.gz");
 		} catch (MalformedURLException e) {
 			throw new RuntimeException(e);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
@@ -41,7 +41,7 @@ public class SiftsMappingProvider {
 	private final static Logger logger = LoggerFactory.getLogger(SiftsMappingProvider.class);
 
 
-	private static final String EBI_SIFTS_FILE_LOCATION = "ftp://ftp.ebi.ac.uk/pub/databases/msd/sifts/xml/%s.xml.gz";
+	private static final String EBI_SIFTS_FILE_LOCATION = "http://ftp.ebi.ac.uk/pub/databases/msd/sifts/xml/%s.xml.gz";
 
 	private static String fileLoc = EBI_SIFTS_FILE_LOCATION;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/rcsb/RCSBUpdates.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/rcsb/RCSBUpdates.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public class RCSBUpdates {
 
 	// The URL for acquiring the data
-	public static final String baseURL = "ftp://ftp.rcsb.org/pub/pdb/data/status/latest/";
+	public static final String baseURL = "http://ftp.rcsb.org/pub/pdb/data/status/latest/";
 
 	/**
 	 *


### PR DESCRIPTION
Travis still fails at downloading external resources quite often (especially ftp resources). This change would cache some of the resources across builds. 

I haven't tested this yet. The build of this PR will do the test.

It is still possible to clear the cache when needed, see https://docs.travis-ci.com/user/caching/#Clearing-Caches