### PR TITLE
Confirm Genbank parser handles new accession formats.

### DIFF
--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
@@ -223,4 +223,44 @@ public class GenbankReaderTest {
 
 	}
 
+	private DNASequence readGenbankResource(final String resource) throws Exception {
+		DNASequence sequence = null;
+		InputStream inputStream = null;
+		try {
+			inputStream = getClass().getResourceAsStream(resource);
+
+			GenbankReader<DNASequence, NucleotideCompound> genbankDNA
+				= new GenbankReader<>(
+					inputStream,
+					new GenericGenbankHeaderParser<>(),
+					new DNASequenceCreator(DNACompoundSet.getDNACompoundSet())
+					);
+			LinkedHashMap<String, DNASequence> dnaSequences = genbankDNA.process();
+			sequence = dnaSequences.values().iterator().next();
+		}
+		catch (Exception e) {
+			fail(e.getMessage());
+		}
+		finally {
+			try {
+				inputStream.close();
+			}
+			catch (Exception e) {
+				// ignore
+			}
+		}
+		return sequence;
+	}
+
+	@Test
+	public void testNcbiExpandedAccessionFormats() throws Exception {
+		DNASequence header0 = readGenbankResource("/empty_header0.gb");
+		assertEquals("CP032762             5868661 bp    DNA     circular BCT 15-OCT-2018", header0.getOriginalHeader());
+
+		DNASequence header1 = readGenbankResource("/empty_header1.gb");
+		assertEquals("AZZZAA02123456789 9999999999 bp    DNA     linear   PRI 15-OCT-2018", header1.getOriginalHeader());
+
+		DNASequence header2 = readGenbankResource("/empty_header2.gb");
+		assertEquals("AZZZAA02123456789 10000000000 bp    DNA     linear   PRI 15-OCT-2018", header2.getOriginalHeader());
+	}
 }

--- a/biojava-core/src/test/resources/empty_header0.gb
+++ b/biojava-core/src/test/resources/empty_header0.gb
@@ -1,0 +1,8 @@
+LOCUS       CP032762             5868661 bp    DNA     circular BCT 15-OCT-2018
+DEFINITION  no sequence
+ACCESSION   
+VERSION     .0
+KEYWORDS    .
+FEATURES             Location/Qualifiers
+ORIGIN
+//

--- a/biojava-core/src/test/resources/empty_header1.gb
+++ b/biojava-core/src/test/resources/empty_header1.gb
@@ -1,0 +1,8 @@
+LOCUS       AZZZAA02123456789 9999999999 bp    DNA     linear   PRI 15-OCT-2018
+DEFINITION  no sequence
+ACCESSION   
+VERSION     .0
+KEYWORDS    .
+FEATURES             Location/Qualifiers
+ORIGIN
+//

--- a/biojava-core/src/test/resources/empty_header2.gb
+++ b/biojava-core/src/test/resources/empty_header2.gb
@@ -1,0 +1,8 @@
+LOCUS       AZZZAA02123456789 10000000000 bp    DNA     linear   PRI 15-OCT-2018
+DEFINITION  no sequence
+ACCESSION   
+VERSION     .0
+KEYWORDS    .
+FEATURES             Location/Qualifiers
+ORIGIN
+//


### PR DESCRIPTION
Fixes #811.

**tl;dr**  The regular expression we use for the LOCUS line is whitespace separated, so we shouldn't have any trouble with the new Genbank accession formats.