### PR TITLE
ChemComp#monNstdParentCompId now returns null instead of empty String

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/ChemComp.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/ChemComp.java
@@ -149,7 +149,7 @@ public class ChemComp implements CifBean, Comparable<ChemComp> {
     }
 
     public void setMonNstdParentCompId(String monNstdParentCompId) {
-        this.monNstdParentCompId = monNstdParentCompId.isEmpty() ? null : monNstdParentCompId;
+        this.monNstdParentCompId = (monNstdParentCompId == null || monNstdParentCompId.isEmpty()) ? null : monNstdParentCompId;
         setStandardFlag();
     }
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/ChemComp.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/ChemComp.java
@@ -149,7 +149,7 @@ public class ChemComp implements CifBean, Comparable<ChemComp> {
     }
 
     public void setMonNstdParentCompId(String monNstdParentCompId) {
-        this.monNstdParentCompId = monNstdParentCompId;
+        this.monNstdParentCompId = monNstdParentCompId.isEmpty() ? null : monNstdParentCompId;
         setStandardFlag();
     }
 


### PR DESCRIPTION
ChemComps without parent would erroneously return an empty String. This restores the old behavior and will return `null`.
This fixes #921.