### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/biojava-aa-prop/pom.xml
+++ b/biojava-aa-prop/pom.xml
@@ -72,30 +72,15 @@
 			<artifactId>biojava-core</artifactId>
 			<version>6.0.0-SNAPSHOT</version>
 		</dependency>
-		<dependency>
-			<groupId>org.biojava</groupId>
-			<artifactId>biojava-structure</artifactId>
-			<version>6.0.0-SNAPSHOT</version>
-		</dependency>
-
-		<!-- logging dependencies (managed by parent pom, don't set versions or scopes here) -->
+		
 		<dependency>
         	<groupId>org.slf4j</groupId>
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+ 		
+  		
+  		
 
 
 		<dependency>

--- a/biojava-alignment/pom.xml
+++ b/biojava-alignment/pom.xml
@@ -61,17 +61,8 @@
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+ 		
+  		
+  		
 	</dependencies>
 </project>

--- a/biojava-core/pom.xml
+++ b/biojava-core/pom.xml
@@ -51,27 +51,14 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
 	    </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-        </dependency>
-		<!-- logging dependencies (managed by parent pom, don't set versions or scopes here) -->
+        
 		<dependency>
         	<groupId>org.slf4j</groupId>
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+ 		
+  		
+  		
 	</dependencies>
 </project>

--- a/biojava-genome/pom.xml
+++ b/biojava-genome/pom.xml
@@ -116,18 +116,9 @@
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+ 		
+  		
+  		
 	</dependencies>
 
 </project>

--- a/biojava-integrationtest/pom.xml
+++ b/biojava-integrationtest/pom.xml
@@ -48,18 +48,9 @@
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+ 		
+  		
+  		
   </dependencies>
   <description>A module which only has the purpose to run slow running integration tests.
 

--- a/biojava-modfinder/pom.xml
+++ b/biojava-modfinder/pom.xml
@@ -41,18 +41,9 @@
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+ 		
+  		
+  		
   </dependencies>
   <build>
   <plugins>

--- a/biojava-ontology/pom.xml
+++ b/biojava-ontology/pom.xml
@@ -31,18 +31,9 @@
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+ 		
+  		
+  		
   </dependencies>
 
       <properties>

--- a/biojava-protein-disorder/pom.xml
+++ b/biojava-protein-disorder/pom.xml
@@ -72,18 +72,9 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<!-- binding for log4j2, scope=runTime set in parent pom -->
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-slf4j-impl</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.logging.log4j</groupId>
-			<artifactId>log4j-core</artifactId>
-		</dependency>
+		
+		
+		
 		<dependency>
 		    <groupId>javax.xml.bind</groupId>
 		    <artifactId>jaxb-api</artifactId>

--- a/biojava-structure-gui/pom.xml
+++ b/biojava-structure-gui/pom.xml
@@ -51,18 +51,9 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <!-- binding for log4j2, scope=runTime set in parent pom -->
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-slf4j-impl</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-        </dependency>
+        
+        
+        
         <dependency>
             <groupId>org.biojava</groupId>
             <artifactId>jcolorbrewer</artifactId>

--- a/biojava-structure/pom.xml
+++ b/biojava-structure/pom.xml
@@ -72,39 +72,17 @@
 		    <groupId>javax.xml.bind</groupId>
 		    <artifactId>jaxb-api</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-		</dependency>
-
-		<!-- logging dependencies (managed by parent pom, don't set versions or
-			scopes here) -->
+		
+		
+		
 		<dependency>
         	<groupId>org.slf4j</groupId>
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
-		<!--  Testing related dependencies -->
+ 		
+  		
+  		
 
 		<dependency>
 			<groupId>junit</groupId>

--- a/biojava-survival/pom.xml
+++ b/biojava-survival/pom.xml
@@ -19,34 +19,17 @@
     </licenses>
 
     <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
+        
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math</artifactId>
             <version>2.2</version>
         </dependency>
 		<!-- logging dependencies (managed by parent pom, don't set versions or scopes here) -->
-		<dependency>
-        	<groupId>org.slf4j</groupId>
-        	<artifactId>slf4j-api</artifactId>
-    	</dependency>
-    	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+		
+ 		
+  		
+  		
     </dependencies>
 
     <properties>

--- a/biojava-ws/pom.xml
+++ b/biojava-ws/pom.xml
@@ -39,18 +39,9 @@
         	<artifactId>slf4j-api</artifactId>
     	</dependency>
     	<!-- binding for log4j2, scope=runTime set in parent pom -->
- 		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-slf4j-impl</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-api</artifactId>
-  		</dependency>
-  		<dependency>
-    		<groupId>org.apache.logging.log4j</groupId>
-    		<artifactId>log4j-core</artifactId>
-  		</dependency>
+ 		
+  		
+  		
 	</dependencies>
     <build>
         <plugins>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
biojava
biojava-core
{groupId='org.junit.vintage', artifactId='junit-vintage-engine'}
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-alignment
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-structure
{groupId='com.sun.xml.bind', artifactId='jaxb-core'}
{groupId='com.sun.xml.bind', artifactId='jaxb-impl'}
{groupId='javax.activation', artifactId='activation'}
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-structure-gui
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-genome
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-modfinder
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-ws
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-protein-disorder
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-aa-prop
{groupId='org.biojava', artifactId='biojava-structure'}
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-survival
{groupId='junit', artifactId='junit'}
{groupId='org.slf4j', artifactId='slf4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-ontology
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}
biojava-integrationtest
{groupId='org.apache.logging.log4j', artifactId='log4j-slf4j-impl'}
{groupId='org.apache.logging.log4j', artifactId='log4j-api'}
{groupId='org.apache.logging.log4j', artifactId='log4j-core'}


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
