### PR TITLE
fix logging in CifStructureConsumerImpl if type symbol is unknown

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
@@ -332,7 +332,7 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
                 atom.setElement(element);
             }  catch (IllegalArgumentException e) {
                 logger.info("Element {} was not recognised as a BioJava-known element, the element will be " +
-                        "represented as the generic element {}", typeSymbol, Element.R.name());
+                        "represented as the generic element {}", ts, Element.R.name());
                 atom.setElement(Element.R);
             }
 


### PR DESCRIPTION
- log statement mistakenly referenced `typeSymbol` (which is now the CifColumn object)
- led to cryptic log messages like: `org.biojava.nbio.structure.io.cif.CifStructureConsumerImpl - Element org.rcsb.cif.schema.DelegatingStrColumn@13353fd2 was not recognised as a BioJava-known element, the element will be represented as the generic element R`
- fixed to log like previously: `org.biojava.nbio.structure.io.cif.CifStructureConsumerImpl - Element X was not recognised as a BioJava-known element, the element will be represented as the generic element R`