### PR TITLE
Assembly chain ids for cases with composed operators in assembly expansion

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestBioassemblies.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestBioassemblies.java
@@ -104,6 +104,41 @@ public class TestBioassemblies {
 		assertEquals(2, multiModelBioAssemblies.get(2).getPolyChains().size());
 		assertEquals(2, flattenedBioAssemblies.get(2).getPolyChains().size());
 
+		// all 3 flattened bioassemblies have operator id 1 in their new chain ids
+		assertEquals("1", flattenedBioAssemblies.get(0).getPolyChains().get(0).getId().split("_")[1]);
+		assertEquals("1", flattenedBioAssemblies.get(1).getPolyChains().get(0).getId().split("_")[1]);
+		assertEquals("1", flattenedBioAssemblies.get(2).getPolyChains().get(0).getId().split("_")[1]);
+
+		StructureIO.setAtomCache(prevAtomCache);
+
+	}
+
+
+	/**
+	 * A test for an entry with cartesian product in assembly operators
+	 * @throws StructureException
+	 * @throws IOException
+	 */
+	@Test
+	public void test1M4X() throws IOException, StructureException {
+
+		AtomCache prevAtomCache = StructureIO.getAtomCache();
+		AtomCache cache = new AtomCache();
+		cache.setUseMmCif(true);
+		StructureIO.setAtomCache(cache);
+
+		Structure flattenedBioAssembly5 = StructureIO.getBiologicalAssembly("1M4X" , 5);
+
+		// checking that we have 1 model only
+		assertEquals(1, flattenedBioAssembly5.nrModels());
+
+		// bioassembly 5 expands to 90 chains (3 chains x 5 operators x 6 operators), the expression is '(1-5)(61-88)'
+		assertEquals(90, flattenedBioAssembly5.getPolyChains().size());
+
+		// the operator ids are composed for this case, e.g. A_5x61
+		assertTrue(flattenedBioAssembly5.getPolyChains().get(0).getId().contains("x"));
+		assertEquals(2, flattenedBioAssembly5.getPolyChains().get(0).getId().split("_").length);
+
 		StructureIO.setAtomCache(prevAtomCache);
 
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
@@ -75,7 +75,7 @@ public class SubunitExtractor {
 				logger.debug("Chain " + c.getId() + "; CA Atoms: " + ca.length + "; SEQRES: " + c.getSeqResSequence());
 				if (ca.length==0)
 					continue;
-				subunits.add(new Subunit(ca, c.getName(), null, structure));
+				subunits.add(new Subunit(ca, c.getId(), null, structure));
 			}
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
@@ -48,8 +48,8 @@ public class SubunitExtractor {
 
 	/**
 	 * Extract the information of each protein Chain in a Structure and converts
-	 * them into a List of Subunit. The name of the Subunits is set to the
-	 * {@link Chain#getName()}.
+	 * them into a List of Subunit. The name of the Subunits is set to
+	 * {@link Chain#getId()}.
 	 * 
 	 * 
 	 * @param structure

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/PdbxStructOperList.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/model/PdbxStructOperList.java
@@ -20,15 +20,11 @@
  */
 package org.biojava.nbio.structure.io.mmcif.model;
 
-
-import org.biojava.nbio.structure.jama.Matrix;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import java.io.Serializable;
-import java.util.Arrays;
 
 /**
  * The bean for pdbx_struct_oper_list category
@@ -59,8 +55,7 @@ public class PdbxStructOperList implements Serializable{
 
 	@Override
 	public String toString() {
-		return "PdbxStructOperList [id=" + id + ", type=" + type + ", matrix="
-				+ matrix + ", vector=" + Arrays.toString(vector) + "]";
+		return "PdbxStructOperList [id=" + id + ", type=" + type + "]";
 	}
 
 
@@ -104,18 +99,12 @@ public class PdbxStructOperList implements Serializable{
 	
 	
 	// from here fields that are not in the cif category
-	
-	@IgnoreField
-	private Matrix matrix;
 
-	@IgnoreField
-	private double[] vector;
 
 	public PdbxStructOperList(){
-		matrix =  Matrix.identity(3,3);
-		vector = new double[3];
 
 	}
+
 	@XmlAttribute
 	public String getType() {
 		return type;
@@ -125,21 +114,6 @@ public class PdbxStructOperList implements Serializable{
 		this.type = type;
 	}
 
-	public Matrix getMatrix() {
-		return matrix;
-	}
-
-	public void setMatrix(Matrix matrix) {
-		this.matrix = matrix;
-	}
-	@XmlAttribute
-	public double[] getVector() {
-		return vector;
-	}
-
-	public void setVector(double[] vector) {
-		this.vector = vector;
-	}
 	@XmlAttribute
 	public String getId() {
 		return id;
@@ -150,32 +124,32 @@ public class PdbxStructOperList implements Serializable{
 	}
 
 	public void setMatrix11(String val){
-		matrix.set(0,0,Double.parseDouble(val));
+		this.matrix11 = val;
 	}
 	public void setMatrix21(String val){
-		matrix.set(1,0,Double.parseDouble(val));
+		this.matrix21 = val;
 	}
 	public void setMatrix31(String val){
-		matrix.set(2,0,Double.parseDouble(val));
+		this.matrix31 = val;
 	}
 
 	public void setMatrix12(String val){
-		matrix.set(0,1,Double.parseDouble(val));
+		this.matrix12 = val;
 	}
 	public void setMatrix22(String val){
-		matrix.set(1,1,Double.parseDouble(val));
+		this.matrix22 = val;
 	}
 	public void setMatrix32(String val){
-		matrix.set(2,1,Double.parseDouble(val));
+		this.matrix32 = val;
 	}
 	public void setMatrix13(String val){
-		matrix.set(0,2,Double.parseDouble(val));
+		this.matrix13 = val;
 	}
 	public void setMatrix23(String val){
-		matrix.set(1,2,Double.parseDouble(val));
+		this.matrix23 = val;
 	}
 	public void setMatrix33(String val){
-		matrix.set(2,2,Double.parseDouble(val));
+		this.matrix33 =val;
 	}
 	
 	public void setName(String name) {
@@ -186,19 +160,19 @@ public class PdbxStructOperList implements Serializable{
 		return vector1;
 	}
 	public void setVector1(String vector1) {
-		vector[0] = Double.parseDouble(vector1);
+		this.vector1 = vector1;
 	}
 	public String getVector2() {
 		return vector2;
 	}
 	public void setVector2(String vector2) {
-		vector[1] = Double.parseDouble(vector2);
+		this.vector2 = vector2;
 	}
 	public String getVector3() {
 		return vector3;
 	}
 	public void setVector3(String vector3) {
-		vector[2] = Double.parseDouble(vector3);
+		this.vector3 = vector3;
 	}
 	public String getName() {
 		return name;
@@ -210,39 +184,39 @@ public class PdbxStructOperList implements Serializable{
 		this.symmetry_operation = symmetry_operation;
 	}
 	@XmlElement
-	public double getMatrix11(){
-		return matrix.get(0,0);
+	public String getMatrix11(){
+		return matrix11;
 	}
 	@XmlElement
-	public double getMatrix21(){
-		return matrix.get(1,0);
+	public String getMatrix21(){
+		return matrix21;
 	}
 	@XmlElement
-	public double getMatrix31(){
-		return matrix.get(2,0);
+	public String getMatrix31(){
+		return matrix31;
 	}
 	@XmlElement
-	public double getMatrix12(){
-		return matrix.get(0,1);
+	public String getMatrix12(){
+		return matrix12;
 	}
 	@XmlElement
-	public double getMatrix22(){
-		return matrix.get(1,1);
+	public String getMatrix22(){
+		return matrix22;
 	}
 	@XmlElement
-	public double getMatrix32(){
-		return matrix.get(2,1);
+	public String getMatrix32(){
+		return matrix32;
 	}
 	@XmlElement
-	public double getMatrix13(){
-		return matrix.get(0,2);
+	public String getMatrix13(){
+		return matrix13;
 	}
 	@XmlElement
-	public double getMatrix23(){
-		return matrix.get(1,2);
+	public String getMatrix23(){
+		return matrix23;
 	}
 	@XmlElement
-	public double getMatrix33(){
-		return matrix.get(2,2);
+	public String getMatrix33(){
+		return matrix33;
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -423,7 +423,7 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 
 	/**
 	 * Get the type of group (0,1 or 2) depending on whether it is an amino aicd (1), nucleic acid (2) or ligand (0)
-	 * @param currentGroup
+	 * @param polymerType
 	 * @return The type of group. (0,1 or 2) depending on whether it is an amino aicd (1), nucleic acid (2) or ligand (0)
 	 */
 	private int getGroupTypIndicator(PolymerType polymerType) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/OperatorResolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/OperatorResolver.java
@@ -24,7 +24,8 @@ import java.util.Collections;
 import java.util.List;
 
 
-/** A class to resolve the operators for transformations
+/**
+ * A class to resolve the operators for transformations
  *
  * @author Peter Rose
  *


### PR DESCRIPTION
A solution to problem described in #801. 
* It assigns chain ids containing all operator ids, e.g. for chain id `A` where operators 5 and 61 have been applied, it assigns new chain id `A_5x61`
* A new test is added to check correct behaviour in cartesian product `_pdbx_struct_assembly_gen.oper_expression`  cases
* Some cleanup removing jama objects from `PdbxStructOperList` mmcif model bean
* For consistency, the `Subunit` objects used in symmetry detection now use asym_ids instead of author_ids.