### PR TITLE
Biological assembly builder, transformation ordering fix

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestBioassemblies.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestBioassemblies.java
@@ -145,12 +145,11 @@ public class TestBioassemblies {
 		assertEquals(3, multiModelBioAssemblies.get(0).getPolyChains(0).size() + multiModelBioAssemblies.get(0).getPolyChains(1).size());
 		// 3 chains in flattened structure in bioassembly 1
 		assertEquals(3, flattenedBioAssemblies.get(0).getPolyChains().size());
-		
+
 		// 3 chains divided into 2 models in bioassembly 2
-		assertEquals(3, multiModelBioAssemblies.get(1).getPolyChains(0).size() + multiModelBioAssemblies.get(0).getPolyChains(1).size());
+		assertEquals(3, multiModelBioAssemblies.get(1).getPolyChains(0).size() + multiModelBioAssemblies.get(1).getPolyChains(1).size());
 		// 3 chains in flattened structure in bioassembly 2
 		assertEquals(3, flattenedBioAssemblies.get(1).getPolyChains().size());
-		
 
 		// chain ids and names don't contain underscores in multimodel
 		for (int modelIdx = 0; modelIdx<multiModelBioAssemblies.get(0).nrModels(); modelIdx++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
@@ -144,8 +144,9 @@ public class BiologicalAssemblyBuilder {
 				// set sort order only if the two ids are identical
 				if (t1.getId().equals(t2.getId())) {
 					 return chainIds.indexOf(t1.getChainId()) - chainIds.indexOf(t2.getChainId());
+				} else {
+					return t1.getId().compareTo(t2.getId());
 				}
-			    return 0;
 		    }
 		});
 	}


### PR DESCRIPTION
Fix for the issue #791, total order is now imposed. 