### PR TITLE
Rewrite of PDB status to use new RCSB PDB data API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ BioJava 6.0.0 (future release)
 * The whole `org.biojava.nbio.structure.validation` package
 * The `org.biojava.nbio.structure.domain.PDBDomainProvider` class to pull domain definitions from legacy RCSB PDB APIs
 * Support for automatically fetching dssp files from RCSB (`org.biojava.nbio.structure.secstruc.DSSPParser.fetch()`)
+* `org.biojava.nbio.structure.PDBStatus`: simplified `Status` enum to 3 states, with OBSOLETE now called REMOVED
+* `org.biojava.nbio.structure.PDBStatus`: removed `getReplacement` and `getReplaces` 
 
 BioJava 5.4.0
 =============

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBStatus.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBStatus.java
@@ -70,7 +70,7 @@ public class PDBStatus {
 		 * @throws IllegalArgumentException If the string is not recognized
 		 */
 		public static Status fromString(String statusStr) {
-			if (statusStr == null) return null;
+			if (statusStr == null) throw new IllegalArgumentException("Status string can't be null");
 			if(statusStr.equalsIgnoreCase("REMOVED"))
 				return Status.REMOVED;
 			else if(statusStr.equalsIgnoreCase("CURRENT"))

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBStatus.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBStatus.java
@@ -33,7 +33,7 @@ import java.net.URL;
 import java.util.*;
 
 /**
- * Methods for getting the status of a PDB file (current, obsolete, unreleased)
+ * Methods for getting the status of a PDB file (current, removed, unreleased)
  * and for accessing different versions of the structure.
  *
  * <p>
@@ -70,18 +70,16 @@ public class PDBStatus {
 		 * @throws IllegalArgumentException If the string is not recognized
 		 */
 		public static Status fromString(String statusStr) {
-			Status status;
-			String statusStrUpper = statusStr.toUpperCase();
-			if(statusStrUpper.equalsIgnoreCase("REMOVED"))
-				status = Status.REMOVED;
-			else if(statusStrUpper.equalsIgnoreCase("CURRENT"))
-				status = Status.CURRENT;
-			else if(statusStrUpper.equalsIgnoreCase("UNRELEASED"))
-				status = Status.UNRELEASED;
+			if (statusStr == null) return null;
+			if(statusStr.equalsIgnoreCase("REMOVED"))
+				return Status.REMOVED;
+			else if(statusStr.equalsIgnoreCase("CURRENT"))
+				return Status.CURRENT;
+			else if(statusStr.equalsIgnoreCase("UNRELEASED"))
+				return Status.UNRELEASED;
 			else {
-				throw new IllegalArgumentException("Unable to parse status '"+statusStrUpper+"'.");
+				throw new IllegalArgumentException("Unable to parse status '"+statusStr+"'.");
 			}
-			return status;
 		}
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBStatus.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBStatus.java
@@ -18,65 +18,29 @@
  *      http://www.biojava.org/
  *
  */
-/**
- *
- */
 package org.biojava.nbio.structure;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.biojava.nbio.structure.align.util.URLConnectionTools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.xml.sax.*;
-import org.xml.sax.helpers.DefaultHandler;
 
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.*;
 
 /**
- * Methods for getting the status of a PDB file (current, obsolete, etc)
+ * Methods for getting the status of a PDB file (current, obsolete, unreleased)
  * and for accessing different versions of the structure.
  *
  * <p>
  * All methods query the
  * <a href="https://data.rcsb.org">
  * RCSB Data REST API</a>
- *
  * <p>
- * PDB supersessions form a directed acyclic graph, where edges point from an
- * obsolete ID to the entry that directly superseded it. For example, here are
- * edges from one portion of the graph:
- * <p>
- * 1CAT -> 3CAT<br/>
- * 3CAT -> 7CAT<br/>
- * 3CAT -> 8CAT<br/>
- *
- * <p>
- * The methods {@link #getReplaces(String, boolean) getReplaces(pdbId, false)}/
- * {@link #getReplacement(String, boolean, boolean) getReplacement(pdbId, false, true)}
- * just get the incoming/outgoing edges for a single node. The recursive versions
- * ({@link #getReplaces(String, boolean) getReplaces(pdbId, true)},
- * {@link #getReplacement(String, boolean, boolean) getReplacement(pdbId, true, false)})
- * will do a depth-first search up/down the tree and return a list of all nodes ]
- * reached.
- *
- * <p>
- * Finally, the {@link #getCurrent(String)} method returns a single PDB ID from among the
- * results of
- * {@link #getReplacement(String, boolean, boolean)}.
- * To be consistent with the old REST ordering, this is the PDB ID that occurs
- * last alphabetically.
- *
- * <p>
- * Results are cached to reduce server load.
  *
  * @author Spencer Bliven
  * @author Amr AL-Hossary
@@ -87,40 +51,21 @@ public class PDBStatus {
 
 	private static final Logger logger = LoggerFactory.getLogger(PDBStatus.class);
 
-	//public static final String DEFAULT_PDB_SERVER = "www.rcsb.org";
 	public static final String DEFAULT_RCSB_DATA_API_SERVER = "data.rcsb.org";
 	public static final String ALL_CURRENT_ENDPOINT = "https://%s/rest/v1/holdings/current/entry_ids";
+	public static final String STATUS_ENDPOINT = "https://%s/rest/v1/holdings/status/%s";
+	public static final String STATUS_LIST_ENDPOINT = "https://%s/rest/v1/holdings/status?ids=%s";
 
 	/**
-	 * saves the returned results for further use.
-	 *
-	 */
-	private static final Map<String, Map<String, String>> recordsCache= new Hashtable<>();
-
-	/**
-	 * Represents the status of PDB IDs. 'OBSOLETE' and 'CURRENT' are the most
-	 * common.
+	 * Represents a simplified 3 state status of PDB IDs.
 	 * @author Spencer Bliven
 	 *
 	 */
 	public enum Status {
-		// this is the list for unreleased: "AUCO" "AUTH" "HOLD" "HPUB" "POLC" "PROC" "REFI" "REPL" "WAIT" "WDRN"
-		// The remaining from below are removed-related: OBSOLETE, MODEL (not available in Data API).
-		// In Data API in rcsb_repository_holdings_insilico_models.status_code: 3 values "OBS", "TRSF", "WDRN" and 1 in  rcsb_repository_holdings_transferred.status_code: "TRSF"
-		// for current: CURRENT (not available in current API)
-		OBSOLETE,
+		// the simplified status enum in rcsb_repository_holdings_combined
+		REMOVED,
 		CURRENT,
-		AUTH,
-		HOLD,
-		HPUB,
-		POLC,
-		PROC,
-		REFI,
-		REPL,
-		WAIT,
-		WDRN,
-		MODEL,
-		UNKNOWN;
+		UNRELEASED;
 
 		/**
 		 * @throws IllegalArgumentException If the string is not recognized
@@ -128,32 +73,12 @@ public class PDBStatus {
 		public static Status fromString(String statusStr) {
 			Status status;
 			String statusStrUpper = statusStr.toUpperCase();
-			if(statusStrUpper.equalsIgnoreCase("OBSOLETE"))
-				status = Status.OBSOLETE;
+			if(statusStrUpper.equalsIgnoreCase("REMOVED"))
+				status = Status.REMOVED;
 			else if(statusStrUpper.equalsIgnoreCase("CURRENT"))
 				status = Status.CURRENT;
-			else if(statusStrUpper.equalsIgnoreCase("AUTH"))
-				status = Status.AUTH;
-			else if(statusStrUpper.equalsIgnoreCase("HOLD"))
-				status = Status.HOLD;
-			else if(statusStrUpper.equalsIgnoreCase("HPUB"))
-				status = Status.HPUB;
-			else if(statusStrUpper.equalsIgnoreCase("POLC"))
-				status = Status.POLC;
-			else if(statusStrUpper.equalsIgnoreCase("PROC"))
-				status = Status.PROC;
-			else if(statusStrUpper.equalsIgnoreCase("REFI"))
-				status = Status.REFI;
-			else if(statusStrUpper.equalsIgnoreCase("REPL"))
-				status = Status.REPL;
-			else if(statusStrUpper.equalsIgnoreCase("WAIT"))
-				status = Status.WAIT;
-			else if(statusStrUpper.equalsIgnoreCase("WDRN"))
-				status = Status.WDRN;
-			else if(statusStrUpper.equalsIgnoreCase("MODEL"))
-				status = Status.MODEL;
-			else if(statusStrUpper.equalsIgnoreCase("UNKNOWN"))
-				status = Status.UNKNOWN;
+			else if(statusStrUpper.equalsIgnoreCase("UNRELEASED"))
+				status = Status.UNRELEASED;
 			else {
 				throw new IllegalArgumentException("Unable to parse status '"+statusStrUpper+"'.");
 			}
@@ -164,447 +89,81 @@ public class PDBStatus {
 	/**
 	 * Get the status of the PDB in question.
 	 *
-	 * @param pdbId
+	 * @param pdbId the id
 	 * @return The status, or null if an error occurred.
 	 */
 	public static Status getStatus(String pdbId) throws IOException {
-		Status[] statuses = getStatus(new String[] {pdbId});
-		if(statuses != null) {
-			assert(statuses.length == 1);
-			return statuses[0];
-		} else {
-			return null;
-		}
+		URL url = new URL(String.format(STATUS_ENDPOINT, DEFAULT_RCSB_DATA_API_SERVER, pdbId.toUpperCase()));
+		ObjectMapper objectMapper = new ObjectMapper();
+		JsonNode node = objectMapper.readValue(url.openStream(), JsonNode.class);
+		return parseStatusRecord(node);
 	}
 
 	/**
 	 * Get the status of the a collection of PDBs in question in a single query.
 	 *
 	 * @see #getStatus(String)
-	 * @param pdbIds
+	 * @param pdbIds the ids
 	 * @return The status array, or null if an error occurred.
 	 */
 	public static Status[] getStatus(String[] pdbIds) throws IOException {
-		Status[] statuses = new Status[pdbIds.length];
 
-		List<Map<String,String>> attrList = getStatusIdRecords(pdbIds);
-		//Expect a single record
-		if(attrList == null || attrList.size() != pdbIds.length) {
-			logger.error("Error getting Status for {} from the PDB website.", Arrays.toString(pdbIds));
-			return null;
-		}
+		URL url = new URL(String.format(STATUS_LIST_ENDPOINT, DEFAULT_RCSB_DATA_API_SERVER, String.join(",", pdbIds)));
 
+		List<Status> statuses = new ArrayList<>();
 
-		for(int pdbNum = 0;pdbNum<pdbIds.length;pdbNum++) {
-			//Locate first element of attrList with matching structureId.
-			//attrList is usually short, so don't worry about performance
-			boolean foundAttr = false;
-			for( Map<String,String> attrs : attrList) {
+		ObjectMapper objectMapper = new ObjectMapper();
+		JsonNode node = objectMapper.readValue(url.openStream(), JsonNode.class);
 
-				//Check that the record matches pdbId
-				String id = attrs.get("structureId");
-				if(id == null || !id.equalsIgnoreCase(pdbIds[pdbNum])) {
-					continue;
-				}
-
-				//Check that the status is given
-				String statusStr = attrs.get("status");
-				Status status = null;
-				if(statusStr == null ) {
-					logger.error("No status returned for {}", pdbIds[pdbNum]);
-					statuses[pdbNum] = null;
-				} else {
-					status = Status.fromString(statusStr);
-				}
-
-				if(status == null) {
-					logger.error("Unknown status '{}'", statusStr);
-					statuses[pdbNum] = null;
-				}
-
-				statuses[pdbNum] = status;
-				foundAttr = true;
-			}
-			if(!foundAttr) {
-				logger.error("No result found for {}", pdbIds[pdbNum]);
-				statuses[pdbNum] = null;
+		if (node !=null && node.isArray()) {
+			for (JsonNode record : node) {
+				Status status = parseStatusRecord(record);
+				statuses.add(status);
 			}
 		}
 
-		return statuses;
+		if (statuses.size() != pdbIds.length) {
+			logger.warn("RCSB status request was for {} ids, but {} were returned", pdbIds.length, statuses.size());
+		}
+
+		return statuses.toArray(new Status[0]);
+	}
+
+	private static Status parseStatusRecord(JsonNode jsonNode) {
+		// "rcsb_repository_holdings_combined": {
+		//"id_code_replaced_by_latest": "4HHB",
+		//"status": "REMOVED",
+		//"status_code": "OBS"
+		//},
+		JsonNode rcsbRepoHoldingsNode = jsonNode.get("rcsb_repository_holdings_combined");
+		return Status.fromString(rcsbRepoHoldingsNode.get("status").asText());
 	}
 
 	/**
-	 * Gets the current version of a PDB ID. This is equivalent to selecting
-	 * the first element from
-	 * {@link #getReplacement(String,boolean,boolean)
+	 * Gets the current version of a PDB ID.
 	 *
-	 * @param oldPdbId
-	 * @return The replacement for oldPdbId, or null if none are found or if an error occurred.
+	 * @param oldPdbId the id
+	 * @return The replacement for oldPdbId, or null if none are found.
+	 * If entry is current then the input PDB id is returned
 	 */
 	public static String getCurrent(String oldPdbId) throws IOException {
-		List<String> replacements = getReplacement(oldPdbId,true, false);
-		if(replacements != null && !replacements.isEmpty())
-			return replacements.get(0);
-		else
-			return null;
-	}
-
-	/**
-	 * Gets the PDB which superseded oldPdbId. For CURRENT IDs, this will
-	 * be itself. For obsolete IDs, the behavior depends on the recursion
-	 * parameter. If false, only IDs which directly supersede oldPdbId are
-	 * returned. If true, the replacements for obsolete records are recursively
-	 * fetched, yielding a list of all current replacements of oldPdbId.
-	 *
-	 *
-	 *
-	 * @param oldPdbId A pdb ID
-	 * @param recurse Indicates whether the replacements for obsolete records
-	 * 		should be fetched.
-	 * @param includeObsolete Indicates whether obsolete records should be
-	 * 		included in the results.
-	 * @return The PDB which replaced oldPdbId. This may be oldPdbId itself, for
-	 * 		current records. A return value of null indicates that the ID has
-	 * 		been removed from the PDB or that an error has occurred.
-	 */
-	public static List<String> getReplacement(String oldPdbId, boolean recurse, boolean includeObsolete) throws IOException {
-		List<Map<String,String>> attrList = getStatusIdRecords(new String[] {oldPdbId});
-		//Expect a single record
-		if(attrList == null || attrList.size() != 1) {
-			logger.error("Error getting Status for {} from the PDB website.", oldPdbId);
-			return null;
-		}
-
-		Map<String,String> attrs = attrList.get(0);
-
-		//Check that the record matches pdbId
-		String id = attrs.get("structureId");
-		if(id == null || !id.equalsIgnoreCase(oldPdbId)) {
-			logger.error("Results returned from the query don't match {}", oldPdbId);
-			return null;
-		}
-
-		//Check that the status is given
-		String statusStr = attrs.get("status");
-		if(statusStr == null ) {
-			logger.error("No status returned for {}", oldPdbId);
-			return null;
-		}
-
-		Status status = Status.fromString(statusStr);
-		if(status == null ) {
-			logger.error("Unknown status '{}'", statusStr);
-			return null;
-		}
-
-		// If we're current, just return
-		LinkedList<String> results = new LinkedList<>();
-		switch(status) {
-			case CURRENT:
-				results.add(oldPdbId);
-				return results;
-			case OBSOLETE: {
-				String replacementStr = attrs.get("replacedBy");
-				if(replacementStr == null) {
-					logger.error("{} is OBSOLETE but lacks a replacedBy attribute.", oldPdbId);
-					return null;
-				}
-				replacementStr = replacementStr.toUpperCase();
-				//include this result
-				if(includeObsolete) {
-					results.add(oldPdbId);
-				}
-				// Some PDBs are not replaced.
-				if(replacementStr.equals("NONE")) {
-					return results; //empty
-				}
-
-				String[] replacements = replacementStr.split(" ");
-				Arrays.sort(replacements, new Comparator<String>() {
-					@Override
-					public int compare(String o1, String o2) {
-						return o2.compareToIgnoreCase(o1);
-					}
-				});
-				for(String replacement : replacements) {
-
-					// Return the replacement.
-					if(recurse) {
-						List<String> others = PDBStatus.getReplacement(replacement, recurse, includeObsolete);
-						mergeReversed(results,others);
-					}
-					else {
-						if(includeObsolete) {
-							mergeReversed(results,Arrays.asList(replacement));
-						} else {
-							// check status of replacement
-							Status replacementStatus = getStatus(replacement);
-							switch(replacementStatus) {
-								case OBSOLETE:
-									//ignore obsolete
-									break;
-								case CURRENT:
-								default:
-									// include it
-									mergeReversed(results,Arrays.asList(replacement));
-							}
-						}
-					}
-				}
-
-
-				return results;
-			}
-			case UNKNOWN:
+		URL url = new URL(String.format(STATUS_ENDPOINT, DEFAULT_RCSB_DATA_API_SERVER, oldPdbId.toUpperCase()));
+		ObjectMapper objectMapper = new ObjectMapper();
+		JsonNode node = objectMapper.readValue(url.openStream(), JsonNode.class);
+		JsonNode rcsbRepoHoldingsNode = node.get("rcsb_repository_holdings_combined");
+		Status st = Status.fromString(rcsbRepoHoldingsNode.get("status").asText());
+		if (st == Status.REMOVED) {
+			JsonNode replacedByNode = rcsbRepoHoldingsNode.get("id_code_replaced_by_latest");
+			if (replacedByNode != null)
+				return replacedByNode.asText();
+			else
 				return null;
-			default: { //TODO handle other cases explicitly. They might have other syntax than "replacedBy"
-				String replacementStr = attrs.get("replacedBy");
-
-				if(replacementStr == null) {
-					// If no "replacedBy" attribute, treat like we're current
-					// TODO is this correct?
-					results.add(oldPdbId);
-					return results;
-				}
-
-				replacementStr = replacementStr.toUpperCase();
-				// Some PDBs are not replaced.
-				if(replacementStr.equals("NONE")) {
-					return null;
-				}
-
-
-				//include this result, since it's not obsolete
-				results.add(oldPdbId);
-
-				String[] replacements = replacementStr.split(" ");
-				Arrays.sort(replacements, new Comparator<String>() {
-					@Override
-					public int compare(String o1, String o2) {
-						return o2.compareToIgnoreCase(o1);
-					}
-				});
-				for(String replacement : replacements) {
-
-					// Return the replacement.
-					if(recurse) {
-						List<String> others = PDBStatus.getReplacement(replacement, recurse, includeObsolete);
-						mergeReversed(results,others);
-					}
-					else {
-						mergeReversed(results,Arrays.asList(replacement));
-					}
-				}
-
-
-				return results;
-			}
-		}
-	}
-
-	/**
-	 * Takes two reverse sorted lists of strings and merges the second into the
-	 * first. Duplicates are removed.
-	 *
-	 * @param merged A reverse sorted list. Modified by this method to contain
-	 * 		the contents of other.
-	 * @param other A reverse sorted list. Not modified.
-	 */
-	private static void mergeReversed(List<String> merged,
-	                                  final List<String> other) {
-
-		if(other.isEmpty())
-			return;
-
-		if(merged.isEmpty()) {
-			merged.addAll(other);
-			return;
-		}
-
-		ListIterator<String> m = merged.listIterator();
-		ListIterator<String> o = other.listIterator();
-
-		String nextM, prevO;
-		prevO = o.next();
-		while(m.hasNext()) {
-			// peek at m
-			nextM = m.next();
-			m.previous();
-
-			//insert from O until exhausted or occurs after nextM
-			while(prevO.compareTo(nextM) > 0) {
-				m.add(prevO);
-				if(!o.hasNext()) {
-					return;
-				}
-				prevO = o.next();
-			}
-			//remove duplicates
-			if(prevO.equals(nextM)) {
-				if(!o.hasNext()) {
-					return;
-				}
-				prevO = o.next();
-			}
-
-			m.next();
-		}
-		m.add(prevO);
-		while(o.hasNext()) {
-			m.add(o.next());
-		}
-
-	}
-
-
-	/**
-	 * Get the ID of the protein which was made obsolete by newPdbId.
-	 *
-	 * @param newPdbId PDB ID of the newer structure
-	 * @param recurse If true, return all ancestors of newPdbId.
-	 * 		Otherwise, just go one step newer than oldPdbId.
-	 * @return A (possibly empty) list of ID(s) of the ancestor(s) of
-	 * 		newPdbId, or <tt>null</tt> if an error occurred.
-	 */
-	public static List<String> getReplaces(String newPdbId, boolean recurse) throws IOException {
-		List<Map<String,String>> attrList = getStatusIdRecords(new String[] {newPdbId});
-		//Expect a single record
-		if(attrList == null || attrList.size() != 1) {
-			//TODO Is it possible to have multiple record per ID?
-			// They seem to be combined into one record with space-delimited 'replaces'
-			logger.error("Error getting Status for {} from the PDB website.", newPdbId);
-			return null;
-		}
-
-		Map<String,String> attrs = attrList.get(0);
-
-		//Check that the record matches pdbId
-		String id = attrs.get("structureId");
-		if(id == null || !id.equals(newPdbId)) {
-			logger.error("Results returned from the query don't match {}", newPdbId);
-			return null;
-		}
-
-
-		String replacedList = attrs.get("replaces"); //space-delimited list
-		if(replacedList == null) {
-			// no replaces value; assume root
-			return new ArrayList<String>();
-		}
-		String[] directDescendents = replacedList.split("\\s");
-
-		// Not the root! Return the replaced PDB.
-		if(recurse) {
-			// Note: Assumes a proper directed acyclic graph of revisions
-			// Cycles will cause infinite loops.
-			List<String> allDescendents = new LinkedList<String>();
-			for(String replaced : directDescendents) {
-				List<String> roots = PDBStatus.getReplaces(replaced, recurse);
-				mergeReversed(allDescendents,roots);
-			}
-			mergeReversed(allDescendents,Arrays.asList(directDescendents));
-
-			return allDescendents;
+		} else if (st == Status.CURRENT) {
+			return oldPdbId;
 		} else {
-			return Arrays.asList(directDescendents);
-		}
-	}
-
-
-	/**
-	 * The status of PDB IDs are cached to reduce server overload.
-	 *
-	 * This method clears the cached records.
-	 */
-	public static void clearCache() {
-		recordsCache.clear();
-	}
-
-	/**
-	 * Fetches the status of one or more pdbIDs from the server.
-	 *
-	 * <p>
-	 * Returns the results as a list of Attributes.
-	 * Each attribute should contain "structureId" and "status" attributes, and
-	 * possibly more.
-	 *
-	 * <p>
-	 * Example:
-	 * <p>
-	 * <tt>http://www.rcsb.org/pdb/rest/idStatus?structureID=1HHB,4HHB</tt></br>
-	 * <pre>
-	 * &lt;idStatus&gt;
-	 *   &lt;record structureId="1HHB" status="OBSOLETE" replacedBy="4HHB"/&gt;
-	 *   &lt;record structureId="4HHB" status="CURRENT" replaces="1HHB"/&gt;
-	 * &lt;/idStatus&gt;
-	 * </pre>
-	 *
-	 * <p>
-	 * Results are not guaranteed to be returned in the same order as pdbIDs.
-	 * Refer to the structureId property to match them.
-	 *
-	 * @param pdbIDs the PDB identifiers
-	 * @return A map between attributes and values
-	 */
-	private static List<Map<String, String>> getStatusIdRecords(String[] pdbIDs) throws IOException {
-
-		List<Map<String,String>> result = new ArrayList<>(pdbIDs.length);
-
-		String serverName = DEFAULT_RCSB_DATA_API_SERVER;
-
-		// Build REST query URL
-		if(pdbIDs.length < 1) {
-			throw new IllegalArgumentException("No pdbIDs specified");
-		}
-		String urlStr = String.format("http://%s/pdb/rest/idStatus?structureId=",serverName);
-		for(String pdbId : pdbIDs) {
-			pdbId = pdbId.toUpperCase();
-			//check the cache
-			if (recordsCache.containsKey(pdbId)) {
-				//logger.debug("Fetching "+pdbId+" from Cache");
-				result.add( recordsCache.get(pdbId) );
-			} else {
-				urlStr += pdbId + ",";
-			}
+			return null;
 		}
 
-		// check if any ids still need fetching
-		if(urlStr.charAt(urlStr.length()-1) == '=') {
-			return result;
-		}
-
-		logger.info("Fetching {}", urlStr);
-
-		URL url = new URL(urlStr);
-
-		InputStream uStream = url.openStream();
-
-		InputSource source = new InputSource(uStream);
-		SAXParserFactory parserFactory = SAXParserFactory.newInstance();
-		SAXParser parser = parserFactory.newSAXParser();
-		XMLReader reader = parser.getXMLReader();
-
-		PDBStatusXMLHandler handler = new PDBStatusXMLHandler();
-
-		reader.setContentHandler(handler);
-		reader.parse(source);
-
-		// Fetch results of SAX parsing
-		List<Map<String, String>> records = handler.getRecords();
-
-		//add to cache
-		for (Map<String, String> record : records) {
-			String pdbId = record.get("structureId").toUpperCase();
-			if (pdbId != null) {
-				recordsCache.put(pdbId, record);
-			}
-		}
-
-		// return results
-		result.addAll(handler.getRecords());
-
-		return result;
 	}
 
 	/**
@@ -615,11 +174,8 @@ public class PDBStatus {
 	 */
 	public static SortedSet<String> getCurrentPDBIds() throws IOException {
 
-		//String serverName = System.getProperty(PDB_SERVER_PROPERTY);
-		String serverName = DEFAULT_RCSB_DATA_API_SERVER;
-
 		// Build REST query URL
-		String urlStr = String.format(ALL_CURRENT_ENDPOINT, serverName);
+		String urlStr = String.format(ALL_CURRENT_ENDPOINT, DEFAULT_RCSB_DATA_API_SERVER);
 		URL u = new URL(urlStr);
 
 		InputStream stream = URLConnectionTools.getInputStream(u, 60000);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBStatus.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBStatus.java
@@ -59,7 +59,6 @@ public class PDBStatus {
 	/**
 	 * Represents a simplified 3 state status of PDB IDs.
 	 * @author Spencer Bliven
-	 *
 	 */
 	public enum Status {
 		// the simplified status enum in rcsb_repository_holdings_combined
@@ -87,10 +86,10 @@ public class PDBStatus {
 	}
 
 	/**
-	 * Get the status of the PDB in question.
+	 * Get the status of a PDB id.
 	 *
 	 * @param pdbId the id
-	 * @return The status, or null if an error occurred.
+	 * @return The status.
 	 */
 	public static Status getStatus(String pdbId) throws IOException {
 		URL url = new URL(String.format(STATUS_ENDPOINT, DEFAULT_RCSB_DATA_API_SERVER, pdbId.toUpperCase()));
@@ -100,11 +99,11 @@ public class PDBStatus {
 	}
 
 	/**
-	 * Get the status of the a collection of PDBs in question in a single query.
+	 * Get the status of a collection of PDB ids (in a single API query).
 	 *
 	 * @see #getStatus(String)
 	 * @param pdbIds the ids
-	 * @return The status array, or null if an error occurred.
+	 * @return The status array
 	 */
 	public static Status[] getStatus(String[] pdbIds) throws IOException {
 
@@ -130,6 +129,7 @@ public class PDBStatus {
 	}
 
 	private static Status parseStatusRecord(JsonNode jsonNode) {
+		// e.g.
 		// "rcsb_repository_holdings_combined": {
 		//"id_code_replaced_by_latest": "4HHB",
 		//"status": "REMOVED",

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
@@ -492,7 +492,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 			}
 			return downloadStructure(current, splitDirURL,false, existing);
 		} else if(obsoleteBehavior == ObsoleteBehavior.FETCH_OBSOLETE
-				&& PDBStatus.getStatus(pdbId) == Status.OBSOLETE) {
+				&& PDBStatus.getStatus(pdbId) == Status.REMOVED) {
 			return downloadStructure(pdbId, obsoleteDirURL, true, existing);
 		} else {
 			return downloadStructure(pdbId, splitDirURL, false, existing);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/PDBStatusTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/PDBStatusTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-
 /**
  * @author Spencer Bliven <sbliven@ucsd.edu>
  *
@@ -47,6 +46,15 @@ public class PDBStatusTest {
 		Assert.assertEquals(Status.REMOVED, PDBStatus.getStatus("1HHB"));
 		Assert.assertEquals(Status.CURRENT, PDBStatus.getStatus("3HHB"));
 		Assert.assertEquals(Status.CURRENT, PDBStatus.getStatus("4HHB"));
+	}
+
+	@Test
+	public void testGetStatusMultipleIds() throws IOException {
+		String[] ids = {"1HHB", "3HHB", "4HHB"};
+		Status[] statuses = PDBStatus.getStatus(ids);
+		Assert.assertEquals(Status.REMOVED, statuses[0]);
+		Assert.assertEquals(Status.CURRENT, statuses[1]);
+		Assert.assertEquals(Status.CURRENT, statuses[2]);
 	}
 
 	@Test

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/PDBStatusTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/PDBStatusTest.java
@@ -18,17 +18,14 @@
  *      http://www.biojava.org/
  *
  */
-/**
- *
- */
 package org.biojava.nbio.structure;
 
 import org.biojava.nbio.structure.PDBStatus.Status;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.lang.reflect.Method;
-import java.util.*;
+import java.io.IOException;
+
 
 /**
  * @author Spencer Bliven <sbliven@ucsd.edu>
@@ -46,172 +43,20 @@ public class PDBStatusTest {
 	 *</pre>
 	 */
 	@Test
-	public void testGetStatus() {
-		Assert.assertEquals(Status.OBSOLETE, PDBStatus.getStatus("1HHB"));
+	public void testGetStatus() throws IOException {
+		Assert.assertEquals(Status.REMOVED, PDBStatus.getStatus("1HHB"));
 		Assert.assertEquals(Status.CURRENT, PDBStatus.getStatus("3HHB"));
 		Assert.assertEquals(Status.CURRENT, PDBStatus.getStatus("4HHB"));
 	}
 
 	@Test
-	public void testGetReplacement() {
-		Assert.assertFalse(Arrays.asList("YES").equals(Arrays.asList("NO"))); //check for deep equals
-
-		// 1CMW is replacedBy NONE
-		Assert.assertEquals(Arrays.asList(), PDBStatus.getReplacement("1CMW", true, false));
-		Assert.assertEquals(Arrays.asList("1CMW"), PDBStatus.getReplacement("1CMW", true, true));
-
-		// 1HHB is replacedBy 2-4HHB
-		Assert.assertEquals(Arrays.asList("3HHB"), PDBStatus.getReplacement("3HHB", false, false));
-		Assert.assertEquals(Arrays.asList("3HHB"), PDBStatus.getReplacement("3HHB", false, true));
-		Assert.assertEquals(Arrays.asList("4HHB", "3HHB", "2HHB"), PDBStatus.getReplacement("1HHB", false, false));
-		Assert.assertEquals(Arrays.asList("4HHB", "3HHB", "2HHB", "1HHB"), PDBStatus.getReplacement("1HHB", false, true));
-
-		// 1CAT is replacedBy 3CAT is replacedBy 7-8CAT
-		Assert.assertEquals(Arrays.asList("8CAT", "7CAT", "3CAT", "1CAT"), PDBStatus.getReplacement("1CAT", true, true));
-		Assert.assertEquals(Arrays.asList("8CAT", "7CAT"), PDBStatus.getReplacement("1CAT", true, false));
-		Assert.assertEquals(Arrays.asList("8CAT", "7CAT", "3CAT"), PDBStatus.getReplacement("3CAT", true, true));
-		Assert.assertEquals(Arrays.asList("8CAT", "7CAT"), PDBStatus.getReplacement("3CAT", true, false));
-	}
-
-
-	@Test
-	public void testGetCurrent() {
+	public void testGetCurrent() throws IOException {
 		Assert.assertEquals("4HHB", PDBStatus.getCurrent("1HHB"));
 		Assert.assertEquals("3HHB", PDBStatus.getCurrent("3HHB"));
-		Assert.assertEquals(null, PDBStatus.getCurrent("1CMW"));
+		Assert.assertNull(PDBStatus.getCurrent("1CMW"));
 		Assert.assertEquals("3ENI", PDBStatus.getCurrent("1KSA"));
 		Assert.assertEquals("8CAT", PDBStatus.getCurrent("1CAT"));
 		Assert.assertEquals("8CAT", PDBStatus.getCurrent("3CAT"));
 		Assert.assertEquals("7CAT", PDBStatus.getCurrent("7CAT"));
 	}
-
-	@Test
-	public void testGetReplaces() {
-		Assert.assertEquals(new ArrayList<String>(), Arrays.asList(new String[]{}));
-
-		Assert.assertEquals(Arrays.asList("1HHB"), PDBStatus.getReplaces("4HHB", false));
-		Assert.assertEquals(Arrays.asList("1HHB"), PDBStatus.getReplaces("3HHB", false));
-		Assert.assertEquals(Arrays.asList(), PDBStatus.getReplaces("1HHB", false));
-		Assert.assertEquals(Arrays.asList("1M50", "1KSA"), PDBStatus.getReplaces("3ENI", false));
-		Assert.assertEquals(Arrays.asList("1M50", "1KSA"), PDBStatus.getReplaces("3ENI", true));
-		Assert.assertEquals(Arrays.asList("3CAT"), PDBStatus.getReplaces("8CAT", false));
-		Assert.assertEquals(Arrays.asList("3CAT", "1CAT"), PDBStatus.getReplaces("8CAT", true));
-
-	}
-
-	/**
-	 * Tests a helper method for merging that was giving me problems
-	 */
-	@Test
-	public void testMergeReversed() {
-		try {
-			Method mergeReversed = PDBStatus.class.getDeclaredMethod("mergeReversed",
-					List.class,List.class);
-			mergeReversed.setAccessible(true);
-
-
-			List<String> a,b;
-
-			b = Arrays.asList("F","A");
-			a = new LinkedList<String>();
-			mergeReversed.invoke(null, a,b);
-			Assert.assertEquals(Arrays.asList("F", "A"), a);
-
-			a = new LinkedList<String>();
-			a.add("B");
-			mergeReversed.invoke(null, a,b);
-			Assert.assertEquals(Arrays.asList("F", "B", "A"), a);
-
-			a = new LinkedList<String>();
-			a.add("G");
-			mergeReversed.invoke(null, a,b);
-			Assert.assertEquals(Arrays.asList("G", "F", "A"), a);
-
-			a = new LinkedList<String>();
-			a.add("1");
-			mergeReversed.invoke(null, a,b);
-			Assert.assertEquals(Arrays.asList("F", "A", "1"), a);
-
-			a = new LinkedList<String>();
-			a.add("G");
-			a.add("1");
-			mergeReversed.invoke(null, a,b);
-			Assert.assertEquals(Arrays.asList("G", "F", "A", "1"), a);
-
-			b = Arrays.asList();
-			mergeReversed.invoke(null, a,b);
-			Assert.assertEquals(Arrays.asList("G", "F", "A", "1"), a);
-
-			b = Arrays.asList("G","D","C","A");
-			a = new LinkedList<String>();
-			a.add("F");
-			a.add("B");
-			a.add("1");
-			mergeReversed.invoke(null, a,b);
-			Assert.assertEquals(Arrays.asList("G", "F", "D", "C", "B", "A", "1"), a);
-
-		} catch(Exception e) {
-			e.printStackTrace();
-			Assert.fail(e.getMessage());
-		}
-	}
-
-	/**
-	 * Test low-level connectivity to the PDB
-	 */
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testGetStatusIdRecords() {
-		try {
-		Method getStatusIdRecords = PDBStatus.class.getDeclaredMethod("getStatusIdRecords",
-				String[].class);
-		getStatusIdRecords.setAccessible(true);
-
-
-			List<Map<String,String>> attrsList;
-			String[] pdbIds;
-			Map<String,String> attrs;
-
-			// Test invocation with a single ID
-			pdbIds = new String[] {"1HHB"};
-			attrsList = (List<Map<String,String>>) getStatusIdRecords.invoke(null, (Object) pdbIds);
-			Assert.assertEquals("Wrong number of records.", 1, attrsList.size());
-			attrs = attrsList.get(0);
-			Assert.assertEquals("Wrong number of attributes", 3, attrs.size());
-			Assert.assertEquals("Wrong structureId", "1HHB", attrs.get("structureId"));
-			Assert.assertEquals("Wrong status", "OBSOLETE", attrs.get("status"));
-			Assert.assertEquals("Wrong replacedBy", "4HHB 3HHB 2HHB", attrs.get("replacedBy"));
-
-			// Test with multiple IDs
-			pdbIds = new String[] {"1HHB","4HHB"};
-			attrsList = (List<Map<String,String>>) getStatusIdRecords.invoke(null, (Object) pdbIds);
-			Assert.assertEquals("Wrong number of records.", 2, attrsList.size());
-			attrs = attrsList.get(1);
-			Assert.assertEquals("Wrong number of attributes", 3, attrs.size());
-			Assert.assertEquals("Wrong structureId", "4HHB", attrs.get("structureId"));
-			Assert.assertEquals("Wrong status", "CURRENT", attrs.get("status"));
-			Assert.assertEquals("Wrong replaces", "1HHB", attrs.get("replaces"));
-			attrs = attrsList.get(0);
-			Assert.assertEquals("Wrong number of attributes", 3, attrs.size());
-			Assert.assertEquals("Wrong structureId", "1HHB", attrs.get("structureId"));
-			Assert.assertEquals("Wrong status", "OBSOLETE", attrs.get("status"));
-			Assert.assertEquals("Wrong replacedBy", "4HHB 3HHB 2HHB", attrs.get("replacedBy"));
-
-			// Test invocation with a single ID
-			pdbIds = new String[] {"3ENI"};
-			attrsList = (List<Map<String,String>>) getStatusIdRecords.invoke(null, (Object) pdbIds);
-			Assert.assertEquals("Wrong number of records.", 1, attrsList.size());
-			attrs = attrsList.get(0);
-			Assert.assertEquals("Wrong number of attributes", 3, attrs.size());
-			Assert.assertEquals("Wrong structureId", "3ENI", attrs.get("structureId"));
-			Assert.assertEquals("Wrong status", "CURRENT", attrs.get("status"));
-			Assert.assertEquals("Wrong replacedBy", "1M50 1KSA", attrs.get("replaces"));
-
-
-		} catch(Exception e) {
-			e.printStackTrace();
-			Assert.fail(e.getMessage());
-		}
-	}
-
 }


### PR DESCRIPTION
This replaces the legacy RCSB PDB API by the current one, so that `PDBStatus` continues working after legacy APIs are shutdown in December.

This is a breaking change with a changed `Status` enum and 2 fewer methods (getReplace, getReplaces). All documented in CHANGELOG

