### PR TITLE
Fix #934 Several file and path issues on windows

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/InputStreamProvider.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/InputStreamProvider.java
@@ -23,6 +23,7 @@
 package org.biojava.nbio.core.util;
 
 import java.io.*;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
@@ -117,6 +118,14 @@ public class InputStreamProvider {
 
 	public InputStream getInputStream(URL u)
 	throws IOException{
+		
+		if (u.getProtocol().equals("file")) {
+			try {
+				return getInputStream(new File(u.toURI().getPath()));
+			} catch (URISyntaxException e) {
+				throw new RuntimeException(e);
+			}
+		}
 
 		int magic = 0;
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfStructureReader.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfStructureReader.java
@@ -2,8 +2,8 @@ package org.biojava.nbio.structure.io.mmtf;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.biojava.nbio.structure.Group;
@@ -39,8 +39,7 @@ public class TestMmtfStructureReader {
 		String resource = "org/biojava/nbio/structure/io/mmtf/4CUP.mmtf";
 
 		// Load the structure into memory
-		Structure structure = MmtfActions.readFromFile((
-				Paths.get(classLoader.getResource(resource).getPath())));
+		Structure structure = MmtfActions.readFromFile(new File(classLoader.getResource(resource).getPath()).toPath());
 
 		// Check header properties of the structure
 		assertEquals(structure.getPDBCode(), "4CUP");
@@ -61,8 +60,7 @@ public class TestMmtfStructureReader {
 		String resource = "org/biojava/nbio/structure/io/mmtf/4CUP";
 
 		// Load the structures into memory
-		Structure mmtf = MmtfActions.readFromFile((
-				Paths.get(classLoader.getResource(resource + ".mmtf").getPath())));
+		Structure mmtf = MmtfActions.readFromFile(new File(classLoader.getResource(resource + ".mmtf").getPath()).toPath());
 		Structure mmcif = StructureIO.getStructure(classLoader.getResource(resource + ".cif").getPath());
 
 		// Compare the dates of the structure

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfStructureWriter.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfStructureWriter.java
@@ -22,7 +22,6 @@ package org.biojava.nbio.structure.io.mmtf;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 
 import org.biojava.nbio.structure.AminoAcidImpl;
@@ -66,7 +65,7 @@ public class TestMmtfStructureWriter {
 	@Test
 	public void testRead() throws IOException {
 		ClassLoader classLoader = getClass().getClassLoader();
-		Structure structure = MmtfActions.readFromFile((Paths.get(classLoader.getResource("org/biojava/nbio/structure/io/mmtf/4CUP.mmtf").getPath())));
+		Structure structure = MmtfActions.readFromFile(new File(classLoader.getResource("org/biojava/nbio/structure/io/mmtf/4CUP.mmtf").getPath()).toPath());
 		assertEquals(structure.getPDBCode(),"4CUP");
 		assertEquals(structure.getChains().size(),6);
 	}


### PR DESCRIPTION
MS Windows has file and path problems:
1- spaces are not handled well in URL. Converting it to a URI handles decoding the path well.
2- TestURLIdentifier fails because when the connection is to a file and it contains parameters (e.g. ?format=PDB), they are perceived as part of the file name. getting the path first fixes it.
3- TestMmtfStructureReader and TestMmtfStructureWriter fail because Path does not handle drive specifier with a colon ':' (e.g. C:) well, while File does.
fixes #934 
