### PR TITLE
Test and fix for BioJava #836 to parse and save all OBO synonyms

### DIFF
--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Synonym.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Synonym.java
@@ -48,23 +48,7 @@ public class Synonym implements Comparable<Synonym>{
 	public final static Comparator<Synonym> COMPARATOR = new Comparator<Synonym>() {
 		@Override
 		public int compare(Synonym a, Synonym b) {
-			if (a == null && b == null)
-				return 0;
-			else if (a == null)
-				return -1;
-			else if (b == null)
-				return 1;
-			else {
-				if ((a.getCategory() == null) && (b.getCategory() == null))
-					return 0;
-				else if ( a.getCategory()==null)
-					return -1;
-				else if ( b.getCategory()==null)
-					return 1;
-
-				return a.getCategory().compareToIgnoreCase(
-						b.getCategory());
-			}
+			return String.CASE_INSENSITIVE_ORDER.compare(a.toString(), b.toString());
 		}
 	};
 

--- a/biojava-ontology/src/test/java/org/biojava/nbio/ontology/TestOboFileParsing.java
+++ b/biojava-ontology/src/test/java/org/biojava/nbio/ontology/TestOboFileParsing.java
@@ -80,6 +80,14 @@ public class TestOboFileParsing {
 				Assert.assertTrue(anno.containsProperty("replaced_by"));
 				Assert.assertEquals("HP:0008665", anno.getProperty("replaced_by"));
 			}
+			if(term.getName().equals("HP:0000006")) {
+				Assert.assertEquals("Autosomal dominant inheritance", term.getDescription());
+				Object[] syns = term.getSynonyms();
+				Assert.assertEquals(3,  syns.length);
+				Assert.assertEquals("Autosomal dominant", ((Synonym) syns[0]).getName());
+				Assert.assertEquals("Autosomal dominant form", ((Synonym) syns[1]).getName());
+				Assert.assertEquals("Autosomal dominant type", ((Synonym) syns[2]).getName());
+			}
 		}
 	}
 


### PR DESCRIPTION
Added a simple test to check a term with more than one synonym.
Solution is a modified implementation of Synonym.COMPARATOR.compare() that incorporates all fields of the class, case-insensitive. 