### PR TITLE
Revert "Flaky Test Fixed in TestStructureSerialization"

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
@@ -108,7 +108,6 @@ public class PDBHeader implements PDBRecord {
 			Class<?> c = Class.forName(PDBHeader.class.getName());
 			Method[] methods  = c.getMethods();
 
-			Arrays.sort(methods, (o1, o2)->o1.getName().compareTo(o2.getName()));
 			for (Method m : methods) {
 				String name = m.getName();
 


### PR DESCRIPTION
Reverts biojava/biojava#903

I may have been hasty on mergin #903, which changes mmcif output column order.