### PR TITLE
Minimal read support for files with 'branched' entities 

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityType.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityType.java
@@ -45,6 +45,18 @@ public enum EntityType {
 	POLYMER("polymer"),
 
 	/**
+	 * The 'branched' type use mainly to represent carbohydrates.
+	 * The type was introduced in these versions of the mmcif dictionary:
+	 * 5.101	2012-08-22
+	 * 5.291	2017-09-10
+	 * 5.304	2018-08-01
+	 * The type will only be used for PDB-deposited files from July 2020, as part of
+	 * the carbohydrate remediation project.
+	 * @since 5.4.0
+	 */
+	BRANCHED("branched"),
+
+	/**
 	 * Non-polymeric entities: ligands, metal ions, buffer molecules, etc
 	 */
 	NONPOLYMER("non-polymer"),

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Model.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Model.java
@@ -110,6 +110,10 @@ public class Model implements Serializable {
 			logger.warn("Chain with asym id {} (author id {}) has entity type 'macrolide', considering it non-polymeric", c.getId(), c.getName());
 			nonPolyChains.add(c);
 
+		} else if (info.getType() == EntityType.BRANCHED) {
+			logger.warn("Chain with asym id {} (author id {}) has entity type 'branched', considering it non-polymeric", c.getId(), c.getName());
+			nonPolyChains.add(c);
+
 		} else {
 			logger.warn("Chain with asym id {} (author id {}) has unsupported entity type '{}'. Will not add it to the Structure.", c.getId(), c.getName(), info.getType().toString());
 			// ignore it

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureWriter.java
@@ -37,6 +37,8 @@ import org.biojava.nbio.structure.io.mmcif.model.ChemComp;
 import org.biojava.nbio.structure.quaternary.BioAssemblyInfo;
 import org.rcsb.mmtf.api.StructureAdapterInterface;
 import org.rcsb.mmtf.dataholders.MmtfStructure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class to take Biojava structure data and covert to the DataApi for encoding.
@@ -48,7 +50,9 @@ import org.rcsb.mmtf.dataholders.MmtfStructure;
  */
 public class MmtfStructureWriter {
 
-	private StructureAdapterInterface mmtfDecoderInterface;
+	private static final Logger logger = LoggerFactory.getLogger(MmtfStructureWriter.class);
+
+	private final StructureAdapterInterface mmtfDecoderInterface;
 
 	/**
 	 * Pass data from Biojava structure  to another generic output type. Loops through the data
@@ -179,9 +183,8 @@ public class MmtfStructureWriter {
 			List<Chain> entityChains = entityInfo.getChains();
 			if (entityChains.isEmpty()){
 				// Error mapping chain to entity
-				System.err.println("ERROR MAPPING CHAIN TO ENTITY: "+description);
+				logger.error("ERROR MAPPING CHAIN TO ENTITY: "+description);
 				mmtfDecoderInterface.setEntityInfo(new int[0], "", description, type);
-				continue;
 			}
 			else{
 				int[] chainIndices = new int[entityChains.size()];
@@ -194,7 +197,7 @@ public class MmtfStructureWriter {
 					chainImpl = (ChainImpl) entityChains.get(0);
 				}
 				else{
-					throw new RuntimeException();
+					throw new RuntimeException("Encountered Chain of unexpected type");
 				}
 				String sequence = chainImpl.getSeqResOneLetterSeq();
 				mmtfDecoderInterface.setEntityInfo(chainIndices, sequence, description, type);
@@ -205,8 +208,7 @@ public class MmtfStructureWriter {
 
 	/**
 	 * Generate the bioassembly information on in the desired form.
-	 * @param bioJavaStruct the Biojava structure
-	 * @param header the header
+	 *
 	 */
 	private void storeBioassemblyInformation(Map<String, Integer> chainIdToIndexMap, Map<Integer, BioAssemblyInfo> inputBioAss) {
 		int bioAssemblyIndex = 0;

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URL;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
@@ -441,6 +442,30 @@ public class TestNonDepositedFiles {
 		}
 		int[] counts = {countPoly, countNonPoly, countWater};
 		return counts;
+
+	}
+
+	@Test
+	public void testCarbohydrates() throws IOException {
+		// Example carbohydrate remediation file to be released in July 2020
+		URL url = new URL("https://raw.githubusercontent.com/pdbxmmcifwg/carbohydrate-extension/master/examples/models/1B5F-carb.cif");
+		InputStream inStream = url.openStream();
+
+		MMcifParser parser = new SimpleMMcifParser();
+
+		SimpleMMcifConsumer consumer = new SimpleMMcifConsumer();
+		parser.addMMcifConsumer(consumer);
+		parser.parse(new BufferedReader(new InputStreamReader(inStream)));
+
+		Structure structure = consumer.getStructure();
+
+		assertEquals(7, structure.getEntityInfos().size());
+
+		assertEquals(2, structure.getEntityById(1).getChains().size());
+		assertEquals(2, structure.getEntityById(2).getChains().size());
+
+		assertEquals(0, structure.getNonPolyChains().size());
+		assertEquals(4, structure.getPolyChains().size());
 
 	}
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -446,7 +446,7 @@ public class TestNonDepositedFiles {
 	}
 
 	@Test
-	public void testCarbohydrates() throws IOException {
+	public void testStructureWithBranchedEntities() throws IOException {
 		// Example carbohydrate remediation file to be released in July 2020
 		URL url = new URL("https://raw.githubusercontent.com/pdbxmmcifwg/carbohydrate-extension/master/examples/models/1B5F-carb.cif");
 		InputStream inStream = url.openStream();
@@ -464,8 +464,15 @@ public class TestNonDepositedFiles {
 		assertEquals(2, structure.getEntityById(1).getChains().size());
 		assertEquals(2, structure.getEntityById(2).getChains().size());
 
-		assertEquals(0, structure.getNonPolyChains().size());
+		// we consider the branched chains non-poly chains
+		assertEquals(4, structure.getNonPolyChains().size());
 		assertEquals(4, structure.getPolyChains().size());
 
+		assertEquals(1, structure.getEntityById(3).getChains().size());
+
+		// chain asym_id="E" is from entity 3
+		assertSame(structure.getNonPolyChain("E"), structure.getEntityById(3).getChains().get(0));
+
+		assertEquals(5, structure.getNonPolyChain("E").getAtomGroups().size());
 	}
 }


### PR DESCRIPTION
The [carbohydrate remediation project](https://www.mail-archive.com/ccp4bb@jiscmail.ac.uk/msg48559.html) introduces a new entity type: "branched". The type exists in the mmCIF dictionary for quite some time, but from July 2020 it will be used by many files with carbohydrates.

This pull request simply makes sure that the files can be parsed without breaking any existing functionality. It treats the branched chains as non-polymeric chains.