### PR TITLE
Fix #917: Symmetry doesn't display with non-US locales

### DIFF
--- a/biojava-structure-gui/pom.xml
+++ b/biojava-structure-gui/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>net.sourceforge.jmol</groupId>
             <artifactId>jmol</artifactId>
-            <version>14.29.17</version>
+            <version>14.31.10</version>
         </dependency>
         <!-- logging dependencies (managed by parent pom, don't set versions or
             scopes here) -->

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/jmolScript/JmolSymmetryScriptGenerator.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/jmolScript/JmolSymmetryScriptGenerator.java
@@ -29,6 +29,7 @@ import javax.vecmath.Matrix4d;
 import javax.vecmath.Tuple3d;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -226,11 +227,11 @@ public abstract class JmolSymmetryScriptGenerator {
 	}
 
 	protected static String f1Dot2(float number) {
-		return String.format("%1.2f", number);
+		return String.format(Locale.US, "%1.2f", number);
 	}
 
 	protected static String fDot2(double number) {
-		return String.format("%.2f", number);
+		return String.format(Locale.US, "%.2f", number);
 	}
 
 	/**

--- a/biojava-structure-gui/src/test/java/org/biojava/nbio/structure/symmetry/TestJmolSymmetryScriptGenerator.java
+++ b/biojava-structure-gui/src/test/java/org/biojava/nbio/structure/symmetry/TestJmolSymmetryScriptGenerator.java
@@ -1,0 +1,67 @@
+/*
+ *                    BioJava development code
+ *
+ * This code may be freely distributed and modified under the
+ * terms of the GNU Lesser General Public Licence.  This should
+ * be distributed with the code.  If you do not have a copy,
+ * see:
+ *
+ *      http://www.gnu.org/copyleft/lesser.html
+ *
+ * Copyright for this code is held jointly by the individual
+ * authors.  These should be listed in @author doc comments.
+ *
+ * For more information on the BioJava project and its aims,
+ * or to join the biojava-l mailing list, visit the home page
+ * at:
+ *
+ *      http://www.biojava.org/
+ *
+ */
+package org.biojava.nbio.structure.symmetry;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.StructureException;
+import org.biojava.nbio.structure.StructureIO;
+import org.biojava.nbio.structure.cluster.SubunitCluster;
+import org.biojava.nbio.structure.cluster.SubunitClustererParameters;
+import org.biojava.nbio.structure.symmetry.axis.RotationAxisAligner;
+import org.biojava.nbio.structure.symmetry.core.QuatSymmetryDetector;
+import org.biojava.nbio.structure.symmetry.core.QuatSymmetryParameters;
+import org.biojava.nbio.structure.symmetry.core.QuatSymmetryResults;
+import org.biojava.nbio.structure.symmetry.core.RotationGroup;
+import org.biojava.nbio.structure.symmetry.core.Stoichiometry;
+import org.biojava.nbio.structure.symmetry.core.SymmetryPerceptionMethod;
+import org.biojava.nbio.structure.symmetry.jmolScript.JmolSymmetryScriptGeneratorDn;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Spencer Bliven
+ */
+public class TestJmolSymmetryScriptGenerator {
+    @Before
+    public void setUp() {
+    }
+
+    @Test
+    public void testPolygon() throws IOException, StructureException {
+        Structure struc = StructureIO.getStructure("4hhb");
+        QuatSymmetryParameters sp = new QuatSymmetryParameters();
+		SubunitClustererParameters cp = new SubunitClustererParameters();
+
+        QuatSymmetryResults results = QuatSymmetryDetector.calcGlobalSymmetry(struc, sp, cp);
+        RotationAxisAligner axis = new RotationAxisAligner(results);
+        JmolSymmetryScriptGeneratorDn gen = new JmolSymmetryScriptGeneratorDn(axis, "D3");
+
+        String poly = gen.drawPolyhedron();
+        String expected = "draw polyhedronD30 line{30.02,-39.95,0.59}{29.24,-0.53,40.00}{30.02,38.89,0.59}{30.80,-0.53,-38.82}{30.02,-39.95,0.59}{-30.00,-39.95,-0.60}{-30.79,-0.53,38.81}{-30.00,38.89,-0.60}{-29.22,-0.53,-40.01}{-30.00,-39.95,-0.60}width 0.45 color [x42ffd9] off;draw polyhedronD31 line{29.24,-0.53,40.00}{-30.79,-0.53,38.81}width 0.45 color [x42ffd9] off;draw polyhedronD32 line{30.02,38.89,0.59}{-30.00,38.89,-0.60}width 0.45 color [x42ffd9] off;draw polyhedronD33 line{30.80,-0.53,-38.82}{-29.22,-0.53,-40.01}width 0.45 color [x42ffd9] off;";
+        assertEquals(expected, poly);
+    }
+}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/ZipChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/ZipChemCompProvider.java
@@ -206,7 +206,8 @@ public class ZipChemCompProvider implements ChemCompProvider{
         final String filename = "chemcomp/" + recordName + ".cif.gz";
 
         // try with resources block to read from the filesystem.
-        try (FileSystem fs = FileSystems.newFileSystem(m_zipFile, null)) {
+        // Don't remove the (ClassLoader) cast! It is required for openjdk 11.
+        try (FileSystem fs = FileSystems.newFileSystem(m_zipFile, (ClassLoader)null)) {
             Path cif = fs.getPath(filename);
 
             if (Files.exists(cif)) {
@@ -255,7 +256,8 @@ public class ZipChemCompProvider implements ChemCompProvider{
 		*/
 
         // Copy in each file.
-        try (FileSystem zipfs = FileSystems.newFileSystem(zipFile, null)) {
+        // Don't remove the (ClassLoader) cast! It is required for openjdk 11.
+        try (FileSystem zipfs = FileSystems.newFileSystem(zipFile, (ClassLoader)null)) {
             Files.createDirectories(pathWithinArchive);
             for (File f : files) {
                 if (!f.isDirectory() && f.exists()) {

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
@@ -222,6 +222,15 @@ public class TestAtomCache {
 	}
 
 	@Test
+	public void testGetScopDomain() throws IOException, StructureException {
+		String name = "d2gs2a_";
+
+		Structure s = cache.getStructure(name);
+		assertNotNull("Failed to fetch structure from SCOP ID", s);
+		assertEquals("2gs2.A", s.getName());
+	}
+
+	@Test
 	public void testSettingFileParsingType(){
 		AtomCache cache = new AtomCache();
 


### PR DESCRIPTION
The core of this is the locale fix, which is necessary for CESymm/QuatSymm to function properly on non-US systems.

I've also included some commits for general cleanup and tests. If any of these are controversial I can revert them or move them to separate PRs.