### PR TITLE
Cif reader file parsing parameters fix

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/URLIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/URLIdentifier.java
@@ -153,7 +153,7 @@ public class URLIdentifier implements StructureIdentifier {
 
 		switch(format) {
 			case CIF: case BCIF:
-				return CifStructureConverter.fromURL(url);
+				return CifStructureConverter.fromURL(url, cache.getFileParsingParams());
 			case MMTF:
 				return MmtfActions.readFromInputStream(url.openStream());
 			default: case PDB:

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConverter.java
@@ -57,7 +57,7 @@ public class CifStructureConverter {
      * @return the target
      * @throws IOException thrown when reading fails
      */
-    private static Structure fromURL(URL url, FileParsingParameters parameters) throws IOException {
+    public static Structure fromURL(URL url, FileParsingParameters parameters) throws IOException {
         return fromInputStream(url.openStream(), parameters);
     }
 


### PR DESCRIPTION
The file parsing parameters weren't respected by the new Cif reader.