### PR TITLE
Bugfix: unknown residues were not looked up properly

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/ChemCompGroupFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/ChemCompGroupFactory.java
@@ -111,7 +111,7 @@ public class ChemCompGroupFactory {
         String oneLetter = cc.getOneLetterCode();
         if (oneLetter == null || oneLetter.equals("X") || oneLetter.equals("?")) {
             String parentId = cc.getMonNstdParentCompId();
-            if (parentId == null) {
+            if (parentId == null || parentId.trim().equals("")) {
                 return oneLetter;
             }
             // cases like OIM have multiple parents (comma separated), we shouldn't try grab a chemcomp for those strings


### PR DESCRIPTION
`ChemCompGroupFactory.getOneLetterCode(Chemcomp)` would try to get a chemcomp for an empty identifier ".cif", because parent chemcomp from the new `ChemComp` object is an empty string rather than null. 

This fixes the problem. But I'd like @JonStargaryen to have a look at this and see if we need to make `ChemComp.monNstdParentCompId` default to null instead.