### PR TITLE
update junit3->junit4 test, remove doc references to ju3

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/TestSECalignment.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/TestSECalignment.java
@@ -22,7 +22,14 @@
  */
 package org.biojava.nbio.structure.test;
 
-import junit.framework.TestCase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.InputStream;
+
+import org.biojava.nbio.core.util.StringManipulationHelper;
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.align.StructureAlignment;
 import org.biojava.nbio.structure.align.StructureAlignmentFactory;
@@ -33,9 +40,7 @@ import org.biojava.nbio.structure.align.xml.AFPChainXMLConverter;
 import org.biojava.nbio.structure.align.xml.AFPChainXMLParser;
 import org.biojava.nbio.structure.test.align.fatcat.FlipAFPChainTest;
 import org.biojava.nbio.structure.test.util.StringManipulationTestsHelper;
-import org.biojava.nbio.core.util.StringManipulationHelper;
-
-import java.io.InputStream;
+import org.junit.Test;
 
 /** This test makes sure that the new representation of selenocysteins as SEC amino acids does not
  * affect the structure alignment results.
@@ -43,8 +48,9 @@ import java.io.InputStream;
  * @author andreas
  *
  */
-public class TestSECalignment extends  TestCase {
+public class TestSECalignment {
 
+	@Test
 	public void testOldSecOutput() throws Exception {
 
 		String fileName = "/ce_1fdo.A_2iv2.X.out";

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/align/ce/OptimalCECPMainTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/align/ce/OptimalCECPMainTest.java
@@ -46,13 +46,7 @@ public class OptimalCECPMainTest {
 
 	private AtomCache cache = new AtomCache();
 
-	/* (non-Javadoc)
-	 * @see junit.framework.TestCase#setUp()
-	 */
-	@Before
-	public void setUp() throws Exception {
-	}
-
+	
 	/**
 	 * Basic test that alignPermuted(..., 0) is equivalent to a normal CE alignment.
 	 *

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/ElementTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/ElementTest.java
@@ -21,7 +21,7 @@
 
 package org.biojava.nbio.structure;
 
-import junit.framework.TestCase;
+
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Thought it might be useful to update the few remaining junit3 tests to use junit4; so that in the event the junit5 PR is accepted, there won't be 3 concurrent versions of junit tests, just 2.