### PR TITLE
Add GFF3Reader overload that accepts Path

### DIFF
--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Reader.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Reader.java
@@ -20,6 +20,9 @@
  */
 package org.biojava.nbio.genome.parsers.gff;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,11 +70,15 @@ public class GFF3Reader {
 	 */
 
 	public static FeatureList read(String filename, List<String> indexes) throws IOException {
-		logger.info("Reading: {}", filename);
+		return read(Paths.get(filename), indexes);
+	}
+
+	public static FeatureList read(Path path, List<String> indexes) throws IOException {
+		logger.info("Reading: {}", path.toString());
 
 		FeatureList features = new FeatureList();
 		features.addIndexes(indexes);
-		BufferedReader br = new BufferedReader(new FileReader(filename));
+		BufferedReader br = Files.newBufferedReader(path);
 
 		String s;
 		for (s = br.readLine(); null != s; s = br.readLine()) {
@@ -101,6 +108,10 @@ public class GFF3Reader {
 
 	public static FeatureList read(String filename) throws IOException {
 	   return read(filename,new ArrayList<String>(0));
+	}
+
+	public static FeatureList read(Path path) throws IOException {
+		return read(path,new ArrayList<String>(0));
 	}
 
 

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Reader.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Reader.java
@@ -68,11 +68,17 @@ public class GFF3Reader {
 	 * @return A FeatureList.
 	 * @throws IOException Something went wrong -- check exception detail message.
 	 */
-
 	public static FeatureList read(String filename, List<String> indexes) throws IOException {
 		return read(Paths.get(filename), indexes);
 	}
 
+	/**
+	 * Read a file into a FeatureList. Each line of the file becomes one Feature object.
+	 *
+	 * @param path The path to the GFF file.
+	 * @return A FeatureList.
+	 * @throws IOException Something went wrong -- check exception detail message.
+	 */
 	public static FeatureList read(Path path, List<String> indexes) throws IOException {
 		logger.info("Reading: {}", path.toString());
 

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Reader.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Reader.java
@@ -27,7 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
The String-based functions are still here, and almost all the code is shared.
The Path overload allows everyone to read files via NIO providers, such as e.g.
the GCS NIO provider for reading files on Google Cloud Storage.

Key change: new BufferedReader(new FileReader(filename)) -> Files.newBufferedReader(path)