### PR TITLE
Fixing bug that even leads incompatible string to be passed to Integer.parseInt

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmcif/SimpleMMcifParser.java
@@ -1021,7 +1021,8 @@ public class SimpleMMcifParser implements MMcifParser {
 
 			try {
 				if ( pType[0].getName().equals(Integer.class.getName())) {
-					if ( val != null && ! val.equals("?") && !val.equals(".")) {
+// 					if ( val != null && ! val.equals("?") && !val.equals(".")) {
+					if(checkIfValidStrForIntConversion(val)) {
 
 						Integer intVal = Integer.parseInt(val);
 						setter.invoke(o, intVal);
@@ -1040,6 +1041,19 @@ public class SimpleMMcifParser implements MMcifParser {
 		return o;
 	}
 
+	private boolean checkIfValidStrForIntConversion(String val) {
+
+		if(val == null || val.isEmpty())
+			return false;
+
+		//val should not contain anything apart from digits from 0 to 9.
+		for(char ch : val.toCharArray()) {
+			if(ch < '0' || ch > '9')
+				return false;
+		}
+		return true;
+	}
+	
 	private void produceWarning(String key, String val, Class<?> c, Set<String> warnings) {
 
 		String warning = "Trying to set field " + key + " in "+ c.getName() +" found in file, but no corresponding field could be found in model class (value:" + val + ")";


### PR DESCRIPTION
Initially, some of the tests failed, because the following logic in SimpleMMcifParser.java does not prevent invalid strings from being passed to Integer.parseInt()

`if ( val != null && ! val.equals("?") && !val.equals("."))`
If val is either "?" or ".", it will still return a true because of the presence of && operator. 

I have written a generic function that would prevent any invalid string from being passed to an Integer.parseInt():
The module checkIfValidStrForIntConversion_ returns a boolean value. The logic states that if the string to be parsed to Integer is either null or empty or contains any characters apart from digits 0-9, the method would return a false. In all other cases, it will return a true.