### PR TITLE
Fixing the flakiness caused by testGetProteinSequenceForStructure

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/StructureSequenceMatcher.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/StructureSequenceMatcher.java
@@ -119,7 +119,7 @@ public class StructureSequenceMatcher {
 
 		for(Chain chain : struct.getChains()) {
 			List<Group> groups = chain.getAtomGroups();
-			Map<Integer,Integer> chainIndexPosition = new HashMap<Integer, Integer>();
+			Map<Integer,Integer> chainIndexPosition = new LinkedHashMap<Integer, Integer>();
 			int prevLen = seqStr.length();
 
 			// get the sequence for this chain

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/StructureSequenceMatcher.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/StructureSequenceMatcher.java
@@ -119,7 +119,7 @@ public class StructureSequenceMatcher {
 
 		for(Chain chain : struct.getChains()) {
 			List<Group> groups = chain.getAtomGroups();
-			Map<Integer,Integer> chainIndexPosition = new LinkedHashMap<Integer, Integer>();
+			Map<Integer,Integer> chainIndexPosition = new HashMap<Integer, Integer>();
 			int prevLen = seqStr.length();
 
 			// get the sequence for this chain

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -106,7 +106,7 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 	private List<Chain> chainList;
 
 	/** All the chains as a list of maps */
-	private List<LinkedHashMap<String,Chain>> chainMap;
+	private List<Map<String,Chain>> chainMap;
 
 	private List<double[]> transformList;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfStructureReader.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -105,7 +106,7 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 	private List<Chain> chainList;
 
 	/** All the chains as a list of maps */
-	private List<Map<String,Chain>> chainMap;
+	private List<LinkedHashMap<String,Chain>> chainMap;
 
 	private List<double[]> transformList;
 
@@ -178,7 +179,7 @@ public class MmtfStructureReader implements StructureAdapterInterface, Serializa
 			int chainCount) {
 		modelNumber = inputModelNumber;
 		structure.addModel(new ArrayList<Chain>(chainCount));
-		chainMap.add(new HashMap<>());
+		chainMap.add(new LinkedHashMap<>());
 	}
 
 	/* (non-Javadoc)


### PR DESCRIPTION
As part of our course project CS527 at UIUC, we chose to fix flaky tests in Biojava project. Flaky tests are those tests that pass and fail without any code changes [https://hackernoon.com/flaky-tests-a-war-that-never-ends-9aa32fdef359]. Flaky tests are can be quite costly since they often require engineers to re-trigger entire builds on CI and often waste a lot of time waiting for new builds to complete successfully.

We used the NonDex tool to find flaky tests [ https://github.com/TestingResearchIllinois/NonDex ] . This is a tool developed in our research lab and has been widely accepted.

Iterating through the hashmap for entries is non-deterministic in nature, so we changed the HashMap to a LinkedHashMap and re-ran the test. The Junits were executed again and they passed. We ran the NonDex tool again and we observed that  flakiness caused due to the test disappears.



 
