### PR TITLE
Case insensitive chem.comp type lookup

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/chem/ResidueType.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/chem/ResidueType.java
@@ -140,9 +140,9 @@ public enum ResidueType implements Serializable {
 			{
 				return rt;
 			}
-			if ( rt.chem_comp_type.startsWith(chem_comp_type))
+			if ( rt.chem_comp_type.toLowerCase().startsWith(chem_comp_type.toLowerCase()))
 				return rt;
-			if ( chem_comp_type.startsWith(rt.chem_comp_type))
+			if ( chem_comp_type.toLowerCase().startsWith(rt.chem_comp_type.toLowerCase()))
 				return rt;
 		}
 		return null;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -214,6 +214,9 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 			char singleLetterCode, int sequenceIndexId, int secStructType) {
 		// Get the polymer type
 		ResidueType residueType = ResidueType.getResidueTypeFromString(chemCompType);
+		if (residueType == null)
+			throw new IllegalStateException("Couldn't resolve residue type for "+ chemCompType);
+
 		int polymerType = getGroupTypIndicator(residueType.polymerType);
 		switch (polymerType) {
 		case 1:


### PR DESCRIPTION
mmtf has it all upper-case - fails to lookup for chem.comp type because of different case