### PR TITLE
Bugfix: expanded symmetry partner chains weren't added to entities

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestMMCIFWriting.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestMMCIFWriting.java
@@ -1,0 +1,28 @@
+package org.biojava.nbio.structure.test.io;
+
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.xtal.CrystalBuilder;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertNotNull;
+
+public class TestMMCIFWriting {
+
+    /**
+     * Test that a bioassembly formed with a symmetry mate gets written out without problems.
+     * @throws IOException
+     * @throws StructureException
+     */
+    @Test
+    public void testBiounitWriting6a63() throws IOException, StructureException {
+        Structure s = StructureIO.getBiologicalAssembly("6a63", 1);
+        String mmcif = s.toMMCIF();
+        assertNotNull(mmcif);
+    }
+
+}

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestMMCIFWriting.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestMMCIFWriting.java
@@ -3,13 +3,12 @@ package org.biojava.nbio.structure.test.io;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
-import org.biojava.nbio.structure.xtal.CrystalBuilder;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.HashMap;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class TestMMCIFWriting {
 
@@ -23,6 +22,8 @@ public class TestMMCIFWriting {
         Structure s = StructureIO.getBiologicalAssembly("6a63", 1);
         String mmcif = s.toMMCIF();
         assertNotNull(mmcif);
+        assertTrue(mmcif.contains("A_1"));
+        assertTrue(mmcif.contains("A_2"));
     }
 
 }

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestMMCIFWriting.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestMMCIFWriting.java
@@ -26,4 +26,11 @@ public class TestMMCIFWriting {
         assertTrue(mmcif.contains("A_2"));
     }
 
+    @Test
+    public void testStructWriting1STP() throws IOException, StructureException {
+        Structure s = StructureIO.getStructure("1STP");
+        String mmcif = s.toMMCIF();
+        assertNotNull(mmcif);
+        assertTrue(mmcif.contains("A"));
+    }
 }

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestMMCIFWriting.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/TestMMCIFWriting.java
@@ -18,8 +18,8 @@ public class TestMMCIFWriting {
      * @throws StructureException
      */
     @Test
-    public void testBiounitWriting6a63() throws IOException, StructureException {
-        Structure s = StructureIO.getBiologicalAssembly("6a63", 1);
+    public void testBiounitWriting1STP() throws IOException, StructureException {
+        Structure s = StructureIO.getBiologicalAssembly("1STP", 1);
         String mmcif = s.toMMCIF();
         assertNotNull(mmcif);
         assertTrue(mmcif.contains("A_1"));

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -306,7 +306,12 @@ public class EntityInfo implements Serializable {
 
 		boolean contained = false;
 		for (Chain member:getChains()) {
-			if (c.getId().equals(member.getId())) {
+			// deal with sym mates
+			String origChainId = c.getId();
+			if (origChainId.contains("_")) {
+				origChainId = origChainId.substring(0, origChainId.indexOf('_'));
+			}
+			if (origChainId.equals(member.getId())) {
 				contained = true;
 				break;
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -24,7 +24,6 @@ package org.biojava.nbio.structure;
 
 
 import org.biojava.nbio.structure.io.FileParsingParameters;
-import org.biojava.nbio.structure.quaternary.BiologicalAssemblyBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -294,9 +294,11 @@ public class EntityInfo implements Serializable {
 	}
 
 	/**
-	 * Given a Group g of Chain c (member of this EnityInfo) return the corresponding position in the
+	 * Given a Group g of Chain c (member of this EntityInfo) return the corresponding position in the
 	 * alignment of all member sequences (1-based numbering), i.e. the index (1-based) in the SEQRES sequence.
-	 * This allows for comparisons of residues belonging to different chains of the same EnityInfo (entity).
+	 * This allows for comparisons of residues belonging to different chains of the same EntityInfo (entity).
+	 * <p>
+	 * Note this method should only be used for entities of type {@link EntityType#POLYMER}
 	 * <p>
 	 * If {@link FileParsingParameters#setAlignSeqRes(boolean)} is not used or SEQRES not present, a mapping
 	 * will not be available and this method will return {@link ResidueNumber#getSeqNum()} for all residues, which
@@ -310,7 +312,7 @@ public class EntityInfo implements Serializable {
 	 * is returned as a fall-back, if the group is not found in the SEQRES groups then -1 is returned
 	 * for the given group and chain
 	 * @throws IllegalArgumentException if the given Chain is not a member of this EnityInfo
-	 * @see {@link Chain#getSeqResGroup(int)}
+	 * @see Chain#getSeqResGroup(int)
 	 */
 	public int getAlignedResIndex(Group g, Chain c) {
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -230,7 +230,7 @@ public class EntityInfo implements Serializable {
 	 */
 	public Chain getRepresentative() {
 
-		List<String> chainIds = new ArrayList<String>();
+		List<String> chainIds = new ArrayList<>();
 		for (Chain chain:chains) {
 			chainIds.add(chain.getId());
 		}
@@ -276,12 +276,12 @@ public class EntityInfo implements Serializable {
 	 */
 	public List<String> getChainIds() {
 
-		Set<String> uniqChainIds = new TreeSet<String>();
+		Set<String> uniqChainIds = new TreeSet<>();
 		for (int i=0;i<getChains().size();i++) {
 			uniqChainIds.add(getChains().get(i).getId());
 		}
 
-		return new ArrayList<String>(uniqChainIds);
+		return new ArrayList<>(uniqChainIds);
 	}
 
 	/**
@@ -307,12 +307,7 @@ public class EntityInfo implements Serializable {
 
 		boolean contained = false;
 		for (Chain member:getChains()) {
-			// deal with sym mates
-			String origChainId = c.getId();
-			if (origChainId.contains(BiologicalAssemblyBuilder.SYM_CHAIN_ID_SEPARATOR)) {
-				origChainId = origChainId.substring(0, origChainId.indexOf('_'));
-			}
-			if (origChainId.equals(member.getId())) {
+			if (c.getId().equals(member.getId())) {
 				contained = true;
 				break;
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -24,6 +24,7 @@ package org.biojava.nbio.structure;
 
 
 import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.biojava.nbio.structure.quaternary.BiologicalAssemblyBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -308,7 +309,7 @@ public class EntityInfo implements Serializable {
 		for (Chain member:getChains()) {
 			// deal with sym mates
 			String origChainId = c.getId();
-			if (origChainId.contains("_")) {
+			if (origChainId.contains(BiologicalAssemblyBuilder.SYM_CHAIN_ID_SEPARATOR)) {
 				origChainId = origChainId.substring(0, origChainId.indexOf('_'));
 			}
 			if (origChainId.equals(member.getId())) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -28,7 +28,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * An object to contain the info from the PDB header for a Molecule.
@@ -123,8 +131,8 @@ public class EntityInfo implements Serializable {
 	private Long id;
 
 	public EntityInfo () {
-		chains = new ArrayList<Chain>();
-		chains2pdbResNums2ResSerials = new HashMap<String, Map<ResidueNumber,Integer>>();
+		chains = new ArrayList<>();
+		chains2pdbResNums2ResSerials = new HashMap<>();
 		molId = -1;
 	}
 
@@ -135,9 +143,11 @@ public class EntityInfo implements Serializable {
 	 */
 	public EntityInfo (EntityInfo c) {
 
-		this.chains = new ArrayList<Chain>();
+	    this.id = c.id;
 
-		this.chains2pdbResNums2ResSerials = new HashMap<String, Map<ResidueNumber,Integer>>();
+		this.chains = new ArrayList<>();
+
+		this.chains2pdbResNums2ResSerials = new HashMap<>();
 
 		this.molId = c.molId;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -163,7 +163,7 @@ public class StructureImpl implements Structure {
 
 		// deep-copying of entityInfofos is tricky: there's cross references also in the Chains
 		// beware: if we copy the entityInfos we would also need to reset the references to entityInfos in the individual chains
-		List<EntityInfo> newEntityInfoList = new ArrayList<EntityInfo>();
+		List<EntityInfo> newEntityInfoList = new ArrayList<>();
 		for (EntityInfo entityInfo : this.entityInfos) {
 			EntityInfo newEntityInfo = new EntityInfo(entityInfo); // this sets everything but the chains
 			for (String asymId:entityInfo.getChainIds()) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MMCIFFileTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/MMCIFFileTools.java
@@ -27,6 +27,7 @@ import java.util.*;
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.Element;
+import org.biojava.nbio.structure.EntityType;
 import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.GroupType;
 import org.biojava.nbio.structure.Structure;
@@ -375,10 +376,13 @@ public class MMCIFFileTools {
 		String labelSeqId = Integer.toString(g.getResidueNumber().getSeqNum());
 		if (g.getChain()!=null && g.getChain().getEntityInfo()!=null) {
 			entityId = Integer.toString(g.getChain().getEntityInfo().getMolId());
-			labelSeqId = Integer.toString(g.getChain().getEntityInfo().getAlignedResIndex(g, g.getChain()));
+			if (g.getChain().getEntityInfo().getType() == EntityType.POLYMER) {
+				// this only makes sense for polymeric chains, non-polymer chains will never have seqres groups and there's no point in calling getAlignedResIndex
+				labelSeqId = Integer.toString(g.getChain().getEntityInfo().getAlignedResIndex(g, g.getChain()));
+			}
 		}
 
-		Character  altLoc = a.getAltLoc()           ;
+		Character  altLoc = a.getAltLoc();
 		String altLocStr;
 		if (altLoc==null || altLoc == ' ') {
 			altLocStr = MMCIF_DEFAULT_VALUE;
@@ -473,7 +477,7 @@ public class MMCIFFileTools {
 		List<AtomSite> list = new ArrayList<>();
 
 		if (c.getEntityInfo()==null) {
-			logger.warn("No Compound (entity) found for chain {}: entity_id will be set to 0, label_seq_id will be the same as auth_seq_id", c.getName());
+			logger.warn("No entity found for chain {}: entity_id will be set to 0, label_seq_id will be the same as auth_seq_id", c.getName());
 		}
 
 		for ( int h=0; h<c.getAtomLength();h++){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
@@ -132,8 +132,6 @@ public class BiologicalAssemblyBuilder {
 
 				// note that the Structure.addChain/Structure.addModel methods set the parent reference to the new Structure
 
-				// TODO set entities properly in the new structures! at the moment they are a mess... - JD 2016-05-19
-
 				if (multiModel)
 					addChainMultiModel(s, chain, transformId);
 				else
@@ -211,6 +209,7 @@ public class BiologicalAssemblyBuilder {
 			s.addChain(newChain, modelCount-1);
 		}
 
+		newChain.getEntityInfo().addChain(newChain);
 	}
 
 	/**
@@ -225,6 +224,7 @@ public class BiologicalAssemblyBuilder {
 		newChain.setId(newChain.getId()+SYM_CHAIN_ID_SEPARATOR+transformId);
 		newChain.setName(newChain.getName()+SYM_CHAIN_ID_SEPARATOR+transformId);
 		s.addChain(newChain);
+		newChain.getEntityInfo().addChain(newChain);
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
@@ -23,6 +23,7 @@ package org.biojava.nbio.structure.quaternary;
 
 import org.biojava.nbio.structure.Calc;
 import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.io.mmcif.model.PdbxStructAssembly;
 import org.biojava.nbio.structure.io.mmcif.model.PdbxStructAssemblyGen;
@@ -97,10 +98,11 @@ public class BiologicalAssemblyBuilder {
 
 		Structure s = asymUnit.clone();
 
-
+		Map<Integer, EntityInfo> entityInfoMap = new HashMap<>();
 		// this resets all models (not only the first one): this is important for NMR (multi-model)
 		// like that we can be sure we start with an empty structures and we add models or chains to it
 		s.resetModels();
+		s.setEntityInfos(new ArrayList<>());
 
 		for (BiologicalAssemblyTransformation transformation : transformations){
 
@@ -136,6 +138,17 @@ public class BiologicalAssemblyBuilder {
 					addChainMultiModel(s, chain, transformId);
 				else
 					addChainFlattened(s, chain, transformId);
+
+				EntityInfo entityInfo;
+				if (!entityInfoMap.containsKey(chain.getEntityInfo().getMolId())) {
+					entityInfo = new EntityInfo(chain.getEntityInfo());
+					entityInfoMap.put(chain.getEntityInfo().getMolId(), entityInfo);
+					s.addEntityInfo(entityInfo);
+				} else {
+					entityInfo = entityInfoMap.get(chain.getEntityInfo().getMolId());
+				}
+				chain.setEntityInfo(entityInfo);
+				entityInfo.addChain(chain);
 
 			}
 		}
@@ -209,7 +222,6 @@ public class BiologicalAssemblyBuilder {
 			s.addChain(newChain, modelCount-1);
 		}
 
-		newChain.getEntityInfo().addChain(newChain);
 	}
 
 	/**
@@ -224,7 +236,6 @@ public class BiologicalAssemblyBuilder {
 		newChain.setId(newChain.getId()+SYM_CHAIN_ID_SEPARATOR+transformId);
 		newChain.setName(newChain.getName()+SYM_CHAIN_ID_SEPARATOR+transformId);
 		s.addChain(newChain);
-		newChain.getEntityInfo().addChain(newChain);
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
@@ -45,6 +45,16 @@ public class BiologicalAssemblyBuilder {
 
 	private static final Logger logger = LoggerFactory.getLogger(BiologicalAssemblyBuilder.class);
 
+	/**
+	 * The character separating the original chain identifier from the operator id.
+	 */
+	public static final String SYM_CHAIN_ID_SEPARATOR = "_";
+
+	/**
+	 * The character separating operator ids that are composed.
+	 */
+	public static final String COMPOSED_OPERATOR_SEPARATOR = "x";
+
 	private OperatorResolver operatorResolver;
 
 
@@ -54,7 +64,7 @@ public class BiologicalAssemblyBuilder {
 	 */
 	private Map<String, Matrix4d> allTransformations;
 
-	private List<String> modelIndex = new ArrayList<String>();
+	private List<String> modelIndex = new ArrayList<>();
 
 	public BiologicalAssemblyBuilder(){
 		init();
@@ -194,7 +204,7 @@ public class BiologicalAssemblyBuilder {
 		if (modelCount == 0) {
 			s.addChain(newChain);
 		} else if (modelCount > s.nrModels()) {
-			List<Chain> newModel = new ArrayList<Chain>();
+			List<Chain> newModel = new ArrayList<>();
 			newModel.add(newChain);
 			s.addModel(newModel);
 		} else {
@@ -212,8 +222,8 @@ public class BiologicalAssemblyBuilder {
 	 * @param transformId
 	 */
 	private void addChainFlattened(Structure s, Chain newChain, String transformId) {
-		newChain.setId(newChain.getId()+"_"+transformId);
-		newChain.setName(newChain.getName()+"_"+transformId);
+		newChain.setId(newChain.getId()+SYM_CHAIN_ID_SEPARATOR+transformId);
+		newChain.setName(newChain.getName()+SYM_CHAIN_ID_SEPARATOR+transformId);
 		s.addChain(newChain);
 	}
 
@@ -271,7 +281,7 @@ public class BiologicalAssemblyBuilder {
 
 	private ArrayList<BiologicalAssemblyTransformation> getBioUnitTransformationsListBinaryOperators(String assemblyId, List<PdbxStructAssemblyGen> psags) {
 
-		ArrayList<BiologicalAssemblyTransformation> transformations = new ArrayList<BiologicalAssemblyTransformation>();
+		ArrayList<BiologicalAssemblyTransformation> transformations = new ArrayList<>();
 
 		List<OrderedPair<String>> operators = operatorResolver.getBinaryOperators();
 
@@ -298,7 +308,7 @@ public class BiologicalAssemblyBuilder {
 						composed.mul(original2);
 						BiologicalAssemblyTransformation transform = new BiologicalAssemblyTransformation();
 						transform.setChainId(chainId);
-						transform.setId(operator.getElement1() + "x" + operator.getElement2());
+						transform.setId(operator.getElement1() + COMPOSED_OPERATOR_SEPARATOR + operator.getElement2());
 						transform.setTransformationMatrix(composed);
 						transformations.add(transform);
 					}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCloning.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestCloning.java
@@ -24,10 +24,6 @@
  */
 package org.biojava.nbio.structure;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -35,6 +31,8 @@ import java.util.List;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class TestCloning {
 
@@ -86,6 +84,45 @@ public class TestCloning {
 		final Structure c = s.clone();
 
 		compareCloned(s, c);
+
+	}
+
+	@Test
+	public void testBiounitEntitiesFlatChains() throws StructureException, IOException {
+		Structure s;
+		s = StructureIO.getBiologicalAssembly("1stp", 1);
+
+		EntityInfo entityFromStruct = s.getEntityById(1);
+		EntityInfo entityFromChain = s.getPolyChainByPDB("A_1").getEntityInfo();
+
+		assertSame(entityFromStruct, entityFromChain);
+
+		assertNull(s.getPolyChainByPDB("A"));
+
+		assertEquals(3, s.getEntityInfos().size());
+
+		assertEquals(4, entityFromStruct.getChains().size());
+		assertEquals(4, entityFromStruct.getChainIds().size());
+
+	}
+
+	@Test
+	public void testBiounitEntitiesMultimodel() throws StructureException, IOException {
+		Structure s;
+		s = StructureIO.getBiologicalAssembly("1stp", 1, true);
+
+		EntityInfo entityFromStruct = s.getEntityById(1);
+		EntityInfo entityFromChain = s.getPolyChainByPDB("A").getEntityInfo();
+
+		assertSame(entityFromStruct, entityFromChain);
+
+		assertNull(s.getPolyChainByPDB("A_1"));
+
+		assertEquals(3, s.getEntityInfos().size());
+
+		assertEquals(4, entityFromStruct.getChains().size());
+		// as per javadoc, getChainIds() returns the unique chain names only
+		assertEquals(1, entityFromStruct.getChainIds().size());
 
 	}
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -28,11 +28,19 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import org.biojava.nbio.structure.AminoAcidImpl;
 import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.AtomImpl;
 import org.biojava.nbio.structure.Chain;
+import org.biojava.nbio.structure.ChainImpl;
+import org.biojava.nbio.structure.Element;
+import org.biojava.nbio.structure.EntityInfo;
+import org.biojava.nbio.structure.Group;
+import org.biojava.nbio.structure.ResidueNumber;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.StructureImpl;
 import org.biojava.nbio.structure.StructureTools;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.io.mmcif.MMCIFFileTools;
@@ -205,5 +213,72 @@ public class TestMMCIFWriting {
 				readStruct.getCrystallographicInfo().getSpaceGroup());
 
 
+	}
+
+	/**
+	 * Tests that structures containing symmetry mates with modified chain identifiers
+	 * can be written out correctly.
+	 */
+	@Test
+	public void testBiounitWriting()  {
+		Structure s = createDummyStructure();
+		String mmcif = s.toMMCIF();
+		System.out.println(mmcif);
+		assertNotNull(mmcif);
+		assertTrue(mmcif.length()>5);
+	}
+
+	private static Structure createDummyStructure() {
+		Group g = new AminoAcidImpl();
+		Atom a = getAtom("CA", Element.C, 1, 1, 1, 1);
+		g.addAtom(a);
+		g.setResidueNumber(new ResidueNumber("A", 1, null));
+		Group altLocG = new AminoAcidImpl();
+		Atom a2 = getAtom("CA", Element.C, 2, 2, 2, 2);
+		altLocG.addAtom(a2);
+		altLocG.setResidueNumber(new ResidueNumber("A", 1, null));
+
+		g.addAltLoc(altLocG);
+
+		Chain c1 = new ChainImpl();
+		c1.addGroup(g);
+		c1.setId("A");
+		EntityInfo entityInfo = new EntityInfo();
+		entityInfo.setMolId(1);
+		entityInfo.addChain(c1);
+		c1.setEntityInfo(entityInfo);
+
+		Group gc2 = new AminoAcidImpl();
+		Atom ac2 = getAtom("CA", Element.C, 3, 3, 3, 3);
+		gc2.addAtom(ac2);
+		gc2.setResidueNumber(new ResidueNumber("A_1", 1, null));
+
+		Group altLocGc2 = new AminoAcidImpl();
+		Atom ac22 = getAtom("CA", Element.C, 4, 4, 4, 4);
+		altLocGc2.addAtom(ac22);
+		altLocGc2.setResidueNumber(new ResidueNumber("A_1", 1, null));
+
+		gc2.addAltLoc(altLocGc2);
+
+		Chain c2 = new ChainImpl();
+		c2.addGroup(gc2);
+		c2.setId("A_1");
+		c2.setEntityInfo(entityInfo);
+
+		Structure s = new StructureImpl();
+		s.addChain(c1);
+		s.addChain(c2);
+		return s;
+	}
+
+	private static Atom getAtom(String name, Element e, int id, double x, double y, double z) {
+		Atom a = new AtomImpl();
+		a.setX(x);
+		a.setY(y);
+		a.setZ(z);
+		a.setPDBserial(id);
+		a.setName(name);
+		a.setElement(e);
+		return a;
 	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -266,6 +266,7 @@ public class TestMMCIFWriting {
 		c2.addGroup(gc2);
 		c2.setId("A_1");
 		c2.setEntityInfo(entityInfo);
+		entityInfo.addChain(c2);
 
 		Structure s = new StructureImpl();
 		s.addChain(c1);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestMMCIFWriting.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.biojava.nbio.structure.AminoAcidImpl;
 import org.biojava.nbio.structure.Atom;
@@ -223,9 +224,10 @@ public class TestMMCIFWriting {
 	public void testBiounitWriting()  {
 		Structure s = createDummyStructure();
 		String mmcif = s.toMMCIF();
-		System.out.println(mmcif);
+		String[] lines = mmcif.split("\n");
+		long atomLines = Arrays.stream(lines).filter(l -> l.startsWith("ATOM")).count();
 		assertNotNull(mmcif);
-		assertTrue(mmcif.length()>5);
+		assertEquals(4, atomLines);
 	}
 
 	private static Structure createDummyStructure() {


### PR DESCRIPTION
This prevented things like writing out to mmcif file a bioassembly with expanded chains.