### PR TITLE
Make biojava work with java 9, 10, 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
- - oraclejdk9
+ - oraclejdk8
 sudo: required
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
- - oraclejdk8
+ - oraclejdk9
 sudo: required
 cache:
   directories:

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/embl/EmblId.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/embl/EmblId.java
@@ -20,8 +20,6 @@
  */
 package org.biojava.nbio.core.sequence.io.embl;
 
-import jdk.nashorn.internal.ir.annotations.Immutable;
-
 /**
  * This class contains the processed data of embl file
  * Primary accession number
@@ -35,7 +33,6 @@ import jdk.nashorn.internal.ir.annotations.Immutable;
  * @author Noor Aldeen Al Mbaidin
  * @since 5.0.0
  */
-@Immutable
 public class EmblId {
 
 

--- a/biojava-protein-disorder/pom.xml
+++ b/biojava-protein-disorder/pom.xml
@@ -84,6 +84,10 @@
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 		</dependency>
+		<dependency>
+		    <groupId>javax.xml.bind</groupId>
+		    <artifactId>jaxb-api</artifactId>
+		</dependency>
 	</dependencies>
 
 	<properties>

--- a/biojava-structure/pom.xml
+++ b/biojava-structure/pom.xml
@@ -62,9 +62,23 @@
   			<version>1.1.0</version>
 		</dependency>
 
+		<!-- JAXb explicit dependency is needed since Java 9. See https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j
+		  Note versions are set in parent pom in dependency management section -->
 		<dependency>
 		    <groupId>javax.xml.bind</groupId>
 		    <artifactId>jaxb-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.sun.xml.bind</groupId>
+			<artifactId>jaxb-impl</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
 		</dependency>
 
 		<!-- logging dependencies (managed by parent pom, don't set versions or 

--- a/biojava-structure/pom.xml
+++ b/biojava-structure/pom.xml
@@ -62,6 +62,11 @@
   			<version>1.1.0</version>
 		</dependency>
 
+		<dependency>
+		    <groupId>javax.xml.bind</groupId>
+		    <artifactId>jaxb-api</artifactId>
+		</dependency>
+
 		<!-- logging dependencies (managed by parent pom, don't set versions or 
 			scopes here) -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,21 @@
 			    <artifactId>jaxb-api</artifactId>
 			    <version>2.3.0</version>
 			</dependency>
+			<dependency>
+				<groupId>com.sun.xml.bind</groupId>
+				<artifactId>jaxb-core</artifactId>
+				<version>2.3.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.sun.xml.bind</groupId>
+				<artifactId>jaxb-impl</artifactId>
+				<version>2.3.0</version>
+			</dependency>
+			<dependency>
+				<groupId>javax.activation</groupId>
+				<artifactId>activation</artifactId>
+				<version>1.1.1</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,10 +176,6 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
-					<!-- warning: before upgrading to a newer version of this plugin
-					      there are some config changes required.
-					      see https://github.com/biojava/biojava/issues/531
-					      -->
 					<version>3.1.0</version>
 				</plugin>
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-dependency-plugin</artifactId>
-					<version>3.0.2</version>
+					<version>3.1.1</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-jar-plugin</artifactId>
@@ -179,11 +179,11 @@
 					      there are some config changes required.
 					      see https://github.com/biojava/biojava/issues/531
 					      -->
-					<version>3.0.2</version>
+					<version>3.1.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-scm-plugin</artifactId>
-					<version>1.9.5</version>
+					<version>1.10.0</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-source-plugin</artifactId>
@@ -191,7 +191,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-failsafe-plugin</artifactId>
-					<version>2.21.0</version>
+					<version>2.22.0</version>
 				</plugin>
 				<plugin>
 					<groupId>net.sf</groupId>
@@ -201,7 +201,7 @@
 				<plugin>
 					<groupId>org.jvnet.jaxb2.maven2</groupId>
 					<artifactId>maven-jaxb2-plugin</artifactId>
-					<version>0.13.1</version>
+					<version>0.14.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -224,7 +224,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.0.1</version>
 					<configuration>
 					    <additionalJOptions>-Xdoclint:none</additionalJOptions>
 					    <!-- we need to allow script in comments or otherwise we can't use google analytics js in footer below - JD 2017-03-30 -->
@@ -242,7 +242,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.1.0</version>
+					<version>3.1.1</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-assembly-plugin</artifactId>
@@ -280,18 +280,18 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.17</version>
+					<version>3.0.0</version>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-resources-plugin</artifactId>
-					<version>3.0.2</version>
+					<version>3.1.0</version>
 				</plugin>
 
 				<plugin>
 					<artifactId>maven-enforcer-plugin</artifactId>
-					<version>3.0.0-M1</version>
+					<version>3.0.0-M2</version>
 					<executions>
 						<execution>
 							<id>enforce-java</id>
@@ -316,12 +316,12 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.21.0</version>
+					<version>2.22.0</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-site-plugin</artifactId>
-					<version>3.7</version>
+					<version>3.7.1</version>
 				</plugin>
 
 			</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,9 @@
 		</license>
 	</licenses>
 	<properties>
-		<jdk.version>9</jdk.version>
-		<maven.enforcer.jdk-version>9</maven.enforcer.jdk-version>
+		<!-- Notice: if using java 9 or 10 jres, it is possible to simply use here "8", "9" or "10". But if using java 8 jre, "8" is not an allowed value but only "1.8"-->
+		<jdk.version>1.8</jdk.version>
+		<maven.enforcer.jdk-version>1.8</maven.enforcer.jdk-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>
 		<!-- needed for failsafe plugin in integrationtest module - JD 2018-03-08 -->

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 		</license>
 	</licenses>
 	<properties>
-		<jdk.version>1.8</jdk.version>
-		<maven.enforcer.jdk-version>1.8</maven.enforcer.jdk-version>
+		<jdk.version>9</jdk.version>
+		<maven.enforcer.jdk-version>9</maven.enforcer.jdk-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>
 		<!-- needed for failsafe plugin in integrationtest module - JD 2018-03-08 -->
@@ -507,6 +507,11 @@
 				<artifactId>forester</artifactId>
 				<version>1.038</version>
 			</dependency>
+			<dependency>
+			    <groupId>javax.xml.bind</groupId>
+			    <artifactId>jaxb-api</artifactId>
+			    <version>2.3.0</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -518,7 +523,7 @@
 					<aggregate>true</aggregate>
 					<breakiterator>true</breakiterator>
 					<quiet>true</quiet>
-					<source>1.8</source>
+					<source>${jdk.version}</source>
 					<verbose>false</verbose>
 					<linksource>true</linksource>
 


### PR DESCRIPTION
Solves #804. Thanks @sbliven for most of the work.

This does:
- Keeps Java 8 compliance (compiled byte code is 8)
- Makes biojava work with java 9, 10 or 11 JREs

At some later point we can decide to move to next version of compliance (9, 10 or 11). That only requires changing the properties `jdk.version` and `maven.enforcer.jdk-version` in main pom.xml.