### PR TITLE
Fixes on optimization of subunit clusterer for quaternary sym detection of PDB deposited structures

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -372,17 +372,9 @@ public class TestQuatSymmetryDetectorExamples {
 		Structure pdb = StructureIO.getStructure("BIO:1SMT:1");
 
 		SubunitClustererParameters cp = new SubunitClustererParameters();
-//		cp.setOptimizeAlignment(false);
-//		cp.setSequenceIdentityThreshold(0.75);
-//		cp.setMinimumSequenceLength(3);
-//		cp.setAbsoluteMinimumSequenceLength(3);
-//		cp.setUseSequenceCoverage(false);
-//		cp.setUseStructureCoverage(false);
-//		cp.setUseRMSD(false);
 		cp.setUseEntityIdForSeqIdentityDetermination(true);
 		cp.setClustererMethod(SubunitClustererMethod.SEQUENCE);
 		QuatSymmetryParameters symmParams = new QuatSymmetryParameters();
-//		symmParams.setOnTheFly(true);
 		QuatSymmetryResults symmetry = QuatSymmetryDetector.calcGlobalSymmetry(
 				pdb, symmParams, cp);
 

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -366,4 +366,28 @@ public class TestQuatSymmetryDetectorExamples {
 		assertEquals(SubunitClustererMethod.SEQUENCE, symmetry.getSubunitClusters().get(0).getClustererMethod());
 
 	}
+
+	@Test
+	public void testSymDetectionWithSubunitClusterByEntityId() throws IOException, StructureException {
+		Structure pdb = StructureIO.getStructure("BIO:1SMT:1");
+
+		SubunitClustererParameters cp = new SubunitClustererParameters();
+//		cp.setOptimizeAlignment(false);
+//		cp.setSequenceIdentityThreshold(0.75);
+//		cp.setMinimumSequenceLength(3);
+//		cp.setAbsoluteMinimumSequenceLength(3);
+//		cp.setUseSequenceCoverage(false);
+//		cp.setUseStructureCoverage(false);
+//		cp.setUseRMSD(false);
+		cp.setUseEntityIdForSeqIdentityDetermination(true);
+		cp.setClustererMethod(SubunitClustererMethod.SEQUENCE);
+		QuatSymmetryParameters symmParams = new QuatSymmetryParameters();
+//		symmParams.setOnTheFly(true);
+		QuatSymmetryResults symmetry = QuatSymmetryDetector.calcGlobalSymmetry(
+				pdb, symmParams, cp);
+
+		// C2 symmetry, A2 stoichiometry
+		assertEquals("C2", symmetry.getSymmetry());
+		assertEquals("A2", symmetry.getStoichiometry().toString());
+	}
 }

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -32,6 +32,7 @@ import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.cluster.SubunitClusterer;
 import org.biojava.nbio.structure.cluster.SubunitClustererMethod;
 import org.biojava.nbio.structure.cluster.SubunitClustererParameters;
+import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryDetector;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryParameters;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryResults;
@@ -369,6 +370,13 @@ public class TestQuatSymmetryDetectorExamples {
 
 	@Test
 	public void testSymDetectionWithSubunitClusterByEntityId() throws IOException, StructureException {
+		AtomCache cache = new AtomCache();
+		cache.setUseMmtf(false);
+		cache.setUseMmCif(true);
+		FileParsingParameters params = new FileParsingParameters();
+		params.setAlignSeqRes(true);
+		cache.setFileParsingParams(params);
+		StructureIO.setAtomCache(cache);
 		Structure pdb = StructureIO.getStructure("BIO:1SMT:1");
 
 		SubunitClustererParameters cp = new SubunitClustererParameters();

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -398,7 +398,6 @@ public class TestQuatSymmetryDetectorExamples {
 	/**
 	 * A performance test that demonstrates how the SubunitClustererParameters.setUseEntityIdForSeqIdentityDetermination()
 	 * has a dramatic effect in runtime versus doing alignments.
-	 * This takes minutes with the parameter on, but hours without the parameter.
 	 */
 	@Ignore("This is a performance test to be run manually")
 	@Test
@@ -413,14 +412,20 @@ public class TestQuatSymmetryDetectorExamples {
 		StructureIO.setAtomCache(cache);
 
 		// making sure we remove all atoms but representative before we expand, otherwise memory requirements are huge
+		// 6Q1F is another good example
 		Structure au = StructureIO.getStructure("6NHJ");
 		StructureTools.reduceToRepresentativeAtoms(au);
 		BiologicalAssemblyBuilder builder = new BiologicalAssemblyBuilder();
 		List<BiologicalAssemblyTransformation> transforms = au.getPDBHeader().getBioAssemblies().get(1).getTransforms();
-		Structure pdb =builder.rebuildQuaternaryStructure(au, transforms, true, false);
+		Structure pdb = builder.rebuildQuaternaryStructure(au, transforms, true, false);
 
 		SubunitClustererParameters cp = new SubunitClustererParameters();
-		cp.setUseEntityIdForSeqIdentityDetermination(true); // this is the parameter that makes this fast
+
+		// This is the parameter that makes this fast, set it to false to see the difference.
+		// As of git commit ed322e387cd46344a7864a, the difference in runtime is not that huge:
+		// 2 minutes with true, 10 minutes with false. I observed a much larger difference before, but can't reproduce anymore - JD 2020-01-23
+		cp.setUseEntityIdForSeqIdentityDetermination(true);
+
 		cp.setClustererMethod(SubunitClustererMethod.SEQUENCE);
 		QuatSymmetryParameters symmParams = new QuatSymmetryParameters();
 		QuatSymmetryResults symmetry = QuatSymmetryDetector.calcGlobalSymmetry(

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -306,12 +306,12 @@ public class EntityInfo implements Serializable {
 	 * used and when all chains within the entity are numbered in the same way), but
 	 * in general they will be neither unique (because of insertion codes) nor aligned.
 	 * </p>
-	 * @param g
-	 * @param c
+	 * @param g the group
+	 * @param c the chain
 	 * @return the aligned residue index (1 to n), if no SEQRES groups are available at all then {@link ResidueNumber#getSeqNum()}
 	 * is returned as a fall-back, if the group is not found in the SEQRES groups then -1 is returned
 	 * for the given group and chain
-	 * @throws IllegalArgumentException if the given Chain is not a member of this EnityInfo
+	 * @throws IllegalArgumentException if the given Chain is not a member of this EntityInfo
 	 * @see Chain#getSeqResGroup(int)
 	 */
 	public int getAlignedResIndex(Group g, Chain c) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1264,7 +1264,7 @@ public class StructureTools {
 	 *            3-character code for a group.
 	 *
 	 */
-	public static final boolean isNucleotide(String groupCode3) {
+	public static boolean isNucleotide(String groupCode3) {
 		String code = groupCode3.trim();
 		return nucleotides30.containsKey(code)
 				|| nucleotides23.containsKey(code);
@@ -1283,7 +1283,7 @@ public class StructureTools {
 	 * @deprecated Use {@link StructureIdentifier#reduce(Structure)} instead (v. 4.2.0)
 	 */
 	@Deprecated
-	public static final Structure getReducedStructure(Structure s,
+	public static Structure getReducedStructure(Structure s,
 			String chainId) throws StructureException {
 		// since we deal here with structure alignments,
 		// only use Model 1...
@@ -1338,7 +1338,7 @@ public class StructureTools {
 		return newS;
 	}
 
-	public static final String convertAtomsToSeq(Atom[] atoms) {
+	public static String convertAtomsToSeq(Atom[] atoms) {
 
 		StringBuilder buf = new StringBuilder();
 		Group prevGroup = null;
@@ -1374,7 +1374,7 @@ public class StructureTools {
 	 * @throws StructureException
 	 *             if the group cannot be found.
 	 */
-	public static final Group getGroupByPDBResidueNumber(Structure struc,
+	public static Group getGroupByPDBResidueNumber(Structure struc,
 			ResidueNumber pdbResNum) throws StructureException {
 		if (struc == null || pdbResNum == null) {
 			throw new IllegalArgumentException("Null argument(s).");
@@ -1447,7 +1447,7 @@ public class StructureTools {
 	 * @param chain
 	 * @param cutoff
 	 * @return
-	 * @see {@link #getRepresentativeAtomsInContact(Chain, double)}
+	 * @see #getRepresentativeAtomsInContact(Chain, double)
 	 */
 	public static AtomContactSet getAtomsCAInContact(Chain chain, double cutoff) {
 		Grid grid = new Grid(cutoff);
@@ -1921,4 +1921,24 @@ public class StructureTools {
 		return name;
 	}
 
+	/**
+	 * Remove all atoms but the representative atoms (C alphas or phosphates) from the given structure.
+	 * @param structure the structure
+	 * @since 5.4.0
+	 */
+	public static void reduceToRepresentativeAtoms(Structure structure) {
+		for (int modelIdx = 0; modelIdx<structure.nrModels(); modelIdx++) {
+			for (Chain c : structure.getPolyChains(modelIdx)) {
+				for (Group g : c.getAtomGroups()) {
+					List<Atom> atoms = g.getAtoms();
+					if (g.isAminoAcid()) {
+						atoms.removeIf(a->!a.getName().equals(CA_ATOM_NAME));
+					} else if (g.isNucleotide()) {
+						atoms.removeIf(a->!a.getName().equals(NUCLEOTIDE_REPRESENTATIVE));
+					}
+					// else we keep all other atoms. We are concerned only about aminoacids and nucleotides that make up the bulk of the structures
+				}
+			}
+		}
+	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
@@ -192,22 +192,35 @@ public class SubunitCluster {
 	 * @return true if the SubunitClusters are identical, false otherwise
 	 */
 	public boolean isIdenticalByEntityIdTo(SubunitCluster other) {
-		Structure thisStruct = this.subunits.get(this.representative).getStructure();
-		Structure otherStruct = other.subunits.get(other.representative).getStructure();
-		String thisName = this.subunits.get(this.representative).getName();
-		String otherName = other.subunits.get(this.representative).getName();
+		Subunit thisSub = this.subunits.get(this.representative);
+		Subunit otherSub = other.subunits.get(other.representative);
+		String thisName = thisSub.getName();
+		String otherName = otherSub.getName();
+
+		Structure thisStruct = thisSub.getStructure();
+		Structure otherStruct = otherSub.getStructure();
+		if (thisStruct == null || otherStruct == null) {
+			logger.info("SubunitClusters {}-{} have no referenced structures. Ignoring identity check by entity id",
+					thisName,
+					otherName);
+			return false;
+		}
+		if (thisStruct != otherStruct) {
+			// different object references: will not cluster even if entity id is same
+			return false;
+		}
 		Chain thisChain = thisStruct.getChain(thisName);
 		Chain otherChain = otherStruct.getChain(otherName);
 		if (thisChain == null || otherChain == null) {
 			logger.info("Can't determine entity ids of SubunitClusters {}-{}. Ignoring identity check by entity id",
-					this.subunits.get(this.representative).getName(),
-					other.subunits.get(other.representative).getName());
+					thisName,
+					otherName);
 			return false;
 		}
 		if (thisChain.getEntityInfo() == null || otherChain.getEntityInfo() == null) {
 			logger.info("Can't determine entity ids of SubunitClusters {}-{}. Ignoring identity check by entity id",
-					this.subunits.get(this.representative).getName(),
-					other.subunits.get(other.representative).getName());
+					thisName,
+					otherName);
 			return false;
 		}
 		int thisEntityId = thisChain.getEntityInfo().getMolId();
@@ -256,18 +269,19 @@ public class SubunitCluster {
 
 		Subunit thisSub = this.subunits.get(this.representative);
 		Subunit otherSub = other.subunits.get(other.representative);
+		String thisName = thisSub.getName();
+		String otherName = otherSub.getName();
+
 		logger.info("SubunitClusters {}-{} belong to same entity. Assuming they are identical",
-				thisSub.getName(),
-				otherSub.getName());
+				thisName,
+				otherName);
 
 		List<Integer> thisAligned = new ArrayList<>();
 		List<Integer> otherAligned = new ArrayList<>();
 
-		// we've merged by entity id, we can assume structure, chain and entity are available
+		// we've merged by entity id, we can assume structure, chain and entity are available (checked in isIdenticalByEntityIdTo())
 		Structure thisStruct = thisSub.getStructure();
 		Structure otherStruct = otherSub.getStructure();
-		String thisName = thisSub.getName();
-		String otherName = otherSub.getName();
 		Chain thisChain = thisStruct.getChain(thisName);
 		Chain otherChain = otherStruct.getChain(otherName);
 		EntityInfo entityInfo = thisChain.getEntityInfo();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
@@ -298,14 +298,14 @@ public class SubunitCluster {
 				continue;
 			}
 
+			// note the seqresindex is 1-based
 			Group otherG = otherChain.getSeqResGroups().get(seqresIndex - 1);
 
-			if (!otherChain.getAtomGroups().contains(otherG)) {
-				// skip residues that are unobserved in other sequence ("gaps" in the entity alignment)
+			int otherIndex = otherChain.getAtomGroups().indexOf(otherG);
+			if (otherIndex == -1) {
+				// skip residues that are unobserved in other sequence ("gaps" in the entity SEQRES alignment)
 				continue;
 			}
-
-			int otherIndex = otherChain.getAtomGroups().indexOf(otherG);
 
 			// Only consider residues that are part of the SubunitCluster
 			if (this.subunitEQR.get(this.representative).contains(thisIndex)
@@ -316,7 +316,7 @@ public class SubunitCluster {
 		}
 
 		if (thisAligned.size() == 0 && otherAligned.size() == 0) {
-			logger.warn("No equivalent aligned atoms found between SubunitClusters {}-{} via entity seqres alignment. Is FileParsingParameters.setAlignSeqRes() set?", thisName, otherName);
+			logger.warn("No equivalent aligned atoms found between SubunitClusters {}-{} via entity SEQRES alignment. Is FileParsingParameters.setAlignSeqRes() set?", thisName, otherName);
 		}
 
 		updateEquivResidues(other, thisAligned, otherAligned);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
@@ -241,7 +241,7 @@ public class SubunitCluster {
 	 * same Subunit. This is checked by comparing the entity identifiers of the subunits
 	 * if one can be found.
 	 * Thus this only makes sense when the subunits are complete chains of a
-	 * deposited PDB entry. I
+	 * deposited PDB entry.
 	 *
 	 * @param other
 	 *            SubunitCluster

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
@@ -293,6 +293,11 @@ public class SubunitCluster {
 
 			int seqresIndex = entityInfo.getAlignedResIndex(g, thisChain);
 
+			if (seqresIndex == -1) {
+				// this might mean that FileParsingParameters.setAlignSeqRes() wasn't set to true during parsing
+				continue;
+			}
+
 			Group otherG = otherChain.getSeqResGroups().get(seqresIndex - 1);
 
 			if (!otherChain.getAtomGroups().contains(otherG)) {
@@ -308,6 +313,10 @@ public class SubunitCluster {
 				thisAligned.add(thisIndex);
 				otherAligned.add(otherIndex);
 			}
+		}
+
+		if (thisAligned.size() == 0 && otherAligned.size() == 0) {
+			logger.warn("No equivalent aligned atoms found between SubunitClusters {}-{} via entity seqres alignment. Is FileParsingParameters.setAlignSeqRes() set?", thisName, otherName);
 		}
 
 		updateEquivResidues(other, thisAligned, otherAligned);
@@ -743,7 +752,7 @@ public class SubunitCluster {
 	 */
 	public List<Atom[]> getAlignedAtomsSubunits() {
 
-		List<Atom[]> alignedAtoms = Collections.emptyList();
+		List<Atom[]> alignedAtoms = new ArrayList<>();
 
 		// Loop through all subunits and add the aligned positions
 		for (int s = 0; s < subunits.size(); s++)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClustererParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitClustererParameters.java
@@ -511,7 +511,8 @@ public class SubunitClustererParameters implements Serializable {
 	/**
 	 * Whether to use the entity id of subunits to infer that sequences are identical.
 	 * Only applies if the {@link SubunitClustererMethod} is a sequence based one.
-	 * @return
+	 * @return the flag
+	 * @since 5.4.0
 	 */
 	public boolean isUseEntityIdForSeqIdentityDetermination() {
 		return useEntityIdForSeqIdentityDetermination;
@@ -520,7 +521,10 @@ public class SubunitClustererParameters implements Serializable {
 	/**
 	 * Whether to use the entity id of subunits to infer that sequences are identical.
 	 * Only applies if the {@link SubunitClustererMethod} is a sequence based one.
+	 * Note this requires {@link org.biojava.nbio.structure.io.FileParsingParameters#setAlignSeqRes(boolean)} to be
+	 * set to true.
 	 * @param useEntityIdForSeqIdentityDetermination the flag to be set
+	 * @since 5.4.0
 	 */
 	public void setUseEntityIdForSeqIdentityDetermination(boolean useEntityIdForSeqIdentityDetermination) {
 		this.useEntityIdForSeqIdentityDetermination = useEntityIdForSeqIdentityDetermination;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/C2RotationSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/C2RotationSolver.java
@@ -39,8 +39,8 @@ import java.util.List;
  * @author Peter
  */
 public class C2RotationSolver implements QuatSymmetrySolver {
-	private QuatSymmetrySubunits subunits = null;
-	private QuatSymmetryParameters parameters = null;
+	private QuatSymmetrySubunits subunits;
+	private QuatSymmetryParameters parameters;
 	private Vector3d centroid = new Vector3d();
 	private Matrix4d centroidInverse = new Matrix4d();
 
@@ -132,7 +132,7 @@ public class C2RotationSolver implements QuatSymmetrySolver {
 	}
 
 	private void addEOperation() {
-		List<Integer> permutation = Arrays.asList(new Integer[]{0,1});
+		List<Integer> permutation = Arrays.asList(0,1);
 		Matrix4d transformation = new Matrix4d();
 		transformation.setIdentity();
 		combineWithTranslation(transformation);
@@ -145,7 +145,6 @@ public class C2RotationSolver implements QuatSymmetrySolver {
 
 	/**
 	 * Adds translational component to rotation matrix
-	 * @param rotTrans
 	 * @param rotation
 	 * @return
 	 */

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetrySubunits.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetrySubunits.java
@@ -21,6 +21,7 @@
 package org.biojava.nbio.structure.symmetry.core;
 
 import org.biojava.nbio.structure.Atom;
+import org.biojava.nbio.structure.Calc;
 import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.cluster.SubunitCluster;
 import org.biojava.nbio.structure.geometry.CalcPoint;
@@ -34,7 +35,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 /**
- * A bean to represent information about the set of {@link Subunit} being
+ * A bean to represent information about the set of {@link org.biojava.nbio.structure.cluster.Subunit}s being
  * considered for symmetry detection. This class is a helper for the
  * {@link QuatSymmetryDetector} algorithm, since it calculates and caches the
  * {@link MomentsOfInertia} and the centroids of each Subunit.
@@ -45,13 +46,13 @@ import java.util.stream.Collectors;
  */
 public class QuatSymmetrySubunits {
 
-	private List<Point3d[]> caCoords = new ArrayList<Point3d[]>();
-	private List<Point3d> originalCenters = new ArrayList<Point3d>();
-	private List<Point3d> centers = new ArrayList<Point3d>();
-	private List<Vector3d> unitVectors = new ArrayList<Vector3d>();
+	private List<Point3d[]> caCoords = new ArrayList<>();
+	private List<Point3d> originalCenters = new ArrayList<>();
+	private List<Point3d> centers = new ArrayList<>();
+	private List<Vector3d> unitVectors = new ArrayList<>();
 
-	private List<Integer> folds = new ArrayList<Integer>();
-	private List<Integer> clusterIds = new ArrayList<Integer>();
+	private List<Integer> folds = new ArrayList<>();
+	private List<Integer> clusterIds = new ArrayList<>();
 	private List<SubunitCluster> clusters;
 
 	private Point3d centroid;
@@ -75,10 +76,7 @@ public class QuatSymmetrySubunits {
 				clusterIds.add(c);
 				Atom[] atoms = clusters.get(c).getAlignedAtomsSubunit(s);
 
-				// Convert atoms to points
-				Point3d[] points = new Point3d[atoms.length];
-				for (int i = 0; i < atoms.length; i++)
-					points[i] = atoms[i].getCoordsAsPoint3d();
+				Point3d[] points = Calc.atomsToPoints(atoms);
 
 				caCoords.add(points);
 			}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/cluster/TestSubunitCluster.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/cluster/TestSubunitCluster.java
@@ -69,9 +69,9 @@ public class TestSubunitCluster {
 
 		// Merged have to be true, and the merged SubunitCluster is sc1
 		assertTrue(merged);
-		assertEquals(sc1.size(), 2);
-		assertEquals(sc2.size(), 1);
-		assertEquals(sc1.length(), 10);
+		assertEquals(2, sc1.size());
+		assertEquals(1, sc2.size());
+		assertEquals(10, sc1.length());
 
 		// Create an Atom Array of poly-glycine
 		Atom[] reprAtoms2 = mockAtomArray(10, "GLY", -1, null);
@@ -83,9 +83,9 @@ public class TestSubunitCluster {
 
 		// Merged have to be false, and Clusters result inmodified
 		assertFalse(merged);
-		assertEquals(sc1.size(), 2);
-		assertEquals(sc2.size(), 1);
-		assertEquals(sc1.length(), 10);
+		assertEquals(2, sc1.size());
+		assertEquals(1, sc2.size());
+		assertEquals(10, sc1.length());
 
 	}
 
@@ -153,9 +153,9 @@ public class TestSubunitCluster {
 
 		// Merged have to be true, and the merged SubunitCluster is sc1
 		assertTrue(merged);
-		assertEquals(sc1.size(), 2);
-		assertEquals(sc2.size(), 1);
-		assertEquals(sc1.length(), 100);
+		assertEquals(2, sc1.size());
+		assertEquals(1, sc2.size());
+		assertEquals(100, sc1.length());
 
 		// Create an Atom Array of poly-glycine
 		Atom[] reprAtoms2 = mockAtomArray(100, "GLY", -1, null);
@@ -167,9 +167,9 @@ public class TestSubunitCluster {
 
 		// Merged have to be false, and Clusters result inmodified
 		assertFalse(merged);
-		assertEquals(sc1.size(), 2);
-		assertEquals(sc2.size(), 1);
-		assertEquals(sc1.length(), 100);
+		assertEquals(2, sc1.size());
+		assertEquals(1, sc2.size());
+		assertEquals(100, sc1.length());
 
 		// Create an Atom Array of 9 glycine and 91 alanine
 		Atom[] reprAtoms3 = mockAtomArray(9, "GLY", 91, "ALA");
@@ -181,9 +181,9 @@ public class TestSubunitCluster {
 
 		// Merged have to be true, and the merged SubunitCluster is sc1
 		assertTrue(merged);
-		assertEquals(sc1.size(), 3);
-		assertEquals(sc2.size(), 1);
-		assertEquals(sc1.length(), 91);
+		assertEquals(3, sc1.size());
+		assertEquals(1, sc2.size());
+		assertEquals(91, sc1.length());
 
 	}
 
@@ -224,10 +224,10 @@ public class TestSubunitCluster {
 		// Merged have to be true, and the merged SubunitCluster is sc1
 		assertTrue(merged13);
 		assertTrue(merged24);
-		assertEquals(sc1.size(), 2);
-		assertEquals(sc2.size(), 2);
-		assertEquals(sc1.length(), 141);
-		assertEquals(sc2.length(), 146);
+		assertEquals(2, sc1.size());
+		assertEquals(2, sc2.size());
+		assertEquals(141, sc1.length());
+		assertEquals(146, sc2.length());
 		assertEquals(sc1.getAlignedAtomsSubunit(0).length,
 				sc1.getAlignedAtomsSubunit(1).length);
 		assertEquals(sc2.getAlignedAtomsSubunit(0).length,
@@ -237,8 +237,8 @@ public class TestSubunitCluster {
 		boolean merged = sc1.mergeStructure(sc2, clustererParameters);
 
 		assertTrue(merged);
-		assertEquals(sc1.size(), 4);
-		assertEquals(sc1.length(), 140, 2);
+		assertEquals(4, sc1.size());
+		assertEquals(140, sc1.length(), 2);
 		assertEquals(sc1.getAlignedAtomsSubunit(0).length,
 				sc1.getAlignedAtomsSubunit(2).length);
 
@@ -270,7 +270,7 @@ public class TestSubunitCluster {
 
 		// Divided has to be true, and Subunit length shorter than half
 		assertTrue(divided);
-		assertEquals(sc1.size(), 2);
+		assertEquals(2, sc1.size());
 		assertTrue(sc1.length() < 178);
 		assertEquals(sc1.getAlignedAtomsSubunit(0).length,
 				sc1.getAlignedAtomsSubunit(1).length);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/cluster/TestSubunitCluster.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/cluster/TestSubunitCluster.java
@@ -53,16 +53,7 @@ public class TestSubunitCluster {
 	public void testMergeIdentical() {
 
 		// Create an Atom Array of poly-alanine
-		List<Atom> atoms = new ArrayList<>(10);
-		for (int i = 0; i < 10; i++) {
-			Group g = new AminoAcidImpl();
-			g.setPDBName("ALA");
-			Atom a = new AtomImpl();
-			a.setName(StructureTools.CA_ATOM_NAME);
-			g.addAtom(a);
-			atoms.add(a);
-		}
-		Atom[] reprAtoms = atoms.toArray(new Atom[atoms.size()]);
+		Atom[] reprAtoms = mockAtomArray(10, "ALA", -1, null);
 
 		// Create two identical SubunitCluster
 		SubunitCluster sc1 = new SubunitCluster(new Subunit(reprAtoms,
@@ -79,16 +70,7 @@ public class TestSubunitCluster {
 		assertEquals(sc1.length(), 10);
 
 		// Create an Atom Array of poly-glycine
-		List<Atom> atoms2 = new ArrayList<>(10);
-		for (int i = 0; i < 10; i++) {
-			Group g = new AminoAcidImpl();
-			g.setPDBName("GLY");
-			Atom a = new AtomImpl();
-			a.setName(StructureTools.CA_ATOM_NAME);
-			g.addAtom(a);
-			atoms2.add(a);
-		}
-		Atom[] reprAtoms2 = atoms2.toArray(new Atom[atoms2.size()]);
+		Atom[] reprAtoms2 = mockAtomArray(10, "GLY", -1, null);
 
 		SubunitCluster sc3 = new SubunitCluster(new Subunit(reprAtoms2,
 				"subunit 1", null, null));
@@ -111,17 +93,8 @@ public class TestSubunitCluster {
 	@Test
 	public void testMergeSequence() throws CompoundNotFoundException {
 
-		// Create an Atom Array of ploy-alanine
-		List<Atom> atoms = new ArrayList<>(100);
-		for (int i = 0; i < 100; i++) {
-			Group g = new AminoAcidImpl();
-			g.setPDBName("ALA");
-			Atom a = new AtomImpl();
-			a.setName(StructureTools.CA_ATOM_NAME);
-			g.addAtom(a);
-			atoms.add(a);
-		}
-		Atom[] reprAtoms = atoms.toArray(new Atom[atoms.size()]);
+		// Create an Atom Array of poly-alanine
+		Atom[] reprAtoms = mockAtomArray(100, "ALA", -1, null);
 
 		// Create two identical SubunitCluster
 		SubunitCluster sc1 = new SubunitCluster(new Subunit(reprAtoms,
@@ -140,16 +113,7 @@ public class TestSubunitCluster {
 		assertEquals(sc1.length(), 100);
 
 		// Create an Atom Array of poly-glycine
-		List<Atom> atoms2 = new ArrayList<Atom>(100);
-		for (int i = 0; i < 100; i++) {
-			Group g = new AminoAcidImpl();
-			g.setPDBName("GLY");
-			Atom a = new AtomImpl();
-			a.setName(StructureTools.CA_ATOM_NAME);
-			g.addAtom(a);
-			atoms2.add(a);
-		}
-		Atom[] reprAtoms2 = atoms2.toArray(new Atom[atoms2.size()]);
+		Atom[] reprAtoms2 = mockAtomArray(100, "GLY", -1, null);
 
 		SubunitCluster sc3 = new SubunitCluster(new Subunit(reprAtoms2,
 				"subunit 3", null, null));
@@ -163,24 +127,7 @@ public class TestSubunitCluster {
 		assertEquals(sc1.length(), 100);
 
 		// Create an Atom Array of 9 glycine and 91 alanine
-		List<Atom> atoms3 = new ArrayList<>(100);
-		for (int i = 0; i < 9; i++) {
-			Group g = new AminoAcidImpl();
-			g.setPDBName("GLY");
-			Atom a = new AtomImpl();
-			a.setName(StructureTools.CA_ATOM_NAME);
-			g.addAtom(a);
-			atoms3.add(a);
-		}
-		for (int i = 0; i < 91; i++) {
-			Group g = new AminoAcidImpl();
-			g.setPDBName("ALA");
-			Atom a = new AtomImpl();
-			a.setName(StructureTools.CA_ATOM_NAME);
-			g.addAtom(a);
-			atoms3.add(a);
-		}
-		Atom[] reprAtoms3 = atoms3.toArray(new Atom[atoms3.size()]);
+		Atom[] reprAtoms3 = mockAtomArray(9, "GLY", 91, "ALA");
 
 		SubunitCluster sc4 = new SubunitCluster(new Subunit(reprAtoms3,
 				"subunit 4", null, null));
@@ -282,5 +229,37 @@ public class TestSubunitCluster {
 		assertTrue(sc1.length() < 178);
 		assertEquals(sc1.getAlignedAtomsSubunit(0).length,
 				sc1.getAlignedAtomsSubunit(1).length);
+	}
+
+	/**
+	 * Create a mock atom array, with size1 residues of type1, followed by size2 residues of type2
+	 * @param size1 the number of residues of type1 to add
+	 * @param type1 the 3 letter code of residue
+	 * @param size2 the number of residues of type2 to add, if -1 none are added
+	 * @param type2 the 3 letter code of residue, if null none are added
+	 * @return the mock atom array
+	 */
+	private Atom[] mockAtomArray(int size1, String type1, int size2, String type2) {
+		List<Atom> atoms = new ArrayList<>(size1 + size2);
+		for (int i = 0; i < size1; i++) {
+			Group g = new AminoAcidImpl();
+			g.setPDBName(type1);
+			Atom a = new AtomImpl();
+			a.setName(StructureTools.CA_ATOM_NAME);
+			g.addAtom(a);
+			atoms.add(a);
+		}
+
+		if (size2 >= 0 && type2 !=null) {
+			for (int i = 0; i < size2; i++) {
+				Group g = new AminoAcidImpl();
+				g.setPDBName(type2);
+				Atom a = new AtomImpl();
+				a.setName(StructureTools.CA_ATOM_NAME);
+				g.addAtom(a);
+				atoms.add(a);
+			}
+		}
+		return atoms.toArray(new Atom[0]);
 	}
 }


### PR DESCRIPTION
A follow up to #857 

This adds tests and fixes a few problems in the implementation (wasn't updating equivalent residues indices for chains of same entity). Also added docs and a new utility method in StructureTools.

In any case as of this PR I can't reproduce anymore the dramatic difference in runtime mentioned in #857 . One of the new (ignored) tests in this PR is to demonstrate the runtime difference, but it's only ~ 5x  