### PR TITLE
Fix 969 Update SCOP version to 2.08

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopFactory.java
@@ -51,6 +51,7 @@ public class ScopFactory {
 	private static final Logger logger = LoggerFactory.getLogger(ScopFactory.class);
 
 	// berkeley 2
+	public static final String VERSION_2_0_8 = "2.08";
 	public static final String VERSION_2_0_7 = "2.07";
 	public static final String VERSION_2_0_6 = "2.06";
 	public static final String VERSION_2_0_5 = "2.05";
@@ -78,7 +79,7 @@ public class ScopFactory {
 	public static final String VERSION_1_55 = "1.55";
 
 	// The most recent version as of compilation time
-	public static final String LATEST_VERSION = VERSION_2_0_7;
+	public static final String LATEST_VERSION = VERSION_2_0_8;
 
 	// Hold one instance for each version
 	private static Map<String,ScopDatabase> versionedScopDBs = new HashMap<>();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
@@ -58,7 +58,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class ScopInstallation implements LocalScopDatabase {
 
-	public static final String DEFAULT_VERSION = "1.75";
+	public static final String DEFAULT_VERSION = ScopFactory.LATEST_VERSION;
 
 	private static final Logger logger = LoggerFactory.getLogger(ScopInstallation.class);
 
@@ -354,7 +354,7 @@ public class ScopInstallation implements LocalScopDatabase {
 		if ( scopId.length() < 6) {
 			throw new ScopIOException("Does not look like a scop ID! " + scopId);
 		}
-		String pdbId = scopId.substring(1,5);
+		String pdbId = scopId.substring(1,5); //TODO handle this when you handle extended PDBId (PDB ID)
 		List<ScopDomain> doms = getDomainsForPDB(pdbId);
 		if ( doms == null)
 			return null;

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/align/util/AtomCacheTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/align/util/AtomCacheTest.java
@@ -64,6 +64,7 @@ import org.biojava.nbio.structure.scop.ScopFactory;
 import org.biojava.nbio.structure.test.util.GlobalsHelper;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,7 +89,7 @@ public class AtomCacheTest {
 		StructureIO.setAtomCache(cache);
 
 		// Use a fixed SCOP version for stability
-		ScopFactory.setScopDatabase(ScopFactory.VERSION_1_75B);
+		ScopFactory.setScopDatabase(ScopFactory.LATEST_VERSION);
 	}
 
 	@After
@@ -166,6 +167,7 @@ public class AtomCacheTest {
 	 * @throws IOException
 	 * @throws StructureException
 	 */
+	@Ignore("SCOP files < 2.08 are no longer available")
 	@Test
 	public void testGetStructureForChainlessDomains() throws IOException, StructureException {
 		ScopDatabase scop = ScopFactory.getSCOP(ScopFactory.VERSION_1_71); // Uses the range '1-135' without a chain


### PR DESCRIPTION
All SCOP installation file downloads fail because all files before 2.08
no longer exist (error 404).

1- All downloads are corrected by upgrading the LATEST_VERSION to 2.08.
2- testGetStructureForChainlessDomains is ignored because chainless
domains are present only in SCOP < 1.73