### PR TITLE
Fix #933 URLConnection to invalid HTTP URL is not detected as failure

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
@@ -325,7 +325,7 @@ public class DownloadChemCompProvider implements ChemCompProvider {
                     success = true;
                 }
                 if(!success) {
-                	throw new IOException("Could not read from URL "+url.toString());
+                	throw new IOException("Malformed URL or no content found in "+url.toString());
                 }
 
                 pw.flush();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
@@ -14,7 +14,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -320,8 +319,13 @@ public class DownloadChemCompProvider implements ChemCompProvider {
             try (PrintWriter pw = new PrintWriter(new GZIPOutputStream(new FileOutputStream(newFile)));
                  BufferedReader fileBuffer = new BufferedReader(new InputStreamReader(uconn.getInputStream()))) {
                 String line;
+                boolean success = false;
                 while ((line = fileBuffer.readLine()) != null) {
                     pw.println(line);
+                    success = true;
+                }
+                if(!success) {
+                	throw new IOException("Could not read from URL "+url.toString());
                 }
 
                 pw.flush();


### PR DESCRIPTION
When the httpConnection is invalid, the application does not detect it, and it saves an empty (precisely a 20 bytes) file.
This fix detects when the connection is invalid or the file has no contents.
Related to #703
Adding a flag to be successful only when at least one byte is successfully read from the server