### PR TITLE
Force US Locale for floats.

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
@@ -69,7 +69,7 @@ public class SingleLinkageClusterer {
 			if (closestDistance==Double.MAX_VALUE) {
 				closestDistStr = String.format("%6s", "inf");
 			} else {
-				closestDistStr = String.format("%6.2f",closestDistance);
+				closestDistStr = String.format(Locale.US, "%6.2f",closestDistance);
 			}
 
 			return "["+first+","+second+"-"+closestDistStr+"]";
@@ -386,11 +386,11 @@ public class SingleLinkageClusterer {
 				}
 				else if (i<j) {
 					if (matrix[i][j]==Double.MAX_VALUE) sb.append(String.format("%6s ","inf"));
-					else sb.append(String.format("%6.2f ",matrix[i][j]));
+					else sb.append(String.format(Locale.US, "%6.2f ",matrix[i][j]));
 				}
 				else {
 					if (matrix[j][i]==Double.MAX_VALUE) sb.append(String.format("%6s ","inf"));
-					else sb.append(String.format("%6.2f ",matrix[j][i]));
+					else sb.append(String.format(Locale.US, "%6.2f ",matrix[j][i]));
 				}
 			}
 			sb.append("\n");
@@ -400,4 +400,3 @@ public class SingleLinkageClusterer {
 	}
 
 }
-

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonn.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonn.java
@@ -111,8 +111,8 @@ public final class ORonn implements Callable<ORonn> {
 			out.println(">" + sequence.getId());
 			if (layout == ResultLayout.VERTICAL) {
 				for (int i = 0; i < meanScores.length; i++) {
-					out.printf("%c\t%.2f%n", seqs[i], meanScores[i]);
-					//out.printf("%c\t%f%n", seqs[i], meanScores[i]);
+					out.printf(Locale.US, "%c\t%.2f%n", seqs[i], meanScores[i]);
+					//out.printf(Locale.US, "%c\t%f%n", seqs[i], meanScores[i]);
 				}
 			} else {
 				final StringBuilder seqLine = new StringBuilder();

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonnModel.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonnModel.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
+import java.util.Locale;
 
 
 
@@ -133,7 +134,7 @@ public final class ORonnModel {
 		}
 	}
 	for (int i = 0; i < scores.length; i++) {
-		output.printf("%c\t%f\n", query[i], scores[i]);
+		output.printf(Locale.US, "%c\t%f\n", query[i], scores[i]);
 	}
 	output.close();
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBCrystallographicInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBCrystallographicInfo.java
@@ -25,6 +25,7 @@ import org.biojava.nbio.structure.xtal.SpaceGroup;
 
 import javax.vecmath.Matrix4d;
 import java.io.Serializable;
+import java.util.Locale;
 
 /**
  * A class to hold crystallographic information about a PDB structure.
@@ -233,7 +234,7 @@ public class PDBCrystallographicInfo implements Serializable {
 				(sg==null?"no SG":sg.getShortSymbol())+" - "+
 
 				(cell==null?"no Cell":
-				String.format("%.2f %.2f %.2f, %.2f %.2f %.2f",
+				String.format(Locale.US, "%.2f %.2f %.2f, %.2f %.2f %.2f",
 						cell.getA(),cell.getB(),cell.getC(),cell.getAlpha(),cell.getBeta(),cell.getGamma()) )+
 				(ncsOperators==null? "" : String.format(" - %d NCS operators",ncsOperators.length) )+
 				"]";

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPChainer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPChainer.java
@@ -151,7 +151,7 @@ public class AFPChainer
 
 		int     currafp = maxafp;
 		if(debug)
-			System.out.println(String.format("maximum score %f, %d\n", maxsco, twi[currafp]));
+			System.out.printf("maximum score %f, %d%n%n", maxsco, twi[currafp]);
 
 		//trace-back from maxafp (maxsco)
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FCAlignHelper.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FCAlignHelper.java
@@ -252,11 +252,11 @@ public class FCAlignHelper
 	private void checkAlign(){
 
 		if(sapp[0] != 0)        {
-			System.err.println(String.format("warn: not a local-alignment result, first operation %d\n", sapp[0]));
+			System.err.printf("warn: not a local-alignment result, first operation %d%n%n", sapp[0]);
 		}
 		double  sco = checkScore();
 		if(Math.abs(sco - alignScore) > 1e-3)       {
-			System.err.println(String.format("FCAlignHelper: warn: alignment scores are different %f(check) %f(align)\n", sco, alignScore));
+			System.err.printf("FCAlignHelper: warn: alignment scores are different %f(check) %f(align)%n%n", sco, alignScore);
 		}
 	}
 
@@ -330,5 +330,3 @@ public class FCAlignHelper
 	}
 
 }
-
-

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AFPChain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AFPChain.java
@@ -28,6 +28,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -366,22 +367,22 @@ public class AFPChain implements Serializable, Cloneable {
 		str.append(this.getCa1Length());
 		str.append("\tLen2:");
 		str.append(this.getCa2Length());
-		str.append(String.format("\tscore: %.2f",this.getAlignScore()));
+		str.append(String.format(Locale.US, "\tscore: %.2f",this.getAlignScore()));
 		str.append("\t");
 		if ( algorithmName.equalsIgnoreCase(CeMain.algorithmName) || algorithmName.equalsIgnoreCase(CeSideChainMain.algorithmName)){
 			str.append("Z-score:");
-			str.append(String.format("%.2f",this.getProbability()));
+			str.append(String.format(Locale.US, "%.2f",this.getProbability()));
 		} else {
 			str.append("Probability:");
-			str.append(String.format("%.2e",this.getProbability()));
+			str.append(String.format(Locale.US, "%.2e",this.getProbability()));
 		}
 		str.append("\tRMSD:");
-		str.append(String.format("%.2f",this.getTotalRmsdOpt()));
+		str.append(String.format(Locale.US, "%.2f",this.getTotalRmsdOpt()));
 
 		str.append("\tSeqID:");
-		str.append(String.format("%.0f",getIdentity()*100));
+		str.append(String.format(Locale.US, "%.0f",getIdentity()*100));
 		str.append("%\tSeqSim:");
-		str.append(String.format("%.0f",getSimilarity()*100));
+		str.append(String.format(Locale.US, "%.0f",getSimilarity()*100));
 		str.append("%\tCov1:");
 		str.append(this.getCoverage1());
 		str.append("%\tCov2:");
@@ -390,7 +391,7 @@ public class AFPChain implements Serializable, Cloneable {
 
 		if (  tmScore != -1)  {
 			str.append("\ttmScore:");
-			str.append(String.format("%.2f",tmScore));
+			str.append(String.format(Locale.US, "%.2f",tmScore));
 		}
 		str.append(newline);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AfpChainWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AfpChainWriter.java
@@ -34,6 +34,7 @@ import org.biojava.nbio.structure.jama.Matrix;
 
 import java.io.StringWriter;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * A class to convert the data in an AfpChain object to various String outputs.
@@ -67,7 +68,7 @@ public class AfpChainWriter
 
 		if ( afpChain.getAlgorithmName().startsWith("CE")) {
 			writer.append("Z-score " );
-			writer.append(String.format("%.2f", afpChain.getProbability()));
+			writer.append(String.format(Locale.US, "%.2f", afpChain.getProbability()));
 			writer.append(newline);
 		}
 
@@ -196,10 +197,10 @@ public class AfpChainWriter
 			txt.append("Short match");
 			return txt.toString();
 		}
-		//txt.append(String.format("raw-score: %.2f norm.-score: %.2f ", alignScore, normAlignScore));
+		//txt.append(String.format(Locale.US, "raw-score: %.2f norm.-score: %.2f ", alignScore, normAlignScore));
 
 		if ( longHeader ) {
-			txt.append(String.format( "Twists %d ini-len %d ini-rmsd %.2f opt-equ %d opt-rmsd %.2f chain-rmsd %.2f Score %.2f align-len %d gaps %d (%.2f%%)",
+			txt.append(String.format(Locale.US, "Twists %d ini-len %d ini-rmsd %.2f opt-equ %d opt-rmsd %.2f chain-rmsd %.2f Score %.2f align-len %d gaps %d (%.2f%%)",
 					blockNum - 1, totalLenIni, totalRmsdIni, optLength, totalRmsdOpt, chainRmsd, alignScore,
 					alnLength, gapLen, (100.0 * gapLen/alnLength)) );
 			txt.append(newline);
@@ -213,12 +214,12 @@ public class AfpChainWriter
 		}
 
 
-		//txt.append(String.format("P-value %.2e Afp-num %d Identity %.2f%% Similarity %.2f%% norm.-score: %.2f"+newline, probability, afpNum, identity * 100, similarity * 100, normAlignScore));
+		//txt.append(String.format(Locale.US, "P-value %.2e Afp-num %d Identity %.2f%% Similarity %.2f%% norm.-score: %.2f"+newline, probability, afpNum, identity * 100, similarity * 100, normAlignScore));
 
 		if ( longHeader) {
 			printScore(txt,algorithmName,probability,longHeader);
 
-			txt.append(String.format("Afp-num %d Identity %.2f%% Similarity %.2f%%", afpNum, identity * 100, similarity * 100));
+			txt.append(String.format(Locale.US, "Afp-num %d Identity %.2f%% Similarity %.2f%%", afpNum, identity * 100, similarity * 100));
 			txt.append(newline);
 		}
 
@@ -229,7 +230,7 @@ public class AfpChainWriter
 			int fragLen = 8 ; // FatCatParameters.DEFAULT_FRAGLEN;
 			for(i = 0; i < blockNum; i ++)  {
 				gap = blockGap[i] /( (double)blockGap[i] + fragLen * blockSize[i]);
-				txt.append(String.format( "Block %2d afp %2d score %5.2f rmsd %5.2f gap %d (%.2f%%)",
+				txt.append(String.format(Locale.US, "Block %2d afp %2d score %5.2f rmsd %5.2f gap %d (%.2f%%)",
 						i, blockSize[i], blockScore[i], blockRmsd[i], blockGap[i], gap));
 				txt.append(newline);
 			}
@@ -389,29 +390,29 @@ public class AfpChainWriter
 			int alnLength, int gapLen, double identity, double similarity, StringBuffer txt)
 	{
 		if ( blockNum - 1 > 0) {
-			txt.append(String.format( "Twists %d ", blockNum -1 ));
+			txt.append(String.format(Locale.US, "Twists %d ", blockNum -1 ));
 			txt.append(newline);
 		}
 
-		txt.append(String.format("Equ: %d ", optLength));
+		txt.append(String.format(Locale.US, "Equ: %d ", optLength));
 		txt.append(newline);
-		txt.append(String.format("RMSD: %.2f ", totalRmsdOpt));
+		txt.append(String.format(Locale.US, "RMSD: %.2f ", totalRmsdOpt));
 		txt.append(newline);
-		txt.append(String.format("Score: %.2f ", alignScore));
+		txt.append(String.format(Locale.US, "Score: %.2f ", alignScore));
 		txt.append(newline);
-		txt.append(String.format("Align-len: %d ", alnLength));
+		txt.append(String.format(Locale.US, "Align-len: %d ", alnLength));
 		txt.append(newline);
-		txt.append(String.format("Gaps: %d (%.2f%%)",
+		txt.append(String.format(Locale.US, "Gaps: %d (%.2f%%)",
 				gapLen, (100.0 * gapLen/alnLength)) );
 		txt.append(newline);
 		if ( afpChain.getTMScore() >= 0) {
-			txt.append(String.format("TM-score: %.2f",afpChain.getTMScore()));
+			txt.append(String.format(Locale.US, "TM-score: %.2f",afpChain.getTMScore()));
 			txt.append(newline);
 		}
 		txt.append(newline);
-		txt.append(String.format("Identity: %.2f%% ", identity * 100 ));
+		txt.append(String.format(Locale.US, "Identity: %.2f%% ", identity * 100 ));
 		txt.append(newline);
-		txt.append(String.format("Similarity: %.2f%%", similarity * 100));
+		txt.append(String.format(Locale.US, "Similarity: %.2f%%", similarity * 100));
 		txt.append(newline);
 	}
 
@@ -421,16 +422,16 @@ public class AfpChainWriter
 			boolean longHeader)
 	{
 		if ( algorithmName.equalsIgnoreCase(CeMain.algorithmName) || algorithmName.equalsIgnoreCase(CeSideChainMain.algorithmName) ){
-			txt.append(String.format("Z-score %.2f ", probability));
+			txt.append(String.format(Locale.US, "Z-score %.2f ", probability));
 			if ( ! longHeader)
 				txt.append(newline);
 		} else if ( algorithmName.equalsIgnoreCase(SmithWaterman3Daligner.algorithmName)) {
 
 		} else {
 			if ( longHeader ){
-				txt.append(String.format("P-value %.2e ",probability));
+				txt.append(String.format(Locale.US, "P-value %.2e ",probability));
 			}  else {
-				txt.append(String.format("P-value: %.2e ",probability));
+				txt.append(String.format(Locale.US, "P-value: %.2e ",probability));
 				txt.append(newline);
 			}
 		}
@@ -1065,15 +1066,15 @@ public class AfpChainWriter
 		str.append("\t");
 		str.append(afpChain.getName2());
 		str.append("\t");
-		str.append(String.format("%.2f",afpChain.getAlignScore()));
+		str.append(String.format(Locale.US, "%.2f",afpChain.getAlignScore()));
 		str.append("\t");
 		if ( afpChain.getAlgorithmName().equalsIgnoreCase(CeMain.algorithmName)){
-			str.append(String.format("%.2f",afpChain.getProbability()));
+			str.append(String.format(Locale.US, "%.2f",afpChain.getProbability()));
 		} else {
-			str.append(String.format("%.2e",afpChain.getProbability()));
+			str.append(String.format(Locale.US, "%.2e",afpChain.getProbability()));
 		}
 		str.append("\t");
-		str.append(String.format("%.2f",afpChain.getTotalRmsdOpt()));
+		str.append(String.format(Locale.US, "%.2f",afpChain.getTotalRmsdOpt()));
 		str.append("\t");
 		str.append(afpChain.getCa1Length());
 		str.append("\t");
@@ -1083,7 +1084,7 @@ public class AfpChainWriter
 		str.append("\t");
 		str.append(afpChain.getCoverage2());
 		str.append("\t");
-		str.append(String.format("%.2f",afpChain.getIdentity()));
+		str.append(String.format(Locale.US, "%.2f",afpChain.getIdentity()));
 		str.append("\t");
 		str.append(afpChain.getDescription2());
 		str.append("\t");
@@ -1119,11 +1120,11 @@ public class AfpChainWriter
 				origString = String.valueOf(blockNr);
 
 
-			txt.append(String.format("     X"+(blockNr+1)+" = (%9.6f)*X"+ origString +" + (%9.6f)*Y"+ origString +" + (%9.6f)*Z"+ origString +" + (%12.6f)",m.get(0,0),m.get(1,0), m.get(2,0), shift.getX()));
+			txt.append(String.format(Locale.US, "     X"+(blockNr+1)+" = (%9.6f)*X"+ origString +" + (%9.6f)*Y"+ origString +" + (%9.6f)*Z"+ origString +" + (%12.6f)",m.get(0,0),m.get(1,0), m.get(2,0), shift.getX()));
 			txt.append( newline);
-			txt.append(String.format("     Y"+(blockNr+1)+" = (%9.6f)*X"+ origString +" + (%9.6f)*Y"+ origString +" + (%9.6f)*Z"+ origString +" + (%12.6f)",m.get(0,1),m.get(1,1), m.get(2,1), shift.getY()));
+			txt.append(String.format(Locale.US, "     Y"+(blockNr+1)+" = (%9.6f)*X"+ origString +" + (%9.6f)*Y"+ origString +" + (%9.6f)*Z"+ origString +" + (%12.6f)",m.get(0,1),m.get(1,1), m.get(2,1), shift.getY()));
 			txt.append( newline);
-			txt.append(String.format("     Z"+(blockNr+1)+" = (%9.6f)*X"+ origString +" + (%9.6f)*Y"+ origString +" + (%9.6f)*Z"+ origString +" + (%12.6f)",m.get(0,2),m.get(1,2), m.get(2,2), shift.getZ()));
+			txt.append(String.format(Locale.US, "     Z"+(blockNr+1)+" = (%9.6f)*X"+ origString +" + (%9.6f)*Y"+ origString +" + (%9.6f)*Z"+ origString +" + (%12.6f)",m.get(0,2),m.get(1,2), m.get(2,2), shift.getZ()));
 			txt.append(newline);
 		}
 		return txt.toString();
@@ -1178,8 +1179,8 @@ public class AfpChainWriter
 		txt.append(")");
 		txt.append(newline);
 		txt.append(newline);
-		txt.append(String.format("Alignment length = %d Rmsd = %.2fA Z-Score = %.1f",optLength,totalRmsdOpt,probability));
-		txt.append(String.format(" Gaps = %d(%.1f%%) CPU = %d ms. Sequence identities = %.1f%%",gapLen,( gapLen*100.0/optLength),calculationTime,identity*100));
+		txt.append(String.format(Locale.US, "Alignment length = %d Rmsd = %.2fA Z-Score = %.1f",optLength,totalRmsdOpt,probability));
+		txt.append(String.format(Locale.US, " Gaps = %d(%.1f%%) CPU = %d ms. Sequence identities = %.1f%%",gapLen,( gapLen*100.0/optLength),calculationTime,identity*100));
 
 		int     linelen = 70;
 		String a;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/MultipleAlignmentImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/MultipleAlignmentImpl.java
@@ -23,6 +23,7 @@ package org.biojava.nbio.structure.align.multiple;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.StructureException;
@@ -138,7 +139,7 @@ public class MultipleAlignmentImpl extends AbstractScoresCache implements
 				+ " \nCore Length: " + getCoreLength();
 		for (String score : getScores()) {
 			resume += " \n" + score + ": ";
-			resume += String.format("%.2f", getScore(score));
+			resume += String.format(Locale.US, "%.2f", getScore(score));
 		}
 		return resume;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentWriter.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.vecmath.Matrix4d;
 
@@ -215,7 +216,7 @@ public class MultipleAlignmentWriter {
 			for (int str = 0; str < alignment.size(); str++) {
 				String origString = "ref";
 
-				txt.append(String.format("     X"+(str+1)+ " = (%9.6f)*X"+
+				txt.append(String.format(Locale.US, "     X"+(str+1)+ " = (%9.6f)*X"+
 						origString +" + (%9.6f)*Y"+
 						origString +" + (%9.6f)*Z"+
 						origString +" + (%12.6f)",
@@ -224,7 +225,7 @@ public class MultipleAlignmentWriter {
 						btransforms.get(str).getElement(0,2),
 						btransforms.get(str).getElement(0,3)));
 				txt.append( "\n");
-				txt.append(String.format("     Y"+(str+1)+" = (%9.6f)*X"+
+				txt.append(String.format(Locale.US, "     Y"+(str+1)+" = (%9.6f)*X"+
 						origString +" + (%9.6f)*Y"+
 						origString +" + (%9.6f)*Z"+
 						origString +" + (%12.6f)",
@@ -233,7 +234,7 @@ public class MultipleAlignmentWriter {
 						btransforms.get(str).getElement(1,2),
 						btransforms.get(str).getElement(1,3)));
 				txt.append( "\n");
-				txt.append(String.format("     Z"+(str+1)+" = (%9.6f)*X"+
+				txt.append(String.format(Locale.US, "     Z"+(str+1)+" = (%9.6f)*X"+
 						origString +" + (%9.6f)*Y"+
 						origString +" + (%9.6f)*Z"+
 						origString +" + (%12.6f)",

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/RotationAxis.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/RotationAxis.java
@@ -21,6 +21,7 @@
 package org.biojava.nbio.structure.align.util;
 
 import java.io.StringWriter;
+import java.util.Locale;
 
 import javax.vecmath.AxisAngle4d;
 import javax.vecmath.Matrix3d;
@@ -460,7 +461,7 @@ public final class RotationAxis {
 
 		// draw axis of rotation
 		result.append(
-				String.format("draw ID rot"+axisID+" CYLINDER {%f,%f,%f} {%f,%f,%f} WIDTH %f COLOR %s ;",
+				String.format(Locale.US, "draw ID rot"+axisID+" CYLINDER {%f,%f,%f} {%f,%f,%f} WIDTH %f COLOR %s ;",
 						axisMin.getX(),axisMin.getY(),axisMin.getZ(),
 						axisMax.getX(),axisMax.getY(),axisMax.getZ(), width, axisColor ));
 
@@ -468,14 +469,14 @@ public final class RotationAxis {
 		boolean positiveScrew = Math.signum(rotationAxis.getX()) == Math.signum(screwTranslation.getX());
 		if( positiveScrew ) {
 			// screw is in the same direction as the axis
-			result.append( String.format(
+			result.append( String.format(Locale.US,
 					"draw ID screw"+axisID+" VECTOR {%f,%f,%f} {%f,%f,%f} WIDTH %f COLOR %s ;",
 					axisMax.getX(),axisMax.getY(),axisMax.getZ(),
 					screwTranslation.getX(),screwTranslation.getY(),screwTranslation.getZ(),
 					width, screwColor ));
 		} else {
 			// screw is in the opposite direction as the axis
-			result.append( String.format(
+			result.append( String.format(Locale.US,
 					"draw ID screw"+axisID+" VECTOR {%f,%f,%f} {%f,%f,%f} WIDTH %f COLOR %s ;",
 					axisMin.getX(),axisMin.getY(),axisMin.getZ(),
 					screwTranslation.getX(),screwTranslation.getY(),screwTranslation.getZ(),
@@ -485,7 +486,7 @@ public final class RotationAxis {
 		// draw angle of rotation
 		if(rotationPos != null) {
 			result.append(System.getProperty("line.separator"));
-			result.append(String.format("draw ID rotArc"+axisID+" ARC {%f,%f,%f} {%f,%f,%f} {0,0,0} {0,%f,%d} SCALE 500 DIAMETER %f COLOR %s;",
+			result.append(String.format(Locale.US, "draw ID rotArc"+axisID+" ARC {%f,%f,%f} {%f,%f,%f} {0,0,0} {0,%f,%d} SCALE 500 DIAMETER %f COLOR %s;",
 					axisMin.getX(),axisMin.getY(),axisMin.getZ(),
 					axisMax.getX(),axisMax.getY(),axisMax.getZ(),
 					Math.toDegrees(theta),

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLConverter.java
@@ -244,24 +244,24 @@ public class AFPChainXMLConverter {
 		xml.attribute("optLength", afpChain.getOptLength() + "");
 		xml.attribute("totalLenIni", afpChain.getTotalLenIni() + "");
 
-		xml.attribute("alignScore", String.format("%5.2f", afpChain.getAlignScore() ).trim());
-		xml.attribute("chainRmsd",  String.format("%5.2f", afpChain.getChainRmsd() ).trim());
-		xml.attribute("identity",String.format("%5.4f", afpChain.getIdentity() ).trim());
-		xml.attribute("normAlignScore", String.format("%5.2f",afpChain.getNormAlignScore()).trim());
-		xml.attribute("probability", String.format("%.2e", afpChain.getProbability() ).trim());
-		xml.attribute("similarity", String.format("%5.4f", afpChain.getSimilarity() ).trim());
+		xml.attribute("alignScore", String.format(Locale.US, "%5.2f", afpChain.getAlignScore() ).trim());
+		xml.attribute("chainRmsd",  String.format(Locale.US, "%5.2f", afpChain.getChainRmsd() ).trim());
+		xml.attribute("identity",String.format(Locale.US, "%5.4f", afpChain.getIdentity() ).trim());
+		xml.attribute("normAlignScore", String.format(Locale.US, "%5.2f",afpChain.getNormAlignScore()).trim());
+		xml.attribute("probability", String.format(Locale.US, "%.2e", afpChain.getProbability() ).trim());
+		xml.attribute("similarity", String.format(Locale.US, "%5.4f", afpChain.getSimilarity() ).trim());
 
 		xml.attribute("similarity1", afpChain.getCoverage1() + "");
 		xml.attribute("similarity2", afpChain.getCoverage2() + "");
-		xml.attribute("totalRmsdIni", String.format("%5.2f",afpChain.getTotalRmsdIni() ).trim());
-		xml.attribute("totalRmsdOpt", String.format("%5.2f",afpChain.getTotalRmsdOpt() ).trim());
+		xml.attribute("totalRmsdIni", String.format(Locale.US, "%5.2f",afpChain.getTotalRmsdIni() ).trim());
+		xml.attribute("totalRmsdOpt", String.format(Locale.US, "%5.2f",afpChain.getTotalRmsdOpt() ).trim());
 		xml.attribute("ca1Length", afpChain.getCa1Length()+"");
 		xml.attribute("ca2Length", afpChain.getCa2Length()+"");
 		xml.attribute("afpNum",afpChain.getAfpSet().size()+"");
-		xml.attribute("alignScoreUpdate",String.format("%5.2f",afpChain.getAlignScoreUpdate()).trim());
+		xml.attribute("alignScoreUpdate",String.format(Locale.US, "%5.2f",afpChain.getAlignScoreUpdate()).trim());
 		xml.attribute("time", String.format("%d",afpChain.getCalculationTime()));
 		if ( afpChain.getTMScore() != -1){
-			xml.attribute("tmScore", String.format("%.2f",afpChain.getTMScore()));
+			xml.attribute("tmScore", String.format(Locale.US, "%.2f",afpChain.getTMScore()));
 		}
 
 		// test if alignment is CP:

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLConverter.java
@@ -30,6 +30,7 @@ import org.biojava.nbio.core.util.PrettyXMLWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.Locale;
 
 
 
@@ -187,8 +188,8 @@ public class AFPChainXMLConverter {
 
 		xml.attribute("blockNr", String.valueOf(bk));
 		xml.attribute("blockSize", String.valueOf(blockSize[bk]));
-		xml.attribute("blockScore", String.format("%5.2f",blockScore[bk]).trim());
-		xml.attribute("blockRmsd", String.format("%5.2f",blockRmsd[bk]).trim());
+		xml.attribute("blockScore", String.format(Locale.US, "%5.2f",blockScore[bk]).trim());
+		xml.attribute("blockRmsd", String.format(Locale.US, "%5.2f",blockRmsd[bk]).trim());
 		xml.attribute("blockGap", String.valueOf(blockGap[bk]));
 
 	}
@@ -210,7 +211,7 @@ public class AFPChainXMLConverter {
 		for (int x=0;x<3;x++){
 			for (int y=0;y<3;y++){
 				String key = "mat"+(x+1)+(y+1);
-				xml.attribute(key,String.format("%.6f",matrix.get(x,y)));
+				xml.attribute(key,String.format(Locale.US, "%.6f",matrix.get(x,y)));
 			}
 		}
 		xml.closeTag("matrix");
@@ -218,9 +219,9 @@ public class AFPChainXMLConverter {
 		Atom[]   shifts = afpChain.getBlockShiftVector();
 		Atom shift = shifts[blockNr];
 		xml.openTag("shift");
-		xml.attribute("x", String.format("%.3f",shift.getX()));
-		xml.attribute("y", String.format("%.3f",shift.getY()));
-		xml.attribute("z", String.format("%.3f",shift.getZ()));
+		xml.attribute("x", String.format(Locale.US, "%.3f",shift.getX()));
+		xml.attribute("y", String.format(Locale.US, "%.3f",shift.getY()));
+		xml.attribute("z", String.format(Locale.US, "%.3f",shift.getZ()));
 		xml.closeTag("shift");
 
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/basepairs/BasePairParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/basepairs/BasePairParameters.java
@@ -36,6 +36,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Map;
@@ -635,9 +636,9 @@ public class BasePairParameters implements Serializable {
 		for (int i = 0; i < pairingParameters.length; i++) {
 			result.append(pairingNames.get(i)+": ");
 			for (int j = 0; j < 6; j++)
-				result.append(String.format("%5.4f", pairingParameters[i][j]) + " ");
+				result.append(String.format(Locale.US, "%5.4f", pairingParameters[i][j]) + " ");
 			for (int j = 0; j < 6; j++)
-				result.append(String.format("%5.4f", stepParameters[i][j]) + " ");
+				result.append(String.format(Locale.US, "%5.4f", stepParameters[i][j]) + " ");
 			result.append("\n");
 		}
 		return result.toString();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/BoundingBox.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/BoundingBox.java
@@ -27,6 +27,7 @@ import javax.vecmath.Point3d;
 import javax.vecmath.Vector3d;
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Locale;
 
 
 /**
@@ -246,6 +247,6 @@ public class BoundingBox implements Serializable {
 
 	@Override
 	public String toString() {
-		return String.format("[(%7.2f,%7.2f),(%7.2f,%7.2f),(%7.2f,%7.2f)]", xmin,xmax,ymin,ymax,zmin,zmax);
+		return String.format(Locale.US, "[(%7.2f,%7.2f),(%7.2f,%7.2f),(%7.2f,%7.2f)]", xmin,xmax,ymin,ymax,zmin,zmax);
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/ClusterDomains.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/ClusterDomains.java
@@ -99,9 +99,11 @@ public class ClusterDomains {
 					 */
 
 					double S_value= total_contacts/(double)total_max_contacts;
-					if(verbose) System.out.println(String.format(" size1=%d size2=%d minDomSize=%5.2f maxDomSize=%5.2f total_contacts = %d ", size1,size2,minDomSize,maxDomSize,total_contacts));
-					if(verbose) System.out.println(String.format(" total_contacts = %d total_max_contacts = %d", total_contacts, total_max_contacts));
-					if(verbose) System.out.println(String.format(" maximum_value = %f S_value = %f\n",maximum_value, S_value));
+					if(verbose) {
+						System.out.printf(" size1=%d size2=%d minDomSize=%5.2f maxDomSize=%5.2f total_contacts = %d %n", size1,size2,minDomSize,maxDomSize,total_contacts);
+						System.out.printf(" total_contacts = %d total_max_contacts = %d%n", total_contacts, total_max_contacts);
+						System.out.printf(" maximum_value = %f S_value = %f%n%n",maximum_value, S_value);
+					}
 
 					if (S_value > maximum_value) {
 						maximum_value = S_value;
@@ -134,8 +136,8 @@ public class ClusterDomains {
 			avd=(domains.get(Si).avd+domains.get(Sj).avd)/2;
 				 */
 				if(verbose) System.out.println(" Criteria 1 matched");
-				if(verbose) System.out.println(String.format(" maximum_value = %f", maximum_value));
-				if(verbose) System.out.println(String.format(" Si = %d Sj = %d ", Si, Sj));
+				if(verbose) System.out.printf(" maximum_value = %f%n", maximum_value);
+				if(verbose) System.out.printf(" Si = %d Sj = %d %n", Si, Sj);
 				domains = combine(domains,Si, Sj, maximum_value);
 				maximum_value = PDPParameters.CUT_OFF_VALUE1-.1;
 				maximum_values = PDPParameters.CUT_OFF_VALUE1S-.1;
@@ -152,8 +154,8 @@ public class ClusterDomains {
 			avd=(domains[Sim].avd+domains[Sjm].avd)/2;
 				 */
 				if(verbose) System.out.println(" Criteria 2 matched");
-				if(verbose) System.out.println(String.format(" maximum_values = %f", maximum_valuem));
-				if(verbose) System.out.println(String.format(" Sim = %d Sjm = %d", Sim, Sjm));
+				if(verbose) System.out.printf(" maximum_values = %f%n", maximum_valuem);
+				if(verbose) System.out.printf(" Sim = %d Sjm = %d%n", Sim, Sjm);
 				domains = combine(domains, Sim, Sjm, maximum_valuem);
 				maximum_value =  PDPParameters.CUT_OFF_VALUE1-.1;
 				maximum_values = PDPParameters.CUT_OFF_VALUE1S-.1;
@@ -170,8 +172,8 @@ public class ClusterDomains {
 			avd=(domains[Sis].avd+domains[Sjs].avd)/2;
 				 */
 				if(verbose) System.out.println(" Criteria 3 matched");
-				if(verbose) System.out.println(String.format(" maximum_values = %f", maximum_values));
-				if(verbose) System.out.println(String.format(" Sis = %d Sjs = %d", Sis, Sjs));
+				if(verbose) System.out.printf(" maximum_values = %f%n", maximum_values);
+				if(verbose) System.out.printf(" Sis = %d Sjs = %d%n", Sis, Sjs);
 				domains = combine(domains, Sis, Sjs, maximum_values);
 				maximum_value = PDPParameters.CUT_OFF_VALUE1-.1;
 				maximum_values = PDPParameters.CUT_OFF_VALUE1S-.1;
@@ -180,11 +182,11 @@ public class ClusterDomains {
 			domains[Sis].avd=domcont(domains[Sis]);
 			domains[Sjs].avd=domcont(domains[Sjs]);
 				 */
-				if(verbose) System.out.println(String.format(" Listing the domains after combining..."));
+				if(verbose) System.out.println(" Listing the domains after combining...");
 				if(verbose) listdomains(domains);
 			}
 			else {
-				if(verbose) System.out.println(String.format(" Maximum value is less than cut off value. (max:" + maximum_value+")" ));
+				if(verbose) System.out.printf(" Maximum value is less than cut off value. (max:%d)%n", maximum_value);
 				maximum_value = -1.0;
 				maximum_values = -1.0;
 				maximum_valuem = -1.0;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/Cut.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/Cut.java
@@ -167,11 +167,11 @@ public class Cut {
 			}
 		}
 		average_density/=size0;
-		if(verbose) System.out.println(String.format("  --- Trying to cut domain of size %d having %d segments and  average cont_density %f\n",dom.size,dom.nseg,average_density));
+		if(verbose) System.out.printf("  --- Trying to cut domain of size %d having %d segments and  average cont_density %f%n%n",dom.size,dom.nseg,average_density);
 
 		if ( verbose )
 			for(kseg=0;kseg<dom.nseg;kseg++)
-				System.out.println(String.format("	--- segment %d from %d to %d",kseg,dom.getSegmentAtPos(kseg).getFrom(),dom.getSegmentAtPos(kseg).getTo()) + " av density: " + average_density);
+				System.out.printf("  --- segment %d from %d to %d av density: %f%n",kseg,dom.getSegmentAtPos(kseg).getFrom(),dom.getSegmentAtPos(kseg).getTo(), average_density);
 
 
 		if(val.first_cut) {
@@ -180,7 +180,7 @@ public class Cut {
 			printf("%d	%s	%d	%d	%d	%d	%f\n",k,protein.res[k].type,k-from,to-k,contacts[k],max_contacts[k],contact_density[k]);
 			 */
 			val.AD = average_density;
-			if(verbose)	System.out.println(String.format("  --- AD=%f", average_density));
+			if(verbose) System.out.printf("  --- AD=%f%n", average_density);
 			/*
 			 */
 		}
@@ -188,7 +188,7 @@ public class Cut {
 
 		val.s_min/=val.AD;
 
-		if(verbose) System.out.println(String.format("  --- after single cut: s_min = %f site_min = %d",val.s_min,site_min));
+		if(verbose) System.out.printf("  --- after single cut: s_min = %f site_min = %d%n",val.s_min,site_min);
 
 		///
 		k=0;
@@ -391,7 +391,7 @@ public class Cut {
 		}
 		val.first_cut=false;
 		if(verbose)
-			System.out.println(String.format("  --- E ... at the end of cut: s_min %f CUTOFF %f site_min %d *site2 %d",val.s_min,PDPParameters.CUT_OFF_VALUE,site_min,val.site2));
+			System.out.printf("  --- E ... at the end of cut: s_min %f CUTOFF %f site_min %d *site2 %d%n",val.s_min,PDPParameters.CUT_OFF_VALUE,site_min,val.site2);
 		if(val.s_min> PDPParameters.CUT_OFF_VALUE) return -1;
 
 		return(site_min);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/CutDomain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/CutDomain.java
@@ -85,7 +85,7 @@ public class CutDomain {
 		}
 
 		if(verbose)
-			System.out.println(String.format("   C ... Cutting at position(s): %d %d %f\n",site,val.site2,dom.score));
+			System.out.printf("   C ... Cutting at position(s): %d %d %f%n%n",site,val.site2,dom.score);
 
 		cut_sites.cut_sites[cut_sites.ncuts++] = site;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucState.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucState.java
@@ -20,6 +20,8 @@
  */
 package org.biojava.nbio.structure.secstruc;
 
+import java.util.Locale;
+
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.Group;
 import org.biojava.nbio.structure.StructureTools;
@@ -321,44 +323,44 @@ public class SecStrucState extends SecStrucInfo {
 		double e1 = (accept1.getEnergy() / 1000.0);
 		if (e1 < 0.0)
 			p1 -= index;
-		buf.append(String.format("%6d,%4.1f", p1, e1));
+		buf.append(String.format(Locale.US, "%6d,%4.1f", p1, e1));
 
 		// O-->H-N
 		int p2 = donor1.getPartner();
 		double e2 = (donor1.getEnergy() / 1000.0);
 		if (e2 < 0.0)
 			p2 -= index;
-		buf.append(String.format("%6d,%4.1f", p2, e2));
+		buf.append(String.format(Locale.US, "%6d,%4.1f", p2, e2));
 
 		// N-H-->O
 		int p3 = accept2.getPartner();
 		double e3 = (accept2.getEnergy() / 1000.0);
 		if (e3 < 0.0)
 			p3 -= index;
-		buf.append(String.format("%6d,%4.1f", p3, e3));
+		buf.append(String.format(Locale.US, "%6d,%4.1f", p3, e3));
 
 		// O-->H-N
 		int p4 = donor2.getPartner();
 		double e4 = (donor2.getEnergy() / 1000.0);
 		if (e4 < 0.0)
 			p4 -= index;
-		buf.append(String.format("%6d,%4.1f", p4, e4));
+		buf.append(String.format(Locale.US, "%6d,%4.1f", p4, e4));
 
 		// TCO TODO
 		buf.append("        ");
 
 		// KAPPA
-		buf.append(String.format("%6.1f", kappa));
+		buf.append(String.format(Locale.US, "%6.1f", kappa));
 
 		// ALPHA TODO
 		buf.append("      ");
 
 		// PHI PSI
-		buf.append(String.format("%6.1f %6.1f ", phi, psi));
+		buf.append(String.format(Locale.US, "%6.1f %6.1f ", phi, psi));
 
 		// X-CA Y-CA Z-CA
 		Atom ca = parent.getAtom("CA");
-		buf.append(String.format("%6.1f %6.1f %6.1f", ca.getX(), ca.getY(),
+		buf.append(String.format(Locale.US, "%6.1f %6.1f %6.1f", ca.getX(), ca.getY(),
 				ca.getZ()));
 
 		return buf.toString();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalCell.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalCell.java
@@ -24,6 +24,7 @@ import javax.vecmath.*;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Locale;
 
 //import org.slf4j.Logger;
 //import org.slf4j.LoggerFactory;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalCell.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalCell.java
@@ -593,6 +593,6 @@ public class CrystalCell implements Serializable {
 
 	@Override
 	public String toString() {
-		return String.format("a%7.2f b%7.2f c%7.2f alpha%6.2f beta%6.2f gamma%6.2f", a, b, c, alpha, beta, gamma);
+		return String.format(Locale.US, "a%7.2f b%7.2f c%7.2f alpha%6.2f beta%6.2f gamma%6.2f", a, b, c, alpha, beta, gamma);
 	}
 }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalTransform.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalTransform.java
@@ -25,6 +25,7 @@ import javax.vecmath.Matrix4d;
 import javax.vecmath.Point3i;
 import javax.vecmath.Vector3d;
 import java.io.Serializable;
+import java.util.Locale;
 
 import static java.lang.Math.abs;
 
@@ -451,7 +452,7 @@ public class CrystalTransform implements Serializable {
 		}
 
 		// Give up and use floating point;
-		return String.format("%.3f", coef);
+		return String.format(Locale.US, "%.3f", coef);
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/SpaceGroup.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/SpaceGroup.java
@@ -43,6 +43,7 @@ import java.io.PrintStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -433,9 +434,9 @@ public class SpaceGroup implements Serializable {
 
 	private static String formatCoef(double c, boolean leading) {
 		if (leading) {
-			return (deltaComp(Math.abs(c),1,DELTA)?(c>0?"":"-"):String.format("%4.2f",c));
+			return (deltaComp(Math.abs(c),1,DELTA)?(c>0?"":"-"):String.format(Locale.US, "%4.2f",c));
 		} else {
-			return (deltaComp(Math.abs(c),1,DELTA)?(c>0?"+":"-"):String.format("%+4.2f",c));
+			return (deltaComp(Math.abs(c),1,DELTA)?(c>0?"+":"-"):String.format(Locale.US, "%+4.2f",c));
 		}
 	}
 
@@ -719,4 +720,3 @@ public class SpaceGroup implements Serializable {
 	}
 
 }
-


### PR DESCRIPTION
#918 showed that locales which use commas for floating-point numbers
can cause problems with output formats. This commit fixes a number
of other cases.

- Force Locale.US when outputting floats to files/streams
- Usually don't force Locale.US when outputting floats to standard out &
  logging (would lead to more consistent logs but breaks localization)
- Replace some `println(String.format(` calls with Java 5 `printf`