### PR TITLE
Parsing resolution values in PDB (REMARK 2 and REMARK 3 [new format]) and mmCif

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
@@ -580,6 +580,16 @@ public class PDBHeader implements PDBRecord {
 		this.crystallographicInfo = crystallographicInfo;
 	}
 
+	/**
+	 * Returns the resolution (or effective resolution) of the experiment. This is
+	 * related to <code>_refine.ls_d_res_high</code> (DIFFRACTION) or
+	 * <code>_em_3d_reconstruction.resolution</code> (ELECTRON MICROSCOPY) for mmCif
+	 * format, or to <code>REMARK 2</code> or <code>REMARK 3</code> for PDB legacy
+	 * format. If more than one value is available (in rare cases), the last one is
+	 * reported. If no value is available, it defaults to 99.
+	 * 
+	 * @return The reported experiment resolution, 99 if no value is available.
+	 */
 	public float getResolution() {
 		return resolution;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
@@ -586,9 +586,11 @@ public class PDBHeader implements PDBRecord {
 	 * <code>_em_3d_reconstruction.resolution</code> (ELECTRON MICROSCOPY) for mmCif
 	 * format, or to <code>REMARK 2</code> or <code>REMARK 3</code> for PDB legacy
 	 * format. If more than one value is available (in rare cases), the last one is
-	 * reported. If no value is available, it defaults to 99.
+	 * reported. If no value is available, it defaults to
+	 * {@link #DEFAULT_RESOLUTION} ({@value #DEFAULT_RESOLUTION}).
 	 * 
-	 * @return The reported experiment resolution, 99 if no value is available.
+	 * @return The reported experiment resolution, {@link #DEFAULT_RESOLUTION}
+	 *         ({@value #DEFAULT_RESOLUTION}) if no value is available.
 	 */
 	public float getResolution() {
 		return resolution;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumer.java
@@ -10,6 +10,7 @@ import org.rcsb.cif.schema.mm.ChemCompBond;
 import org.rcsb.cif.schema.mm.DatabasePDBRemark;
 import org.rcsb.cif.schema.mm.DatabasePDBRev;
 import org.rcsb.cif.schema.mm.DatabasePDBRevRecord;
+import org.rcsb.cif.schema.mm.Em3dReconstruction;
 import org.rcsb.cif.schema.mm.Entity;
 import org.rcsb.cif.schema.mm.EntityPoly;
 import org.rcsb.cif.schema.mm.EntityPolySeq;
@@ -107,7 +108,13 @@ public interface CifStructureConsumer extends CifFileConsumer<Structure> {
      */
     void consumeDatabasePDBRevRecord(DatabasePDBRevRecord databasePDBrevRecord);
 
-    /**
+	/**
+	 * Consume Electron Microscopy 3D reconstruction data
+	 * @param em3dReconstruction
+	 */
+	void consumeEm3dReconstruction(Em3dReconstruction em3dReconstruction);
+
+	/**
      * Consume a particular Cif category.
      * @param entity data
      */

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
@@ -651,8 +651,10 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
     public void consumeEm3dReconstruction(Em3dReconstruction em3dReconstruction) {
     	this.em3dReconstruction = em3dReconstruction;
     	
-        for (int rowIndex = 0; rowIndex < em3dReconstruction.getRowCount(); rowIndex++) {
-        	pdbHeader.setResolution((float) em3dReconstruction.getResolution().get(rowIndex)); //can it have more than 1 value?
+        for (int rowIndex = 0; rowIndex < em3dReconstruction.getRowCount(); rowIndex++) { //can it have more than 1 value?
+        	final FloatColumn resolution = em3dReconstruction.getResolution();
+			if (ValueKind.PRESENT.equals(resolution.getValueKind(rowIndex)))
+        		pdbHeader.setResolution((float) resolution.get(rowIndex));
         }
         //TODO other fields (maybe RFree)?
     }

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
@@ -69,6 +69,7 @@ import org.rcsb.cif.schema.mm.ChemCompBond;
 import org.rcsb.cif.schema.mm.DatabasePDBRemark;
 import org.rcsb.cif.schema.mm.DatabasePDBRev;
 import org.rcsb.cif.schema.mm.DatabasePDBRevRecord;
+import org.rcsb.cif.schema.mm.Em3dReconstruction;
 import org.rcsb.cif.schema.mm.Entity;
 import org.rcsb.cif.schema.mm.EntityPoly;
 import org.rcsb.cif.schema.mm.EntityPolySeq;
@@ -128,6 +129,7 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
     private List<Chain> currentModel;
     private PDBHeader pdbHeader;
     private String currentNmrModelNumber;
+	private Em3dReconstruction em3dReconstruction;
     private List<Chain> entityChains;
 
     private Entity entity;
@@ -644,6 +646,16 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
             revRecords.add(new org.biojava.nbio.structure.DatabasePDBRevRecord(databasePDBrevRecord, i));
         }
     }
+    
+    @Override
+    public void consumeEm3dReconstruction(Em3dReconstruction em3dReconstruction) {
+    	this.em3dReconstruction = em3dReconstruction;
+    	
+        for (int rowIndex = 0; rowIndex < em3dReconstruction.getRowCount(); rowIndex++) {
+        	pdbHeader.setResolution((float) em3dReconstruction.getResolution().get(rowIndex)); //can it have more than 1 value?
+        }
+        //TODO other fields (maybe RFree)?
+    }
 
     @Override
     public void consumeEntity(Entity entity) {
@@ -831,6 +843,10 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
     public void consumeRefine(Refine refine) {
         for (int rowIndex = 0; rowIndex < refine.getRowCount(); rowIndex++) {
             // RESOLUTION
+        	ValueKind valueKind = refine.getLsDResHigh().getValueKind(rowIndex);
+        	if (ValueKind.NOT_PRESENT.equals(valueKind)) {
+        		continue;
+        	}
             // in very rare cases (for instance hybrid methods x-ray + neutron diffraction, e.g. 3ins, 4n9m)
             // there are 2 resolution values, one for each method
             // we take the last one found so that behaviour is like in PDB file parsing

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
@@ -844,7 +844,7 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
         for (int rowIndex = 0; rowIndex < refine.getRowCount(); rowIndex++) {
             // RESOLUTION
         	ValueKind valueKind = refine.getLsDResHigh().getValueKind(rowIndex);
-        	if (ValueKind.NOT_PRESENT.equals(valueKind)) {
+        	if (! ValueKind.PRESENT.equals(valueKind)) {
         		continue;
         	}
             // in very rare cases (for instance hybrid methods x-ray + neutron diffraction, e.g. 3ins, 4n9m)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConverter.java
@@ -118,6 +118,7 @@ public class CifStructureConverter {
         consumer.consumeDatabasePDBRemark(cifBlock.getDatabasePDBRemark());
         consumer.consumeDatabasePDBRev(cifBlock.getDatabasePDBRev());
         consumer.consumeDatabasePDBRevRecord(cifBlock.getDatabasePDBRevRecord());
+        consumer.consumeEm3dReconstruction(cifBlock.getEm3dReconstruction());
         consumer.consumeEntity(cifBlock.getEntity());
         consumer.consumeEntityPoly(cifBlock.getEntityPoly());
         consumer.consumeEntitySrcGen(cifBlock.getEntitySrcGen());


### PR DESCRIPTION
Apparently it affects only cryo-EM entries.

Partially Fixes #1000 
It fixes the PDBFileParser.
Before fixing the mmCifParser we need first to check whether the files should be remediated or not.