### PR TITLE
Update ciftools dependency and fix build/tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<log4j.version>2.14.0</log4j.version>
 		<junit-jupiter.version>5.7.2</junit-jupiter.version>
 		<ciftools.artifact>ciftools-java-jdk8</ciftools.artifact>
-		<ciftools.version>2.0.2</ciftools.version>
+		<ciftools.version>3.0.0</ciftools.version>
 	</properties>
 	<scm>
 		<connection>scm:git:git://github.com/biojava/biojava.git</connection>


### PR DESCRIPTION
- ciftools 3.0.0 (brings AlphaFold/model support to the table)
- ~propose to ignore `openchart` dependency as it doesn't seem to be used - somebody should confirm this, I've never used any of the forester stuff~
- ~with that exclusion, a dependency on jackson-databind was needed~
- ~`Acetylation_site_dataset.gz` reports 403 in tests and on console, but can be downloaded manually via the browser, added this as 1 MB test resource to circumvent test issues~