### PR TITLE
Fixing flaky test in AlignmentToolsTest.java

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/align/AlignmentToolsTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/align/AlignmentToolsTest.java
@@ -320,7 +320,7 @@ public class AlignmentToolsTest {
 		String result,expected;
 		int i=0;
 
-		test = new HashMap<Integer, Integer>();
+		test = new LinkedHashMap<Integer, Integer>();
 		test.put(1, 2);
 		test.put(2, 3);
 		test.put(3, 4);
@@ -331,7 +331,7 @@ public class AlignmentToolsTest {
 		Assert.assertEquals((i++) + ". Linear strings.", expected, result);
 
 
-		test = new HashMap<Integer, Integer>();
+		test = new LinkedHashMap<Integer, Integer>();
 		test.put(1, 2);
 		test.put(2, 3);
 		test.put(3, 1);
@@ -341,7 +341,7 @@ public class AlignmentToolsTest {
 		result = AlignmentTools.toConciseAlignmentString(test);
 		Assert.assertEquals((i++) + ". Cycles.", expected, result);
 
-		test = new HashMap<Integer, Integer>();
+		test = new LinkedHashMap<Integer, Integer>();
 		test.put(1, 2);
 		test.put(2, 3);
 		test.put(3, 1);
@@ -351,7 +351,7 @@ public class AlignmentToolsTest {
 		result = AlignmentTools.toConciseAlignmentString(test);
 		Assert.assertEquals((i++) + ". Complex.", expected, result);
 
-		test = new HashMap<Integer, Integer>();
+		test = new LinkedHashMap<Integer, Integer>();
 		test.put(1, 2);
 		test.put(2, 3);
 		test.put(3, 4);
@@ -376,7 +376,7 @@ public class AlignmentToolsTest {
 		result = AlignmentTools.toConciseAlignmentString(test);
 		Assert.assertEquals((i++) + ". Sub-optimal arrangement", expected, result);
 
-		Map <Integer,Double> test2 = new HashMap<Integer, Double>();
+		Map <Integer,Double> test2 = new LinkedHashMap<Integer, Double>();
 		test2.put(1, 12.);
 		test2.put(2, 13.);
 		test2.put(3, 14.);


### PR DESCRIPTION
The test `AlignmentToolsTest#testToConciseAlignmentString` is flaky due to the order dependence in `AlignmentTools` class `toConciseAlignmentString` method in `S seedNode = alig.keySet().iterator().next();` to which the HashMap is passed from the test `testToConciseAlignmentString`.  Due to the non-deterministic order of iteration, it can be produce different structures since the Oracle specification about HashMap says that "This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time." The documentation is here for your reference:https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html

The retrieval of the elements using keySet() can be non-deterministic for a HashMap and can cause `AlignmentToolsTest#testToConciseAlignmentString` to be a flaky test. The HashMap is now replaced with the LinkedHashMap so that the non-deterministic iteration order of HashMap is eliminated.
