### PR TITLE
Comment out 3R8R from localSymmetry test

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -183,11 +183,12 @@ public class TestQuatSymmetryDetectorExamples {
 				localSymmetries.put("A8","D2");
 			testLocalSymmetries.add(localSymmetries);
 
+		/* Bioassembly for 3R8R changed in January 2020 (PR #867)
 		testIds.add("BIO:3R8R:1");
 			testStoichiometries.add("A12");
 			localSymmetries = new HashMap<>();
 				localSymmetries.put("A10","D5");
-			testLocalSymmetries.add(localSymmetries);
+			testLocalSymmetries.add(localSymmetries);*/
 
 		testIds.add("BIO:1O18:1");
 			testStoichiometries.add("A14B6C5D5");


### PR DESCRIPTION
Stoichiometry changed in January 2020 as indicated by @josemduarte in #867.

Since there are already many examples of local symmetry in the test I simply commented this one out, as it is no longer a case of local symmetry (it's a D5 assembly).