### PR TITLE
Tests for StringManipulationHelper

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Scanner;
 import java.util.stream.Collectors;
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
@@ -28,7 +28,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.AbstractCollection;
 import java.util.Iterator;
 import java.util.Scanner;
 
@@ -220,9 +219,18 @@ public class StringManipulationHelper  {
 		}
 	}
 
-	public static String join(AbstractCollection<String> s, String delimiter) {
-	    if (s == null || s.isEmpty()) return "";
+	/**
+	 * Joins Strings together with a delimiter
+	 * @param s An {@link Iterable} of Strings
+	 * @param delimiter
+	 * @return
+	 */
+	public static String join(Iterable<String> s, String delimiter) {
+	    if (s == null) return "";
 	    Iterator<String> iter = s.iterator();
+		if(!iter.hasNext()){
+			return "";
+		}
 	    StringBuilder builder = new StringBuilder(iter.next());
 	    while( iter.hasNext() ){
 		    builder.append(delimiter).append(iter.next());

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
@@ -150,6 +150,14 @@ public class StringManipulationHelper  {
 		s2.close();
 	}
 
+	/**
+	 * This method is not implemented or used, never returns true
+	 * and should probably be removed.
+	 * @param expected
+	 * @param actual
+	 * @return
+	 * @throws UnsupportedOperationException in most cases
+	 */
 	public static boolean equalsToXml(String expected, String actual) {
 		Document expectedDocument=null;
 		Document actualDocument=null;
@@ -220,7 +228,7 @@ public class StringManipulationHelper  {
 	}
 
 	/**
-	 * Joins Strings together with a delimiter
+	 * Joins Strings together with a delimiter to a single
 	 * @param s An {@link Iterable} of Strings
 	 * @param delimiter
 	 * @return

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
@@ -103,8 +103,10 @@ public class StringManipulationHelper  {
 	}
 
 	/**
-	 * compares two strings for equality, line by line, ignoring any difference
-	 * of end line delimiters contained within the 2 Strings. This method should
+	 * Compares two strings in a case-sensitive manner for equality, line by line, ignoring any difference
+	 * of end line delimiters contained within the 2 Strings.
+	 * <br/>
+	 * This method should
 	 * be used if and only if two Strings are considered identical when all nodes
 	 * are identical including their relative order. Generally useful when
 	 * asserting identity of <b>automatically regenerated</b> XML or PDB.
@@ -124,24 +126,30 @@ public class StringManipulationHelper  {
 		String line1, line2;
 		while (scanner1.hasNextLine()) {
 			line1 = scanner1.nextLine();
-			line2 = scanner2.nextLine();
-			if (! line1.equals(line2)) {
-				scanner1.close();
-				scanner2.close();
+			if(scanner2.hasNextLine()) {
+				line2 = scanner2.nextLine();
+				if (! line1.equals(line2)) {
+					closeScanners(scanner1, scanner2);
+					return false;
+				}
+			} else {
+				closeScanners(scanner1, scanner2);
 				return false;
 			}
 		}
 		if (scanner2.hasNextLine()) {
-			scanner1.close();
-			scanner2.close();
+			closeScanners(scanner1, scanner2);
 			return false;
 		}
 
-		scanner1.close();
-		scanner2.close();
+		closeScanners(scanner1, scanner2);
 		return true;
 	}
 
+	private static void closeScanners(Scanner s1, Scanner s2) {
+		s1.close();
+		s2.close();
+	}
 
 	public static boolean equalsToXml(String expected, String actual) {
 		Document expectedDocument=null;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
@@ -18,7 +18,7 @@
  *      http://www.biojava.org/
  *
  * Created on Sep 14, 2011
- * Author: Amr AL-Hossary
+ * Author: Amr AL-Hossary, Richard Adams
  *
  */
 package org.biojava.nbio.core.util;
@@ -49,6 +49,7 @@ import org.xml.sax.SAXException;
  * All functions are static methods.
  *
  * @author Amr AL-Hossary
+ * @author Richard Adams
  */
 public class StringManipulationHelper  {
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
@@ -68,9 +68,18 @@ public class StringManipulationHelper  {
 	}
 
 	/**
+	 * Converts an InputStream of text to a String, closing the stream
+	 * before returning.
+	 * <ul>
+	 * <li> Newlines are converted to Unix newlines (\n)
+	 * <li> Default charset encoding is used to read the stream.
+	 * <li> Any IOException reading the stream is 'squashed' and not made
+	 *   available to caller
+	 * <li> An additional newline is appended at the end of the string.
+	 * <ul>
 	 * @author andreas
 	 * @param stream
-	 * @return
+	 * @return a possibly empty but non-null String
 	 */
 	public static String convertStreamToString(InputStream stream) {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(stream));
@@ -79,8 +88,7 @@ public class StringManipulationHelper  {
 		String line = null;
 		try {
 			while ((line = reader.readLine()) != null) {
-
-		sb.append(line).append(UNIX_NEWLINE);
+			    sb.append(line).append(UNIX_NEWLINE);
 			}
 		} catch (IOException e) {
 			// logger.error("Exception: ", e);
@@ -91,7 +99,6 @@ public class StringManipulationHelper  {
 				logger.error("Exception: ", e);
 			}
 		}
-
 		return sb.toString();
 	}
 
@@ -196,7 +203,7 @@ public class StringManipulationHelper  {
 	 */
 	public static String padRight(String s, int n) {
 		validatePadding(n);
-	     return String.format("%1$-" + n + "s", s);
+	    return String.format("%1$-" + n + "s", s);
 	}
 
 	private static void validatePadding(int n) {
@@ -209,9 +216,8 @@ public class StringManipulationHelper  {
 	    if (s == null || s.isEmpty()) return "";
 	    Iterator<String> iter = s.iterator();
 	    StringBuilder builder = new StringBuilder(iter.next());
-	    while( iter.hasNext() )
-	    {
-		builder.append(delimiter).append(iter.next());
+	    while( iter.hasNext() ){
+		    builder.append(delimiter).append(iter.next());
 	    }
 	    return builder.toString();
 	}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/StringManipulationHelper.java
@@ -23,6 +23,19 @@
  */
 package org.biojava.nbio.core.util;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.AbstractCollection;
+import java.util.Iterator;
+import java.util.Scanner;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -30,14 +43,6 @@ import org.w3c.dom.DocumentType;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import java.io.*;
-import java.util.AbstractCollection;
-import java.util.Iterator;
-import java.util.Scanner;
 
 
 /**
@@ -61,10 +66,6 @@ public class StringManipulationHelper  {
 	private StringManipulationHelper() {
 		// to prevent instantiation
 	}
-
-
-
-
 
 	/**
 	 * @author andreas
@@ -174,12 +175,34 @@ public class StringManipulationHelper  {
 		throw new UnsupportedOperationException("not yet implemented");
 	}
 
+	/**
+	 * Adds padding to left of supplied string
+	 * @param s The String to pad
+	 * @param n an integer >= 1
+	 * @return The left-padded string. 
+	 * @throws IllegalArgumentException if n <= 0
+	 */
 	public static String padLeft(String s, int n) {
+		validatePadding(n);
 	    return String.format("%1$" + n + "s", s);
 	}
 
+	/**
+	 * Adds padding to right of supplied string
+	 * @param s The String to pad
+	 * @param n an integer >= 1
+	 * @return The right-padded string. 
+	 * @throws IllegalArgumentException if n <= 0
+	 */
 	public static String padRight(String s, int n) {
+		validatePadding(n);
 	     return String.format("%1$-" + n + "s", s);
+	}
+
+	private static void validatePadding(int n) {
+		if (n <=0 ) {
+			throw new IllegalArgumentException("padding must be >= 1");
+		}
 	}
 
 	public static String join(AbstractCollection<String> s, String delimiter) {

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/StringManipulationHelperTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/StringManipulationHelperTest.java
@@ -151,4 +151,17 @@ class StringManipulationHelperTest {
             
         }
     }
+
+    @Nested
+    class EqualsToXml {
+
+        String docType ="<!DOCTYPE " +
+        "ex  [ <!ENTITY foo \"foo\"> <!ENTITY bar"+
+        " \"bar\">]> <ex/>";
+        @Test
+        void isNotImplemented() {
+            assertThrows(UnsupportedOperationException.class, 
+            ()->StringManipulationHelper.equalsToXml(docType, docType));
+        }
+    }
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/StringManipulationHelperTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/StringManipulationHelperTest.java
@@ -1,0 +1,83 @@
+package org.biojava.nbio.core.util;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+class StringManipulationHelperTest {
+
+    @Nested
+    class PaddingTest {
+	    @Test
+        void padLeft() {
+            assertEquals("     ",
+            StringManipulationHelper.padLeft("",5));
+            assertEquals("   xx",
+                StringManipulationHelper.padLeft("xx",5));
+            assertEquals("xxxxxx", StringManipulationHelper.padLeft("xxxxxx",5));
+        }
+
+        @Test
+        void padRight() {
+            assertEquals("     ",
+            StringManipulationHelper.padRight("",5));
+            assertEquals("xx   ",
+                StringManipulationHelper.padRight("xx",5));
+            assertEquals("xxxxxx", StringManipulationHelper.padRight("xxxxxx",5));
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = {0,-1,-2})
+        @DisplayName("invalid padding arguments throw IAE")
+        void padInvalidValues(int invalidPadding) {
+            assertThrows(IllegalArgumentException.class, 
+              ()->StringManipulationHelper.padLeft(
+               "anystring",invalidPadding));
+            assertThrows(IllegalArgumentException.class, 
+               ()->StringManipulationHelper.padRight(
+                "anystring",invalidPadding));
+        }
+    
+   }
+   @Nested
+   class InputStreamToString {
+
+        @Test
+        void basicString(){
+           String singleLine = "hello";
+           ByteArrayInputStream bais = new ByteArrayInputStream(singleLine.getBytes());
+           assertEquals("hello\n", StringManipulationHelper.convertStreamToString(bais));
+        }
+
+        @ParameterizedTest
+        @DisplayName("Newlines are converted to Unix newlines")
+        @ValueSource(strings={"line1\r\nline2", "line1\nline2", "line1\rline2"})
+        void multiLineConvertedToUnixNewLine(String multiline){
+           ByteArrayInputStream bais = new ByteArrayInputStream(multiline.getBytes());
+           assertEquals("line1\nline2\n", StringManipulationHelper.convertStreamToString(bais));
+        }
+
+        @Test
+        void streamIsClosedAfterCompletion() throws IOException{
+            // this is a stream that will throw IOException
+            // if called after closing
+            InputStream is = InputStream.nullInputStream();
+            StringManipulationHelper.convertStreamToString(is);
+            // attempt to read again after closing
+            assertThrows(IOException.class, ()->is.read());
+        }
+
+        @Test
+        void emptyStreamGeneratesEmptyString() {
+            assertEquals("", StringManipulationHelper.convertStreamToString(
+                new ByteArrayInputStream(new byte [0])));
+        }
+    }
+}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/StringManipulationHelperTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/StringManipulationHelperTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -120,6 +122,33 @@ class StringManipulationHelperTest {
         @DisplayName("multiline strings with different lengths are  unequal")
         void s1LongerThanS2() {
             assertFalse(equalsToIgnoreEndline("ab\ncd\nef\nextra","ab\ncd\nef"));
+        }
+    }
+    @Nested
+    class JoinString{   
+        List<String> empty = new ArrayList<>();
+        List<String> items =  new ArrayList<>();
+        void populateItems() {
+            items.add("a");
+            items.add("b");
+            items.add("c");
+        }
+        @Test
+        void join() {
+
+            assertEquals("", StringManipulationHelper.join(empty,","));
+            items.add("a");
+            assertEquals("a", StringManipulationHelper.join(items,","));
+            items.add("b");
+            items.add("c");
+            assertEquals("a,b,c", StringManipulationHelper.join(items,","));
+            assertEquals("abc", StringManipulationHelper.join(items,""));
+        }
+        @Test
+        void delimiterCanBeAnyLength(){
+            populateItems();
+            assertEquals("a---b---c", StringManipulationHelper.join(items,"---"));
+            
         }
     }
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/StringManipulationHelperTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/StringManipulationHelperTest.java
@@ -1,6 +1,9 @@
 package org.biojava.nbio.core.util;
+import static org.biojava.nbio.core.util.StringManipulationHelper.equalsToIgnoreEndline;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -78,6 +81,45 @@ class StringManipulationHelperTest {
         void emptyStreamGeneratesEmptyString() {
             assertEquals("", StringManipulationHelper.convertStreamToString(
                 new ByteArrayInputStream(new byte [0])));
+        }
+    }
+
+    @Nested
+    class equalsToIgnoreEndline{
+        @Test
+        void emptyOrNullStringsAreEqual() {
+            assertTrue(equalsToIgnoreEndline("",""));
+            assertTrue(equalsToIgnoreEndline(null, null));
+        }
+
+        @Test
+        void emptyVsNullStringsAreNotEqual() {
+            assertFalse(equalsToIgnoreEndline(null,""));
+        }
+
+        @Test
+        @DisplayName("multiline strings with different line terminators are equal")
+        void differentLineTerminatorsAreEqual() {
+            assertTrue(equalsToIgnoreEndline("ab\ncd\nef","ab\r\ncd\r\nef"));
+            assertTrue(equalsToIgnoreEndline("ab\r\ncd\nef","ab\rcd\ref"));
+        }
+
+        @Test
+        @DisplayName("comparison is case-sensitive")
+        void caseSensitive() {
+            assertFalse(equalsToIgnoreEndline("ab\ncd\nef","ab\nCD\nef"));
+        }
+
+        @Test
+        @DisplayName("multiline strings with different lengths are  unequal")
+        void s2LongerThanS1() {
+            assertFalse(equalsToIgnoreEndline("ab\ncd\nef","ab\ncd\nef\nextra-line"));
+        }
+
+        @Test
+        @DisplayName("multiline strings with different lengths are  unequal")
+        void s1LongerThanS2() {
+            assertFalse(equalsToIgnoreEndline("ab\ncd\nef\nextra","ab\ncd\nef"));
         }
     }
 }


### PR DESCRIPTION
- identified and fixed a bug in equalsToIgnoreEndline if number of lines was different
- identified equalsToXml as not really mplemented or documented and not used
- re-implemented join() in simpler way using tests to validate unchanged behaviour and widened to accept a Collection rather than AbstractCollection
- some updated javadoc
- work towards #944