### PR TITLE
Tests for core util package

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/Equals.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/Equals.java
@@ -44,6 +44,8 @@ public class Equals {
 
 	/**
 	 * Does not compare class types.
+	 * However, if the two arguments are non-null references to distinct objects,
+	 *  the object's equals() method is called - which may well compare class types.
 	 * @see #classEqual(Object, Object)
 	 */
 	public static boolean equal(Object one, Object two) {
@@ -78,7 +80,7 @@ public class Equals {
 	 *          The first object to test
 	 * @param two
 	 *          The second object to test
-	 * @return A boolean indicating if the logic agrees that these two objects are
+	 * @return A boolean indicating if  these two objects are
 	 *         equal at the class level
 	 */
 	public static boolean classEqual(Object one, Object two) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
@@ -113,7 +113,7 @@ public class FileDownloadUtils {
 	/**
 	 * Download the content provided at URL url and store the result to a local
 	 * file, using a temp file to cache the content in case something goes wrong
-	 * in download
+	 * in download. A timeout of 60 seconds is hard-coded and 10 retries are attempted.
 	 *
 	 * @param url
 	 * @param destination

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
@@ -80,6 +80,12 @@ public class FileDownloadUtils {
 		}
 	}
 
+	/**
+	 * Gets the file extension of a file, excluding '.'.
+	 * If the file name has no extension the file name is returned.
+	 * @param f a File
+	 * @return The extension
+	 */
 	public static String getFileExtension(File f) {
 		String fileName = f.getName();
 		String ext = "";
@@ -88,14 +94,20 @@ public class FileDownloadUtils {
 		return ext;
 	}
 
+	/**
+	 * Gets the file name up to and excluding the first
+	 * '.' character. If there is no extension, the full filename
+	 * is returned.
+	 * @param f A file
+	 * @return A possibly empty but non-null String.
+	 */
 	public static String getFilePrefix(File f) {
 		String fileName = f.getName();
-		String fname = "";
-
 		int mid = fileName.indexOf(".");
-		fname = fileName.substring(0, mid);
-
-		return fname;
+		if (mid < 0) {
+			return fileName;
+		}
+		return fileName.substring(0, mid);
 	}
 
 	/**
@@ -152,7 +164,7 @@ public class FileDownloadUtils {
 
 	/**
 	 * Converts path to Unix convention and adds a terminating slash if it was
-	 * omitted
+	 * omitted. 
 	 *
 	 * @param path original platform dependent path
 	 * @return path in Unix convention
@@ -179,10 +191,11 @@ public class FileDownloadUtils {
 	 *
 	 * <p>
 	 * This does not work for some special cases for paths: Other users' homes
-	 * (~user/...), and Tilde expansion within the path (/.../~/...)
+	 * (~user/...), and Tilde expansion within the path (/.../~/...). In these cases
+	 *  the original argument is returned.
 	 *
-	 * @param file
-	 * @return
+	 * @param file A filepath starting with a tilde
+	 * @return An absolute path
 	 */
 	public static String expandUserHome(String file) {
 		if (file.startsWith("~" + File.separator)) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FlatFileCache.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FlatFileCache.java
@@ -58,7 +58,7 @@ public class FlatFileCache {
 
 	/**
 	 * The file is read and the bytes stored immediately.
-	 * <p/>
+	 * <p/> 
 	 * Once added, {@code fileToCache} can be modified or deleted and the cached values will not change.
 	 * @param key
 	 * @param fileToCache A readable file, of Integer.MAX bytes length or less.
@@ -76,7 +76,7 @@ public class FlatFileCache {
 			// to ensure that file is not larger than Integer.MAX_VALUE.
 			if (length > Integer.MAX_VALUE) {
 				// File is too large
-				throw new IllegalArgumentException("File must be <= " + Integer.MAX_VALUE + "bytes long");
+				throw new IllegalArgumentException("File must be <= " + Integer.MAX_VALUE + " bytes long");
 			}
 
 			// Create the byte array to hold the data

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FlatFileCache.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FlatFileCache.java
@@ -24,10 +24,14 @@
 
 package org.biojava.nbio.core.util;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.*;
 
 /**
  * Provides a cache for storing multiple small files in memory. Can be used to e.g cache gzip compressed PDB files
@@ -52,11 +56,17 @@ public class FlatFileCache {
 
 	}
 
-
+	/**
+	 * The file is read and the bytes stored immediately.
+	 * <p/>
+	 * Once added, {@code fileToCache} can be modified or deleted and the cached values will not change.
+	 * @param key
+	 * @param fileToCache A readable file, of Integer.MAX bytes length or less.
+	 */
 	public  static void addToCache(String key, File fileToCache){
 		//logger.debug("storing " + key + " on file cache (cache size: " + cache.size() + ")");
-		try {
-			InputStream is = new FileInputStream(fileToCache);
+		try (InputStream is = new FileInputStream(fileToCache)){
+			
 			// Get the size of the file
 			long length = fileToCache.length();
 
@@ -66,6 +76,7 @@ public class FlatFileCache {
 			// to ensure that file is not larger than Integer.MAX_VALUE.
 			if (length > Integer.MAX_VALUE) {
 				// File is too large
+				throw new IllegalArgumentException("File must be <= " + Integer.MAX_VALUE + "bytes long");
 			}
 
 			// Create the byte array to hold the data
@@ -94,7 +105,12 @@ public class FlatFileCache {
 			logger.error("Error adding to cache! " + e.getMessage(), e);
 		}
 	}
-
+	/**
+	 * Gets the cached file as an InputStream.
+	 * Clients should check for null as the item might have expired in the  cache.
+	 * @param key
+	 * @return An {@code InputStream} or null. 
+	 */
 	public  static InputStream getInputStream(String key){
 		//logger.debug("returning " + key + " from file cache (cache size: " + cache.size() + ")");
 		byte[] bytes = cache.get(key);
@@ -105,6 +121,11 @@ public class FlatFileCache {
 
 	}
 
+	/**
+	 * Returns the number of items in the cache.
+	 * If the cache is {@}, returns -1
+	 * @return
+	 */
 	public static int size() {
 		if ( cache != null)
 			return cache.size();
@@ -112,10 +133,11 @@ public class FlatFileCache {
 			return -1;
 	}
 
+	/**
+	 * Removes all elements from the cache
+	 */
 	public static void clear(){
 	   cache.clear();
 	}
-
-
 
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/SoftHashMap.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/SoftHashMap.java
@@ -19,18 +19,21 @@
 
 package org.biojava.nbio.core.util;
 
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.SoftReference;
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Set;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.ref.ReferenceQueue;
-import java.lang.ref.SoftReference;
-import java.util.*;
-
 
 /** A in memory cache using soft references. (can be garbage collected)
- *
  * This code is based on: http://java-interview-faqs.blogspot.com/2008/09/building-faster-and-efficient-cache.html
- * */
+ */
 
 
 public class SoftHashMap<K, V> extends AbstractMap<K, V> {
@@ -40,188 +43,112 @@ public class SoftHashMap<K, V> extends AbstractMap<K, V> {
 	public static final int DEFAULT_LIMIT = 1;
 
 	/** The internal HashMap that stores SoftReference to actual data. */
-
 	private final Map<K, SoftReference<V>> map = new HashMap<K, SoftReference<V>>();
 
 	/** Maximum Number of references you dont want GC to collect. */
-
 	private final int max_limit;
 
 	/** The FIFO list of hard references, order of last access. */
-
 	private final LinkedList<V> hardCache = new LinkedList<V>();
 
 	/** Reference queue for cleared SoftReference objects. */
-
 	private final ReferenceQueue<V> queue = new ReferenceQueue<V>();
 
 	public SoftHashMap() {
-
 		this(1000);
-
 	}
 
 	public SoftHashMap(int hardSize) {
-
 		max_limit = hardSize;
-
 	}
 
 	@Override
-public V get(Object key) {
+	public V get(Object key) {
 
 		V result = null;
 
 		// We get the SoftReference represented by that key
-
 		SoftReference<V> soft_ref = map.get(key);
 
 		if (soft_ref != null) {
-
 			try {
-
 				// From the SoftReference we get the value, which can be
-
 				// null if it was not in the map, or it was removed in
-
 				// the clearGCCollected() method defined below
 
 				result = soft_ref.get();
-
 				if (result == null) {
-
 					// If the value has been garbage collected, remove the
-
 					// entry from the HashMap.
-
 					map.remove(key);
-
 				} else {
-
 					// We now add this object to the beginning of the hard
-
 					// reference queue. One reference can occur more than
-
 					// once, because lookups of the FIFO queue are slow, so
-
 					// we don't want to search through it each time to remove
-
 					// duplicates.
 
 					synchronized (hardCache){
 						hardCache.addFirst(result);
-
 						if (hardCache.size() > max_limit) {
-
 							// Remove the last entry if list greater than MAX_LIMIT
-
 							hardCache.removeLast();
-
 						}
 					}
-
 				}
 			} catch (Exception e){
-			 logger.error("Exception: ", e);
+				logger.error("Exception: ", e);
 			}
-
 		}
-
 		return result;
-
 	}
 
-
-
 	/**
-
 	 * We define our own subclass of SoftReference which contains not only the
-
 	 * value but also the key to make it easier to find the entry in the HashMap
-
 	 * after it's been garbage collected.
-
 	 */
-
 	private static class SoftValue<K, V> extends SoftReference<V> {
 
 		private final Object key; // always make data member final
-
-
-
+		
 		/**
-
 		 * Did you know that an outer class can access private data members and
-
 		 * methods of an inner class? I didn't know that! I thought it was only
-
 		 * the inner class who could access the outer class's private
-
 		 * information. An outer class can also access private members of an
-
 		 * inner class inside its inner class.
-
 		 */
-
 		private SoftValue(V k, K key, ReferenceQueue<? super V> q) {
-
 			super(k, q);
-
 			this.key = key;
-
 		}
-
 	}
 
-
-
 	/**
-
 	 * Here we go through the ReferenceQueue and remove garbage collected
-
 	 * SoftValue objects from the HashMap by looking them up using the
-
 	 * SoftValue.key data member.
-
 	 */
-
 	@SuppressWarnings("unchecked") // every Reference in queue is stored as a SoftValue
 	private void clearGCCollected() {
-
 		SoftValue<K, V> sv;
-
 		while ((sv = (SoftValue<K, V>) queue.poll()) != null) {
-
 			map.remove(sv.key); // we can access private data!
-
 		}
-
 	}
-
-
 
 	/**
-
 	 * Here we put the key, value pair into the HashMap using a SoftValue
-
 	 * object.
-
 	 */
-
 	@Override
-public synchronized V put(K key, V value) {
-
+	public synchronized V put(K key, V value) {
 		clearGCCollected();
-
 		logger.debug("Putting {} on cache. size: {}", key, size());
-
 		map.put(key, new SoftValue<K, V>(value, key, queue));
-
 		return value;
-
 	}
-
-
 
 	@Override
 	public V remove(Object key) {
@@ -230,11 +157,8 @@ public synchronized V put(K key, V value) {
 		return map.remove(key).get();
 	}
 
-
-
 	@Override
-public void clear() {
-
+	public void clear() {
 		synchronized (hardCache){
 			hardCache.clear();
 		}
@@ -242,27 +166,16 @@ public void clear() {
 		clearGCCollected();
 		logger.debug("clearing cache");
 		map.clear();
-
 	}
 
-
-
 	@Override
-public int size() {
-
+	public int size() {
 		clearGCCollected();
-
 		return map.size();
-
 	}
-
-
 
 	@Override
-public Set<Map.Entry<K, V>> entrySet() {
-
+	public Set<Map.Entry<K, V>> entrySet() {
 		throw new UnsupportedOperationException();
-
 	}
-
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/SoftHashMap.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/SoftHashMap.java
@@ -33,9 +33,12 @@ import org.slf4j.LoggerFactory;
 
 /** A in memory cache using soft references. (can be garbage collected)
  * This code is based on: http://java-interview-faqs.blogspot.com/2008/09/building-faster-and-efficient-cache.html
+ * <p/>
+ * Note that entrySet() is not implemented and therefore many methods such as keySet(),
+ * containsKey(), values() etc do not work.
+ * <p/>
+ * This class is therefore best used as a cache simply to put and get items by a known key
  */
-
-
 public class SoftHashMap<K, V> extends AbstractMap<K, V> {
 
 	private final static Logger logger = LoggerFactory.getLogger(SoftHashMap.class);
@@ -58,6 +61,10 @@ public class SoftHashMap<K, V> extends AbstractMap<K, V> {
 		this(1000);
 	}
 
+	/**
+	 * @param hardSize A maximum number of items to maintain hard references to
+	 * that will not be eligible for garbage collection
+	 */
 	public SoftHashMap(int hardSize) {
 		max_limit = hardSize;
 	}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/HashcoderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/HashcoderTest.java
@@ -1,0 +1,134 @@
+package org.biojava.nbio.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.biojava.nbio.core.util.Hashcoder;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+
+class HashcoderTest {
+
+    int seed = Hashcoder.SEED;
+    @RepeatedTest(10)
+    void hashcodeBool() {
+        final int EXPECTED_TRUE = 712;
+        final int EXPECTED_FALSE = 711;
+
+        assertEquals(EXPECTED_TRUE, Hashcoder.hash(seed, true));
+        assertFalse(EXPECTED_TRUE == Hashcoder.hash(seed, Boolean.TRUE));
+
+        assertEquals(EXPECTED_FALSE, Hashcoder.hash(seed, false));
+        assertFalse(EXPECTED_FALSE == Hashcoder.hash(seed, Boolean.FALSE));
+    }
+
+    @Test
+    void hashcodeIntProducesUniqueValues() {
+        Set<Integer> hashCodes = new HashSet<>();
+        for (int i =0; i< 1000; i++) {
+            hashCodes.add(Hashcoder.hash(seed, i));
+        }
+        assertEquals(1000, hashCodes.size());
+    }
+
+    @Test
+    void extremeIntValuesHashed(){
+        assertTrue(Hashcoder.hash(seed, Integer.MAX_VALUE) != 0);
+        assertTrue(Hashcoder.hash(seed, Integer.MIN_VALUE) != 0);
+    }
+
+    @Test
+    void hashcodeLongProducesUniqueValues() {
+        Set<Integer> hashCodes = new HashSet<>();
+        for (int i =0; i< 1000; i++) {
+            hashCodes.add(Hashcoder.hash(seed, (long)i));
+        }
+        assertEquals(1000, hashCodes.size());
+      
+    }
+
+    @Test
+    void extremeLongValuesHashed(){
+        assertTrue(Hashcoder.hash(seed, Long.MAX_VALUE) != 0);
+        assertTrue(Hashcoder.hash(seed, Long.MIN_VALUE) != 0);
+    }
+
+    @Test
+    void hashcodeCharProducesUniqueValues() {
+        final int NUM_CHAR=65535;
+        Set<Integer> hashCodes = new HashSet<>();
+        for (int i =0; i< Character.MAX_VALUE; i++) {
+            char [] codes = Character.toChars(i);
+            hashCodes.add(Hashcoder.hash(seed, codes[0]));
+        }
+        assertEquals(NUM_CHAR, hashCodes.size());
+    }
+
+    @Test
+    void hashcodeFloatDifferentPrecisionSameHash() {
+        Set<Integer> hashCodes = new HashSet<>();
+        float [] floats = new float [] {1, 1.0f, 1.00f, 1.000f};
+        for (float f: floats) {
+            hashCodes.add(Hashcoder.hash(seed, f));
+        }
+        assertEquals(1, hashCodes.size());
+    }
+
+    @Test
+    void hashcodeDoubleDifferentPrecisionSameHash() {
+        Set<Integer> hashCodes = new HashSet<>();
+        double [] doubles = new double [] {1, 1.0f, 1.00f, 1.000f};
+        for (double d: doubles) {
+            hashCodes.add(Hashcoder.hash(seed, d));
+        }
+        assertEquals(1, hashCodes.size());
+    }
+
+    @Test
+    void hashcodeLong() {
+        Set<Integer> hashCodes = new HashSet<>();
+        double [] doubles = new double [] {1, 1.0f, 1.00f, 1.000f};
+        for (double d: doubles) {
+            hashCodes.add(Hashcoder.hash(seed, d));
+        }
+        assertEquals(1, hashCodes.size());
+    }
+
+    static class TestObject {
+        // test spies
+        boolean hashcodeInvoked = false;
+        static int totalHashcodeInvocations = 0;
+
+        public int hashCode() {
+            totalHashcodeInvocations++;
+            hashcodeInvoked = true;
+            return 1;
+        }   
+    }
+
+    @Test
+    void hashCodeObjectInvokesObjectsHashcode(){
+        TestObject test = new TestObject();
+        Hashcoder.hash(seed, test);
+        assertTrue(test.hashcodeInvoked);
+    }
+
+    @Test
+    void hashCodeArrayInvokesHashcodeOnEachObject(){
+        // 3 element array
+        TestObject [] testObjects = new TestObject[]{new TestObject(),
+             new TestObject(), new TestObject()};
+        Hashcoder.hash(seed, testObjects);
+        assertEquals(3, TestObject.totalHashcodeInvocations); 
+    }
+
+    @Test
+    void hashcodeOfEmptyArrayReturnsSeed(){
+        assertEquals(seed, Hashcoder.hash(seed, new TestObject[]{}));
+    }
+    
+}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/EqualsTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/EqualsTest.java
@@ -1,0 +1,106 @@
+package org.biojava.nbio.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.temporal.Temporal;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class EqualsTest {
+
+    @Test
+    void equalsInt(){
+        assertTrue(Equals.equal(1, 1));
+        assertTrue(Equals.equal(Integer.MAX_VALUE, Integer.MAX_VALUE));
+        assertTrue(Equals.equal(Integer.valueOf(1), Integer.valueOf(1)));
+        assertFalse(Equals.equal(1, 2));
+    }
+
+    void equalsBool(){
+        assertTrue(Equals.equal(true, true));
+        assertTrue(Equals.equal(Boolean.valueOf(true), Boolean.valueOf(true)));
+        assertFalse(Equals.equal(true, false));
+    }
+
+    void equalsLong(){
+        assertTrue(Equals.equal(1L, 1L));
+        assertTrue(Equals.equal(Long.valueOf(1L), Long.valueOf(1L)));
+        assertTrue(Equals.equal(Long.MAX_VALUE, Long.MAX_VALUE));
+        assertFalse(Equals.equal(1L, 1L));
+    }
+
+    @Nested
+    class ObjectEquals {
+        Object o1 = new Object();
+        Object o1Ref = o1;
+        Object o2 = new Object();
+
+        @Test
+        void twoNullsAreEqual(){
+            assertTrue(Equals.equal(null, null));
+        }
+        @Test
+        void objectWithNullIsNotEqual(){
+            assertFalse(Equals.equal(o1, null));
+            assertFalse(Equals.equal(null, o1));
+        }
+
+        @Test
+        void identicalObjectIsEquals(){
+            assertTrue(Equals.equal(o1, o1));
+            assertTrue(Equals.equal(o1, o1Ref));
+            assertFalse(Equals.equal(o1, o2));
+        }
+
+        @Test
+        void equalsBasedOnProperties(){
+            LocalDate date = LocalDate.of(2021, Month.APRIL, 21);
+            LocalDate sameDate =  LocalDate.of(2021, Month.APRIL, 21);
+            LocalDate differentDate =  LocalDate.of(2022, Month.APRIL, 21);
+            assertTrue(Equals.equal(date, sameDate));
+            assertFalse(Equals.equal(date, differentDate));
+        }
+    }
+
+    @Nested
+    class ClassEquals {
+        LocalDate nowDate = LocalDate.now();
+        LocalDate different = nowDate.plusDays(5);
+        @Test
+        void identicalClassesAreEqual() {  
+            assertTrue(Equals.classEqual(nowDate, different));
+        }
+        @Test
+        void classComparisonIsByActualTypeNotReferenceType() {
+            Temporal temporal = (Temporal) nowDate;
+            assertTrue(Equals.classEqual(temporal, different));
+        }
+
+        @Test
+        void genericsAreIgnored() {
+            List<String> listOfStrings = new ArrayList<>();
+            List<Integer> listOfInts = new ArrayList<>();
+            assertTrue(Equals.classEqual(listOfStrings, listOfInts));
+        }
+
+        class ASuperclass {
+            Integer a, b = 0;
+        }
+        class ASubclass extends ASuperclass {
+            Integer c, d = 0;
+        }
+        @Test
+        void membersOfClassHierarchyAreNotEqual() {
+            ASuperclass superObject = new ASuperclass();
+            ASuperclass subObject = new ASubclass();
+            assertFalse(Equals.classEqual(superObject, subObject));
+            assertFalse(Equals.classEqual(subObject, superObject));
+        }   
+    }  
+}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
@@ -3,11 +3,14 @@ package org.biojava.nbio.core.util;
 import static org.biojava.nbio.core.util.FileDownloadUtils.getFileExtension;
 import static org.biojava.nbio.core.util.FileDownloadUtils.getFilePrefix;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -125,7 +128,7 @@ class FileDownloadUtilsTest {
     }
 
     @Nested
-    class ToUserHome {
+    class ExpandUserHome {
         String currUserHome = System.getProperty("user.home");
         @Test
         void simplePath (){
@@ -137,5 +140,44 @@ class FileDownloadUtilsTest {
             String path="~/a/b/c/sequence.gb";
             assertEquals(currUserHome+File.separator+"a/b/c/sequence.gb", FileDownloadUtils.expandUserHome(path));
         }  
+    }
+
+    @Nested
+    class URLMethods {
+        final String availableUrl = "https://www.google.com";
+
+        @Test
+        void pingGoogleOK(){
+            assertTrue(FileDownloadUtils.ping(availableUrl, 1000));
+        }
+
+        @Test
+        void pingNonExistentFalse(){
+            assertFalse(FileDownloadUtils.ping("https://non-existent.biojava", 1));
+        }
+    }
+    @Nested
+    class DeleteDirectory {
+
+        private File createDirectoryTree () throws IOException {
+
+            File tmpdir = Files.createTempDirectory("tmpDirPrefix").toFile();
+            File child1 = new File(tmpdir, "a");
+            File child2 = new File(child1, "b");
+            File child3 = new File(child2, "c");
+            File f = new File(child3, "seq.fa");
+            child3.mkdirs();
+            f.createNewFile();
+            return tmpdir;
+        }
+
+        @Test
+        void deleteFolderTree() throws IOException{
+            File toDelete = createDirectoryTree();
+            assertTrue(toDelete.exists());
+
+            FileDownloadUtils.deleteDirectory(toDelete.getAbsolutePath());
+            assertFalse(toDelete.exists());
+        }
     }
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
@@ -1,0 +1,52 @@
+package org.biojava.nbio.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class FileDownloadUtilsTest {
+
+    @Nested
+    class FileCopy {   
+        
+        private File createSrcFile () throws IOException {
+            byte [] toSave = new byte []{1,2,3,4,5};
+            File src = File.createTempFile("test", ".dat");
+            try (FileOutputStream fos = new FileOutputStream(src);){
+                fos.write(toSave);
+            }
+            return src;
+        }
+
+        @Test
+        void copyFile() throws IOException {
+            File src = createSrcFile();
+            //sanity check
+            assertEquals(5, src.length());
+            File dest = File.createTempFile("dest", ".dat");
+            assertEquals(0, dest.length());
+            FileDownloadUtils.copy(src, dest);
+            assertEquals(5, dest.length());
+
+            //original is unaffected
+            assertEquals(5, src.length());
+            
+            // bytes are identical
+            try (FileInputStream fis1 = new FileInputStream(src);
+                FileInputStream fis2 =  new FileInputStream(dest)) {
+                int b = -1;
+                while (( b = fis1.read()) != -1) {
+                    int b2 = fis2.read();
+                    assertEquals (b, b2);
+                }
+            }
+        }
+
+    }
+}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
@@ -1,5 +1,7 @@
 package org.biojava.nbio.core.util;
 
+import static org.biojava.nbio.core.util.FileDownloadUtils.getFileExtension;
+import static org.biojava.nbio.core.util.FileDownloadUtils.getFilePrefix;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
@@ -47,6 +49,93 @@ class FileDownloadUtilsTest {
                 }
             }
         }
+    }
 
+    @Nested
+    class FileExtension {
+        @Test
+        void getExtensionHappyCase(){
+            File someFile = new File("sequence.fasta");
+            assertEquals("fasta", getFileExtension(someFile));
+        }
+
+        @Test
+        void lastSuffixOnlyReturned(){
+            File someFile = new File("sequence.1.a.fasta");
+            assertEquals("fasta", getFileExtension(someFile));
+        }
+        
+        @Test
+        void fileNameEndingInDotReturnsEmptyString(){
+            File someFile = new File("noExtension.");
+            assertEquals("", getFileExtension(someFile));
+        }
+
+        @Test
+        void hiddenFile(){
+            File someFile = new File(".m2");
+            assertEquals("m2", getFileExtension(someFile));
+        }
+
+        @Test
+        void noExtension(){
+            File someFile = new File("nameOnly");
+            assertEquals("nameOnly", getFileExtension(someFile));
+        }        
+    }
+
+    @Nested
+    class GetFilePrefix{
+        @Test
+        void standardFileName(){
+            File someFile = new File("sequence.fasta");
+            assertEquals("sequence", getFilePrefix(someFile));
+        }
+        @Test
+        void prefixIsUpToFirstDot(){
+            File someFile = new File("sequence.1.2.fasta");
+            assertEquals("sequence", getFilePrefix(someFile));
+        }
+
+        @Test
+        void noExtension(){
+            File someFile = new File("nameOnly");
+            assertEquals("nameOnly", getFilePrefix(someFile));
+        }
+
+        @Test
+        void hiddenFile(){
+            File someFile = new File(".m2");
+            assertEquals("", getFilePrefix(someFile));
+        }
+    }
+
+    @Nested
+    class ToUnixPath {
+        @Test
+        void windowsToUnixAddsTrailingSlash(){
+            String winPath = "C:\\a\\b\\c";
+            assertEquals("C:/a/b/c/", FileDownloadUtils.toUnixPath(winPath));
+        }
+        @Test
+        void unixPathReturnedUnchanged(){
+            String path = "/a/b/c/";
+            assertEquals(path, FileDownloadUtils.toUnixPath(path));
+        }
+    }
+
+    @Nested
+    class ToUserHome {
+        String currUserHome = System.getProperty("user.home");
+        @Test
+        void simplePath (){
+            String path="~/sequence.gb";
+            assertEquals(currUserHome+File.separator+"sequence.gb", FileDownloadUtils.expandUserHome(path));
+        }
+        @Test
+        void nestedPath (){
+            String path="~/a/b/c/sequence.gb";
+            assertEquals(currUserHome+File.separator+"a/b/c/sequence.gb", FileDownloadUtils.expandUserHome(path));
+        }  
     }
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FlatFileCacheTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FlatFileCacheTest.java
@@ -29,7 +29,6 @@ class FlatFileCacheTest {
         return f;
     }
 
-    int seed = Hashcoder.SEED;
     @Test
     void flatFileRetrieve () throws IOException {
         File aDNAFile = createSmallTmpFile();

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FlatFileCacheTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FlatFileCacheTest.java
@@ -32,16 +32,16 @@ class FlatFileCacheTest {
     int seed = Hashcoder.SEED;
     @Test
     void flatFileRetrieve () throws IOException {
-        File anyFile = createSmallTmpFile();
+        File aDNAFile = createSmallTmpFile();
         assertEquals(0, FlatFileCache.size());
-        FlatFileCache.addToCache("key", anyFile);
+        FlatFileCache.addToCache("key", aDNAFile);
         assertEquals(1, FlatFileCache.size());
 
         InputStream is = FlatFileCache.getInputStream("key");
         assertNotNull(is);
         byte [] b = new byte[1024];
         int read = is.read(b);
-        assertEquals(anyFile.length(), (long)read );
+        assertEquals(aDNAFile.length(), (long)read );
         assertEquals(aDNA, new String(b, "UTF8").substring(0,4));
     }
 
@@ -53,8 +53,6 @@ class FlatFileCacheTest {
         assertEquals(10, FlatFileCache.size());
         FlatFileCache.clear();
         assertEquals(0, FlatFileCache.size());
-
-
     }
 
     @Test
@@ -64,16 +62,19 @@ class FlatFileCacheTest {
 
     @Test
     void fileCanBeModifiedButCachedValueIsUnchanged() throws IOException{
-        File anyFile = createSmallTmpFile();
-        FlatFileCache.addToCache("key", anyFile);
-        Files.writeString(Path.of(anyFile.getAbsolutePath()), aProtein);
+        File aDNAFile = createSmallTmpFile();
+        FlatFileCache.addToCache("key", aDNAFile);
+        long originalLength = aDNAFile.length();
+        
+        // write new content to original file
+        Files.writeString(Path.of(aDNAFile.getAbsolutePath()), aProtein);
+
+        // retrieve from cache, is unchanged
         InputStream is = FlatFileCache.getInputStream("key");
         byte [] b = new byte[1024];
         int read = is.read(b);
-        assertEquals(aDNA.length(), (long)read );
+        assertEquals(originalLength, (long)read );
         assertEquals(aDNA, new String(b, "UTF8").substring(0,4));
     }
 
-    
-    
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FlatFileCacheTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FlatFileCacheTest.java
@@ -1,0 +1,79 @@
+package org.biojava.nbio.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FlatFileCacheTest {
+
+    final String aDNA = "ATCG";
+    final String aProtein = "WCTH";
+
+    @BeforeEach
+    void before(){
+        FlatFileCache.clear();
+    }
+
+    File createSmallTmpFile() throws IOException{
+        File f = File.createTempFile("flatFile","txt");
+        Files.writeString(Path.of(f.getAbsolutePath()), aDNA);
+        return f;
+    }
+
+    int seed = Hashcoder.SEED;
+    @Test
+    void flatFileRetrieve () throws IOException {
+        File anyFile = createSmallTmpFile();
+        assertEquals(0, FlatFileCache.size());
+        FlatFileCache.addToCache("key", anyFile);
+        assertEquals(1, FlatFileCache.size());
+
+        InputStream is = FlatFileCache.getInputStream("key");
+        assertNotNull(is);
+        byte [] b = new byte[1024];
+        int read = is.read(b);
+        assertEquals(anyFile.length(), (long)read );
+        assertEquals(aDNA, new String(b, "UTF8").substring(0,4));
+    }
+
+    @Test
+    void clearRemovesAllItems () throws IOException {
+        for (int i = 0; i< 10; i++) {
+            FlatFileCache.addToCache(""+i, createSmallTmpFile());
+        }
+        assertEquals(10, FlatFileCache.size());
+        FlatFileCache.clear();
+        assertEquals(0, FlatFileCache.size());
+
+
+    }
+
+    @Test
+    void nullReturnedIfNoValueForKey () throws IOException {
+        assertNull(FlatFileCache.getInputStream("nonexistent"));
+    }
+
+    @Test
+    void fileCanBeModifiedButCachedValueIsUnchanged() throws IOException{
+        File anyFile = createSmallTmpFile();
+        FlatFileCache.addToCache("key", anyFile);
+        Files.writeString(Path.of(anyFile.getAbsolutePath()), aProtein);
+        InputStream is = FlatFileCache.getInputStream("key");
+        byte [] b = new byte[1024];
+        int read = is.read(b);
+        assertEquals(aDNA.length(), (long)read );
+        assertEquals(aDNA, new String(b, "UTF8").substring(0,4));
+    }
+
+    
+    
+}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/HashcoderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/HashcoderTest.java
@@ -1,4 +1,4 @@
-package org.biojava.nbio.core;
+package org.biojava.nbio.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.biojava.nbio.core.util.Hashcoder;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/HashcoderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/HashcoderTest.java
@@ -43,8 +43,8 @@ class HashcoderTest {
     @Test
     void hashcodeLongProducesUniqueValues() {
         Set<Integer> hashCodes = new HashSet<>();
-        for (int i =0; i< 1000; i++) {
-            hashCodes.add(Hashcoder.hash(seed, (long)i));
+        for (long i =0; i< 1000; i++) {
+            hashCodes.add(Hashcoder.hash(seed, i));
         }
         assertEquals(1000, hashCodes.size());
       

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/SingleLinkageClustererTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/SingleLinkageClustererTest.java
@@ -1,0 +1,51 @@
+package org.biojava.nbio.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class SingleLinkageClustererTest {
+    
+    // from wikipedia example
+    // https://en.wikipedia.org/wiki/Single-linkage_clustering
+    double [][] matrix = new double[][]{
+        {0, 17, 21,31,23},
+        {17,0,30,34,21},
+        {21,30,0,28,39},
+        {31,34,28,0,43},
+        {23,21,39,43,0}
+        };
+
+
+    @Test
+    void squareMatrixRequired() {
+        double [][] non_square_matrix = new double[][]{{1,2},{1,2,3},{1}};
+        assertThrows(IllegalArgumentException.class, ()->new SingleLinkageClusterer(non_square_matrix, false));
+    }
+    @Test
+    void clusterWikipediaExampleDistanceMatrix(){
+        SingleLinkageClusterer clusterer = new SingleLinkageClusterer(matrix, false);
+        Map<Integer, Set<Integer>> result = clusterer.getClusters(Double.MAX_VALUE);
+        assertEquals(5, result.get(1).size());
+
+        result = clusterer.getClusters(0);
+        assertEquals(1, result.get(1).size());
+    }
+
+    @Test
+    void clusterWikipediaExampleScoreMatrix(){
+        SingleLinkageClusterer clusterer = new SingleLinkageClusterer(matrix, true);
+        Map<Integer, Set<Integer>> result = clusterer.getClusters(0);
+        assertEquals(5, result.get(1).size());
+        result = clusterer.getClusters(Double.MAX_VALUE);
+        assertEquals(1, result.get(1).size());
+
+
+    }
+
+    
+}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/SingleLinkageClustererTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/SingleLinkageClustererTest.java
@@ -12,6 +12,7 @@ class SingleLinkageClustererTest {
     
     // from wikipedia example
     // https://en.wikipedia.org/wiki/Single-linkage_clustering
+    // it should produce clusters ((0,1),2,4),3 at distance 8.5, 10.5 and 14
     double [][] matrix = new double[][]{
         {0, 17, 21,31,23},
         {17,0,30,34,21},
@@ -43,8 +44,6 @@ class SingleLinkageClustererTest {
         assertEquals(5, result.get(1).size());
         result = clusterer.getClusters(Double.MAX_VALUE);
         assertEquals(1, result.get(1).size());
-
-
     }
 
     

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/SoftHashMapTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/SoftHashMapTest.java
@@ -2,35 +2,110 @@ package org.biojava.nbio.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
+
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-
+/** 
+ * Includes a disabled test that asserts behaviour of collecting
+ * SoftReferences, run using -Xmx=5M to expose this behaviour.
+ */
 class SoftHashMapTest {
 
     static class TestObject  {
+        /*
+        *Create an object occupying negligible memory
+        */
+        static TestObject small(String name){
+            return new TestObject(name, 100);
+        }
+
+        /*
+        *Create a test object occupying significant memory(100kB)
+        */
+        static TestObject large(String name){
+            return new TestObject(name, 100_000);
+        }
         private String name;
-        public TestObject(String string) {
+        private int [] internalArray = null; 
+        public TestObject(String string, int capacity) {
             this.name=string;
+            this.internalArray = new int [capacity];
         }
         String getName(){
             return name;
         }
+        public String toString(){
+            return name;
+        }
     }
+
+    // This test needs to be run with restricted memory in order
+    // to expose the behaviour of SoftHashMap in deleting entries 
+    // when under memory pressure. By setting -Xmx=5M the test can
+    // assert that entries are deleted. We don't want to risk throwing
+    // OOM errors during normal test execution so this is disabled
+    @Test
+    @Disabled("requires to run in conditions nearly throwing an OOM")
+    void softMapRemovesRefsToSaveMemory() throws InterruptedException{
+       
+        //Using a regular Map with hard references will probably
+        // cause an OOM error if running with -Xmx=5M. Uncomment this
+        // and comment out the next line to observe this.
+        //Map<String, TestObject> map =new HashMap<>(1);
+
+        // set the maximum number of hard references to 1 (minimum)
+        // to expose behaviour of soft references better. 
+        Map<String, TestObject> map = new SoftHashMap<>(1);
+        int totalPuts =5;
+        for (int i = 0; i < totalPuts; i++) {
+
+            TestObject myObject = TestObject.large(""+i);
+            map.put(myObject.getName(),myObject);
+            //allocate a little slowly
+            // enables GC time to work
+            Thread.sleep(10);
+        }
+        int nonNullValues = countNonNullMapReferences(map, totalPuts);
+        // some but not all references should be removed.
+        assertTrue(nonNullValues > 0 && nonNullValues < totalPuts);
+    }
+
+    private int countNonNullMapReferences(Map<String, TestObject> map, int totalPuts) {
+        try {
+            //sleep a little in case if finalizers are currently running
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        // we can't iterate over map as keySet() isn't implemented
+        int nonNullValues = 0;
+        for (int i = 0; i< totalPuts; i++) {
+            if(map.get("" + i ) != null) {
+                nonNullValues++;
+            }
+        } 
+        return nonNullValues;
+    }
+
+    
     
     @Test
     void basicMapOperations() throws InterruptedException{
         
         SoftHashMap<String, TestObject> map = new SoftHashMap<>(1);
-        TestObject s1= new TestObject("1");
-        TestObject s2= new TestObject("2");
-        TestObject s3= new TestObject("3");
+        TestObject s1= TestObject.small("1");
+        TestObject s2= TestObject.small("2");
+        TestObject s3= TestObject.small("3");
     
         map.put("1", s1);
         map.put("2", s2);
         map.put("3", s3);
         assertEquals(3, map.size());
 
-        map.put("3", new TestObject("4"));
+        map.put("3", TestObject.small("4"));
         assertEquals(3, map.size());
 
         assertEquals(s1, map.remove("1"));
@@ -42,13 +117,13 @@ class SoftHashMapTest {
     @Test
     void manyMapOperationsAreUnsupported() throws Exception{
         SoftHashMap<String, TestObject> map = new SoftHashMap<>(1);
-        TestObject s1= new TestObject("1");
+        TestObject s1= TestObject.small("1");
         map.put("1", null);
         // these all use entrySet internally and throw USOException
         assertThrows(UnsupportedOperationException.class, ()->map.containsValue(s1));
         assertThrows(UnsupportedOperationException.class, ()->map.containsKey("1"));
         assertThrows(UnsupportedOperationException.class, ()->map.values().iterator());
-        assertThrows(UnsupportedOperationException.class, ()->map.getOrDefault("1", new TestObject("2")));     
+        assertThrows(UnsupportedOperationException.class, ()->map.getOrDefault("1", TestObject.small("2")));     
     }
         
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/SoftHashMapTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/SoftHashMapTest.java
@@ -51,10 +51,10 @@ class SoftHashMapTest {
     @Disabled("requires to run in conditions nearly throwing an OOM")
     void softMapRemovesRefsToSaveMemory() throws InterruptedException{
        
-        //Using a regular Map with hard references will probably
+        // Using a regular Map with hard references will probably
         // cause an OOM error if running with -Xmx=5M. Uncomment this
         // and comment out the next line to observe this.
-        //Map<String, TestObject> map =new HashMap<>(1);
+        // Map<String, TestObject> map =new HashMap<>(1);
 
         // set the maximum number of hard references to 1 (minimum)
         // to expose behaviour of soft references better. 
@@ -89,8 +89,6 @@ class SoftHashMapTest {
         } 
         return nonNullValues;
     }
-
-    
     
     @Test
     void basicMapOperations() throws InterruptedException{

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/SoftHashMapTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/SoftHashMapTest.java
@@ -1,0 +1,54 @@
+package org.biojava.nbio.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class SoftHashMapTest {
+
+    static class TestObject  {
+        private String name;
+        public TestObject(String string) {
+            this.name=string;
+        }
+        String getName(){
+            return name;
+        }
+    }
+    
+    @Test
+    void basicMapOperations() throws InterruptedException{
+        
+        SoftHashMap<String, TestObject> map = new SoftHashMap<>(1);
+        TestObject s1= new TestObject("1");
+        TestObject s2= new TestObject("2");
+        TestObject s3= new TestObject("3");
+    
+        map.put("1", s1);
+        map.put("2", s2);
+        map.put("3", s3);
+        assertEquals(3, map.size());
+
+        map.put("3", new TestObject("4"));
+        assertEquals(3, map.size());
+
+        assertEquals(s1, map.remove("1"));
+        assertEquals(2, map.size());
+
+        map.clear();
+        assertEquals(0, map.size());
+    }
+    @Test
+    void manyMapOperationsAreUnsupported() throws Exception{
+        SoftHashMap<String, TestObject> map = new SoftHashMap<>(1);
+        TestObject s1= new TestObject("1");
+        map.put("1", null);
+        // these all use entrySet internally and throw USOException
+        assertThrows(UnsupportedOperationException.class, ()->map.containsValue(s1));
+        assertThrows(UnsupportedOperationException.class, ()->map.containsKey("1"));
+        assertThrows(UnsupportedOperationException.class, ()->map.values().iterator());
+        assertThrows(UnsupportedOperationException.class, ()->map.getOrDefault("1", new TestObject("2")));     
+    }
+        
+}


### PR DESCRIPTION
Added test-classes for several util classes. Mostly routine, a few comments. Planned to add tests for all remaining util methods but that would be a monster PR so breaking into 2. 
- added Javadocs I thought would be useful after discovering behaviour through testing
- In a few cases added some obvious error handling  but made minimal changes to source code
- FileDownloadUtils is tricky to test some of the download methods, without doing some refactoring to mock/stub the actual network call and be able to configure timeout to not be hardcoded to 60s
- SingleLinkageClustererTest is quite basic. I followed the Wikipedia example entry and the results from the code are quite similar but not identical to the worked example. Not sure if this is important or relevant in the context in which it's used but can provide more details if needed.
- I can't think of any way to 'fake' memory usage for SoftHashMapTest, so there is a @Disabled test which can be run after setting -Xmx to a low value e.g. 5M. And the test is  slightly non-deterministic as well.  