### PR TITLE
A flexible system for passing custom URL layout in DownloadChemCompProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ BioJava 6.0.0 (future release)
 * Moved classes in `org.biojava.nbio.structure.io.mmcif` to `org.biojava.nbio.structure.chem`
 * Fixed `CRC64Checksum#public void update(byte[] b, int offset, int length)` to use
 the `length` argument correctly as specified in `java.util.zip.Checksum` interface.
+* Removed `DownloadChemCompProvider.useDefaultUrlLayout` with a more flexible system to provide templated URLs `DownloadChemCompProvider.setChemCompPathUrlTemplate()` 
+and `DownloadChemCompProvider.setServerBaseUrl()`
 
 ### Added
 * New keywords fields in `PDBHeader` class, populated by PDB and mmCIF parsers #946

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
@@ -101,10 +101,10 @@ public class DownloadChemCompProvider implements ChemCompProvider {
     /**
      * Set the path to append to the serverBaseUrl (settable in {@link #setServerBaseUrl(String)}).
      * The string can contain placeholders that will be expanded at runtime:
-     * <li>{ccd_id} to be replaced by the chemical component identifier, in capitals</li>
-     * <li>{ccd_id:beginIndex-endIndex} to be replaced by a substring of the chemical component identifier in capitals,
+     * <li>"{ccd_id}" to be replaced by the chemical component identifier, in capitals</li>
+     * <li>"{ccd_id:beginIndex-endIndex}" to be replaced by a substring of the chemical component identifier in capitals,
      * with indices following the same convention as {@link String#substring(int, int)} </li>
-     * <li>{ccd_id:index} to be replaced by a substring of the chemical component identifier in capitals,
+     * <li>"{ccd_id:index}" to be replaced by a substring of the chemical component identifier in capitals,
      * with index either a positive or negative integer to substring from left or right of the string respectively.</li>
      * If any of the indices are off-bounds, then the full chemical component identifier is replaced
      */
@@ -314,6 +314,13 @@ public class DownloadChemCompProvider implements ChemCompProvider {
         return !f.exists();
     }
 
+    /**
+     * Expands the given path URL template, replacing the placeholders as specified in {@link #setChemCompPathUrlTemplate(String)}
+     * by the ccdId given (or its substrings, if indices are present in the template)
+     * @param templateStr the template string with placeholders for ccd ids
+     * @param ccdId the ccd id to replace (in full or a substring)
+     * @return the input templateStr with placeholders replaced
+     */
     static String expandPathUrlTemplate(String templateStr, String ccdId) {
         Matcher m = CCD_ID_TEMPLATE_REGEX.matcher(templateStr);
         StringBuilder output = new StringBuilder();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
@@ -92,9 +92,12 @@ public class DownloadChemCompProvider implements ChemCompProvider {
 
     /**
      * Set the base URL for the location of all chemical component CIF files, to which the chemCompPathUrlTemplate
-     * is appended, settable in {@link #setChemCompPathUrlTemplate(String)}. Must have a trailing slash.
+     * is appended, settable in {@link #setChemCompPathUrlTemplate(String)}.
      */
     public static void setServerBaseUrl(String serverBaseUrl) {
+        if (!serverBaseUrl.endsWith("/")) {
+            serverBaseUrl = serverBaseUrl + "/";
+        }
         DownloadChemCompProvider.serverBaseUrl = serverBaseUrl;
     }
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/chem/DownloadChemCompProvider.java
@@ -50,6 +50,10 @@ public class DownloadChemCompProvider implements ChemCompProvider {
     public static final String DEFAULT_SERVER_URL = "https://files.rcsb.org/ligands/download/";
     public static final String DEFAULT_CHEMCOMP_PATHURL_TEMPLATE = "{ccd_id}.cif";
 
+    /**
+     * The base URL to which the full path specified via {@link #setChemCompPathUrlTemplate(String)} is appended.
+     * It is assumed that it has a trailing slash.
+     */
     public static String serverBaseUrl = DEFAULT_SERVER_URL;
 
     private static File path;
@@ -92,7 +96,8 @@ public class DownloadChemCompProvider implements ChemCompProvider {
 
     /**
      * Set the base URL for the location of all chemical component CIF files, to which the chemCompPathUrlTemplate
-     * is appended, settable in {@link #setChemCompPathUrlTemplate(String)}.
+     * is appended, settable in {@link #setChemCompPathUrlTemplate(String)}. A trailing slash is appended
+     * if not present.
      */
     public static void setServerBaseUrl(String serverBaseUrl) {
         if (!serverBaseUrl.endsWith("/")) {

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/chem/TestDownloadChemCompProvider.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/chem/TestDownloadChemCompProvider.java
@@ -136,6 +136,13 @@ public class TestDownloadChemCompProvider {
 		String e2 = "/my/path/D/hello/D/dir/abcdef/D/12345/D.cif";
 		String r2 = DownloadChemCompProvider.expandPathUrlTemplate(templateStr,"D");
 		assertEquals(e2, r2);
+
+		String e3 = "/my/path//hello//dir/abcdef//12345/.cif";
+		String r3 = DownloadChemCompProvider.expandPathUrlTemplate(templateStr,"");
+		assertEquals(e3, r3);
+
+		templateStr = "/my/fixed/dir";
+		assertEquals(templateStr, DownloadChemCompProvider.expandPathUrlTemplate(templateStr, "" ));
 	}
 
 }

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/chem/TestDownloadChemCompProvider.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/chem/TestDownloadChemCompProvider.java
@@ -18,7 +18,7 @@
  *      http://www.biojava.org/
  *
  */
-package org.biojava.nbio.structure;
+package org.biojava.nbio.structure.chem;
 
 import org.biojava.nbio.core.util.FlatFileCache;
 import org.biojava.nbio.structure.chem.ChemComp;
@@ -106,6 +106,17 @@ public class TestDownloadChemCompProvider {
 		FlatFileCache.clear();
 
 		assertNull(cc.getName());
+	}
+
+	@Test
+	public void testPathUrlTemplateExpansion() {
+		DownloadChemCompProvider.setChemCompPathUrlTemplate("/my/path/{ccd_id:1-2}/dir/{ccd_id}.cif");
+		String e1 = "/my/path/T/dir/ATP.cif";
+		String r1 = DownloadChemCompProvider.expandPathUrlTemplate("ATP");
+		//String r2 = DownloadChemCompProvider.expandPathUrlTemplate("A");
+		//String r3 = DownloadChemCompProvider.expandPathUrlTemplate("AP");
+
+		assertEquals(e1, r1);
 	}
 
 }


### PR DESCRIPTION
This makes it possible to point DownloadChemCompProvider to any custom CCD repository, with any layout. Related to recent additions to ftp.rcsb.org (see [news announcement](https://www.rcsb.org/news?year=2021&article=613b93b3ef055f03d1f222cf&feature=true) )