### PR TITLE
Update slf4j/log4j dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,8 +41,8 @@
     	<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maxmem>512M</maxmem>
 		<mmtf.version>1.0.9</mmtf.version>
-		<slf4j.version>1.7.25</slf4j.version>
-		<log4j.version>2.6.2</log4j.version>
+		<slf4j.version>1.7.30</slf4j.version>
+		<log4j.version>2.13.1</log4j.version>
 	</properties>
 	<scm>
 		<connection>scm:git:git://github.com/biojava/biojava.git</connection>


### PR DESCRIPTION
slf4j/log4j dependencies are quite old (>3 years), this PR updates

slf4j update 1.7.25 -> 1.7.30
log4j update 2.6.2 -> 2.13.1