### PR TITLE
add EntityInfo to reduced structure

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BioAssemblyTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BioAssemblyTools.java
@@ -337,6 +337,7 @@ public class BioAssemblyTools {
 			Chain c1 = new ChainImpl();
 			c1.setId(c.getId());
 			c1.setName(c.getName());
+			c1.setEntityInfo(c.getEntityInfo());
 			s.addChain(c1);
 
 			for (Group g : c.getAtomGroups()){


### PR DESCRIPTION
Biological assembly builder requires this field, otherwise it does not work on reduced structures.