### PR TITLE
Flaky Test Fixed in TestStructureSerialization

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
@@ -108,6 +108,7 @@ public class PDBHeader implements PDBRecord {
 			Class<?> c = Class.forName(PDBHeader.class.getName());
 			Method[] methods  = c.getMethods();
 
+			Arrays.sort(methods, (o1, o2)->o1.getName().compareTo(o2.getName()));
 			for (Method m : methods) {
 				String name = m.getName();
 


### PR DESCRIPTION
The test `org.biojava.nbio.structure.io.TestStructureSerialization#testSerializeStructure` is flaky due to the order in which Methods are appended into the StringBuilder `str.append(pdbHeader);` which is built in the toString method of the StructureImpl class.

The flakiness is observed due to the non-deterministic order of pdbHeader that can produce different structures.

The flaky test is fixed by sorting the array of Methods in PDBHeader.java class using a custom comparator in the toString method.