### PR TITLE
Fix flaky in TestQuatSymmetryDetectorExamples

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryDetector.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryDetector.java
@@ -460,11 +460,11 @@ public class QuatSymmetryDetector {
 		List<SubunitCluster> globalClusters = globalComposition.getClusters();
 		List<SubunitCluster> localClusters = new ArrayList<>();
 
-		Set<Integer> usedClusterIds =
+		TreeSet<Integer> usedClusterIds =
 				usedSubunitIds.stream().
 					map(allSubunitClusterIds::get).
 					distinct().
-					collect(Collectors.toSet());
+					collect(Collectors.toCollection(TreeSet::new));
 
 		// for each used cluster, remove unused subunits
 		for(Integer usedClusterId:usedClusterIds) {


### PR DESCRIPTION
The test `org.biojava.nbio.structure.test.symmetry.TestQuatSymmetryDetectorExamples#testLocal` in `biojava-integrationtest` is flaky. It sometimes fail when changing the random seeds.
The root cause of the problem is `calcLocalSymmetries` uses a `Set` to store `usedClusterIds`. This will result an unguaranteed order in returned `Stoichiometry`.
This fix is to use an ordered `TreeSet` instead of `Set` to reduce the flakiness in the test.

To reproduce the failing test, use the following command. It basically run the same test multiple times with different random seeds.
`mvn -pl biojava-integrationtest edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.biojava.nbio.structure.test.symmetry.TestQuatSymmetryDetectorExamples#testLocal`