### PR TITLE
Github issue 843 - Genebank parser

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
@@ -222,7 +222,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 					Qualifier q = new Qualifier(key, val.replace('\n', ' '));
 					gbFeature.addQualifier(key, q);
 				} else {
-					if (key.equalsIgnoreCase("translation")) {
+					if (key.equalsIgnoreCase("translation") || key.equals("anticodon")) {
 						// strip spaces from sequence
 						val = val.replaceAll("\\s+", "");
 						Qualifier q = new Qualifier(key, val);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
@@ -222,7 +222,8 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 					Qualifier q = new Qualifier(key, val.replace('\n', ' '));
 					gbFeature.addQualifier(key, q);
 				} else {
-					if (key.equalsIgnoreCase("translation") || key.equals("anticodon")) {
+					if (key.equalsIgnoreCase("translation") || key.equals("anticodon")
+							|| key.equals("transl_except")) {
 						// strip spaces from sequence
 						val = val.replaceAll("\\s+", "");
 						Qualifier q = new Qualifier(key, val);

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
@@ -333,7 +333,7 @@ public class GenbankReaderTest {
 	/**
 	 * Biojava fails to parse anticodon and transl_except feature qualifiers when they line wrap.
 	 * https://github.com/biojava/biojava/issues/843
-	 * File NC_018080.gb downloaded from https://www.ncbi.nlm.nih.gov/nuccore/NC_018080
+	 * Except file NC_018080.gb from https://www.ncbi.nlm.nih.gov/nuccore/NC_018080
 	 */
 	@Test
 	public void testGithub843() throws Exception {

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
@@ -353,11 +353,10 @@ public class GenbankReaderTest {
 		DNASequence dna = new ArrayList<>(dnaSequences.values()).get(0);
 		assertNotNull(dna);
 
-		for (Iterator<FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound>> it = dna.getFeaturesByType("tRNA").iterator(); it.hasNext();) {
-			FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound> tRNAFeature = it.next();
-			String anticodon = tRNAFeature.getQualifiers().get("anticodon").get(0).getValue();
-			assertFalse(anticodon.contains(" "));
-		}
+		FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound> tRNAFeature = dna.getFeaturesByType("tRNA").get(0);
+		String anticodon = tRNAFeature.getQualifiers().get("anticodon").get(0).getValue();
+		assertEquals("(pos:complement(1123552..1123554),aa:Leu,seq:caa)", anticodon);
+
 	}
 
 	/**

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
@@ -36,10 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
@@ -331,6 +328,36 @@ public class GenbankReaderTest {
 		assertEquals(7028, (int)fLocation.getStart().getPosition());
 		assertEquals(286, (int)fLocation.getEnd().getPosition());
 		assertEquals(Strand.NEGATIVE, fLocation.getStrand());
+	}
+
+	/**
+	 * Biojava fails to parse anticodon and transl_except feature qualifiers when they line wrap.
+	 * https://github.com/biojava/biojava/issues/843
+	 * File NC_018080.gb downloaded from https://www.ncbi.nlm.nih.gov/nuccore/NC_018080
+	 */
+	@Test
+	public void testGithub843() throws Exception {
+		CheckableInputStream inStream = new CheckableInputStream(this.getClass().getResourceAsStream("/NC_018080.gb"));
+		assertNotNull(inStream);
+
+		GenbankReader<DNASequence, NucleotideCompound> genbankDNA
+				= new GenbankReader<>(
+				inStream,
+				new GenericGenbankHeaderParser<>(),
+				new DNASequenceCreator(DNACompoundSet.getDNACompoundSet())
+		);
+
+		LinkedHashMap<String, DNASequence> dnaSequences = genbankDNA.process();
+		assertNotNull(dnaSequences);
+
+		DNASequence dna = new ArrayList<>(dnaSequences.values()).get(0);
+		assertNotNull(dna);
+
+		for (Iterator<FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound>> it = dna.getFeaturesByType("tRNA").iterator(); it.hasNext();) {
+			FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound> tRNAFeature = it.next();
+			String anticodon = tRNAFeature.getQualifiers().get("anticodon").get(0).getValue();
+			assertFalse(anticodon.contains(" "));
+		}
 	}
 
 	/**

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankReaderTest.java
@@ -333,7 +333,6 @@ public class GenbankReaderTest {
 	/**
 	 * Biojava fails to parse anticodon and transl_except feature qualifiers when they line wrap.
 	 * https://github.com/biojava/biojava/issues/843
-	 * Except file NC_018080.gb from https://www.ncbi.nlm.nih.gov/nuccore/NC_018080
 	 */
 	@Test
 	public void testGithub843() throws Exception {
@@ -356,7 +355,8 @@ public class GenbankReaderTest {
 		FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound> tRNAFeature = dna.getFeaturesByType("tRNA").get(0);
 		String anticodon = tRNAFeature.getQualifiers().get("anticodon").get(0).getValue();
 		assertEquals("(pos:complement(1123552..1123554),aa:Leu,seq:caa)", anticodon);
-
+		String transl_except = tRNAFeature.getQualifiers().get("transl_except").get(0).getValue();
+		assertEquals("(pos:complement(1123552..1123554),aa:Leu)",transl_except);
 	}
 
 	/**

--- a/biojava-core/src/test/resources/NC_018080.gb
+++ b/biojava-core/src/test/resources/NC_018080.gb
@@ -21,6 +21,8 @@ FEATURES             Location/Qualifiers
                      gene prediction method: tRNAscan-SE."
                      /anticodon=(pos:complement(1123552..1123554),aa:Leu,
                      seq:caa)
+                     /transl_except=(pos:complement(1123552..1123554),
+                     aa:Leu)
 ORIGIN
         1 tttaaagaga ccggcgattc tagtgaaatc gaacgggcag gtcaatttcc aaccagcgat
 //


### PR DESCRIPTION
#### Reference Issue
Partly fixes #843 

#### What does this implement/fix? Explain your changes.
- Corrected GenbankReader.java to parse anticodon qualifiers when they line wrap.
- Wrote new testGithub843 in GenbankReaderTest.java
- Added mentioned file NC_018080.gb downloaded from https://www.ncbi.nlm.nih.gov/nuccore/NC_018080

#### Additional comments
@josemduarte , can you please tell me where I can get NC_018080 in .embl file format? I couldn't find it.