### PR TITLE
fixes biojava/biojava#910 for network flaky tests

### DIFF
--- a/biojava-core/pom.xml
+++ b/biojava-core/pom.xml
@@ -81,5 +81,11 @@
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.github.jensdietrich.saflate</groupId>
+			<artifactId>saflate-network-junit4</artifactId>
+			<version>1.0.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/biojava-core/src/test/java/org/biojava/nbio/core/search/io/SearchIOTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/search/io/SearchIOTest.java
@@ -22,12 +22,11 @@ package org.biojava.nbio.core.search.io;
 
 import java.io.File;
 import java.net.URL;
+
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.core.search.io.blast.BlastXMLParser;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+
 import static org.junit.Assert.*;
 
 /**
@@ -40,7 +39,8 @@ import static org.junit.Assert.*;
  */
 
 public class SearchIOTest {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	public SearchIOTest() {
 	}
 

--- a/biojava-core/src/test/java/org/biojava/nbio/core/search/io/blast/BlastXMLParserTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/search/io/blast/BlastXMLParserTest.java
@@ -24,23 +24,22 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.core.search.io.Hit;
 import org.biojava.nbio.core.search.io.Hsp;
 import org.biojava.nbio.core.search.io.Result;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+
 import static org.junit.Assert.*;
-import org.junit.Ignore;
 
 /**
  *
  * @author Paolo Pavan
  */
 public class BlastXMLParserTest {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	public BlastXMLParserTest() {
 	}
 

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankCookbookTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankCookbookTest.java
@@ -20,6 +20,7 @@
  */
 package org.biojava.nbio.core.sequence.io;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.core.sequence.DNASequence;
 import org.biojava.nbio.core.sequence.ProteinSequence;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
@@ -39,7 +40,8 @@ import java.util.LinkedHashMap;
  * @author Scooter Willis <willishf at gmail dot com>
  */
 public class GenbankCookbookTest {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	private final static Logger logger = LoggerFactory.getLogger(GenbankCookbookTest.class);
 
 	public GenbankCookbookTest() {

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/loader/GenbankProxySequenceReaderTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/loader/GenbankProxySequenceReaderTest.java
@@ -20,6 +20,7 @@
  */
 package org.biojava.nbio.core.sequence.loader;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.core.exceptions.CompoundNotFoundException;
 import org.biojava.nbio.core.sequence.ProteinSequence;
 import org.biojava.nbio.core.sequence.compound.AminoAcidCompound;
@@ -30,6 +31,7 @@ import org.biojava.nbio.core.sequence.features.Qualifier;
 import org.biojava.nbio.core.sequence.template.AbstractSequence;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -55,6 +57,8 @@ import java.util.Map;
  */
 @RunWith(Parameterized.class)
 public class GenbankProxySequenceReaderTest {
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 
 	private String gi;
 	private final static Logger logger = LoggerFactory.getLogger(GenbankProxySequenceReaderTest.class);

--- a/biojava-integrationtest/pom.xml
+++ b/biojava-integrationtest/pom.xml
@@ -60,6 +60,12 @@
     		<groupId>org.apache.logging.log4j</groupId>
     		<artifactId>log4j-core</artifactId>
   		</dependency>
+        <dependency>
+            <groupId>io.github.jensdietrich.saflate</groupId>
+            <artifactId>saflate-network-junit4</artifactId>
+            <version>1.0.0</version>
+            <scope>test</scope>
+        </dependency>
   </dependencies>
   <description>A module which only has the purpose to run slow running integration tests.
 

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/ecod/EcodInstallationTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/ecod/EcodInstallationTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.core.util.ConcurrencyTools;
 import org.biojava.nbio.structure.ResidueNumber;
 import org.biojava.nbio.structure.ResidueRange;
@@ -59,7 +60,8 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class EcodInstallationTest {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	private static final Logger logger = LoggerFactory.getLogger(EcodInstallationTest.class);
 	private static final String VERSION = "develop204"; // Should be updated periodically
 

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/cif/CifFileSupplierIntegrationTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/cif/CifFileSupplierIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.biojava.nbio.structure.test.io.cif;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.AminoAcidImpl;
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.AtomImpl;
@@ -13,6 +14,7 @@ import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureImpl;
 import org.biojava.nbio.structure.StructureTools;
 import org.biojava.nbio.structure.io.cif.CifStructureConverter;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
@@ -26,6 +28,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 public class CifFileSupplierIntegrationTest {
+    @Rule
+    public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
     @Test
     public void test1SMT() throws IOException {
         // an x-ray structure

--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/symmetry/TestQuatSymmetryDetectorExamples.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.util.*;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.io.StructureFiletype;
@@ -42,6 +43,7 @@ import org.biojava.nbio.structure.symmetry.core.QuatSymmetryParameters;
 import org.biojava.nbio.structure.symmetry.core.QuatSymmetryResults;
 import org.biojava.nbio.structure.symmetry.core.Stoichiometry;
 import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +57,8 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class TestQuatSymmetryDetectorExamples {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	private static final Logger logger = LoggerFactory.getLogger(TestQuatSymmetryDetectorExamples.class);
 
 	/**

--- a/biojava-structure/pom.xml
+++ b/biojava-structure/pom.xml
@@ -122,6 +122,13 @@
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>io.github.jensdietrich.saflate</groupId>
+			<artifactId>saflate-network-junit4</artifactId>
+			<version>1.0.0</version>
+			<scope>test</scope>
+		</dependency>
+
 
 	</dependencies>
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/PDBStatusTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/PDBStatusTest.java
@@ -20,8 +20,10 @@
  */
 package org.biojava.nbio.structure;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.PDBStatus.Status;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -31,6 +33,8 @@ import java.io.IOException;
  *
  */
 public class PDBStatusTest {
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 
 	/**
 	 * Test {@link PDBStatus#getStatus(String)}.

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestLoadStructureFromURL.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestLoadStructureFromURL.java
@@ -20,10 +20,12 @@
  */
 package org.biojava.nbio.structure;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.align.util.UserConfiguration;
 import org.biojava.nbio.structure.io.PDBFileReader;
 import org.biojava.nbio.structure.io.StructureFiletype;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
@@ -34,7 +36,8 @@ import static org.junit.Assert.assertNotNull;
 
 
 public class TestLoadStructureFromURL {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	public static final String lineSplit = System.getProperty("file.separator");
 
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/align/util/AtomCacheTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/align/util/AtomCacheTest.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.zip.GZIPOutputStream;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.core.util.FileDownloadUtils;
 import org.biojava.nbio.structure.AtomPositionMap;
 import org.biojava.nbio.structure.Chain;
@@ -65,6 +66,7 @@ import org.biojava.nbio.structure.scop.ScopFactory;
 import org.biojava.nbio.structure.test.util.GlobalsHelper;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,7 +78,8 @@ import org.slf4j.LoggerFactory;
  * @since 3.0.6
  */
 public class AtomCacheTest {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	private static Logger logger = LoggerFactory.getLogger(AtomCacheTest.class);
 	private AtomCache cache;
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/chem/TestDownloadChemCompProvider.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/chem/TestDownloadChemCompProvider.java
@@ -20,10 +20,12 @@
  */
 package org.biojava.nbio.structure.chem;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.core.util.FlatFileCache;
 import org.biojava.nbio.structure.chem.ChemComp;
 import org.biojava.nbio.structure.chem.DownloadChemCompProvider;
 import org.biojava.nbio.structure.io.LocalPDBDirectory;
+import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -35,7 +37,8 @@ import java.util.regex.Matcher;
 import java.util.zip.GZIPOutputStream;
 
 public class TestDownloadChemCompProvider {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	@Test
 	public void testProtectedIDs(){
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -34,6 +34,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.Chain;
 import org.biojava.nbio.structure.EntityInfo;
 import org.biojava.nbio.structure.EntityType;
@@ -43,6 +44,7 @@ import org.biojava.nbio.structure.StructureIO;
 import org.biojava.nbio.structure.align.util.AtomCache;
 import org.biojava.nbio.structure.io.cif.CifStructureConverter;
 import org.biojava.nbio.structure.xtal.CrystalCell;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -56,7 +58,8 @@ import org.junit.Test;
  *
  */
 public class TestNonDepositedFiles {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	@Test
 	public void test1B8GnoSeqresPdb() throws IOException, StructureException {
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestURLBasedFileParsing.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestURLBasedFileParsing.java
@@ -23,9 +23,11 @@ package org.biojava.nbio.structure.io;
 
 import java.io.IOException;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.StructureIO;
+import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -33,7 +35,8 @@ import static org.junit.Assert.*;
  * Created by ap3 on 31/07/2015.
  */
 public class TestURLBasedFileParsing {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	@Test
 	public void testMMcifURL() throws StructureException, IOException{
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfPerformance.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfPerformance.java
@@ -20,7 +20,9 @@
  */
 package org.biojava.nbio.structure.io.mmtf;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.io.PDBFileParser;
+import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +41,8 @@ import static org.junit.Assert.assertTrue;
  *
  */
 public class TestMmtfPerformance {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	private static final Logger logger = LoggerFactory.getLogger(TestMmtfPerformance.class);
 
 	private static final int NUMBER_OF_REPEATS = 10;

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfRoundTrip.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/mmtf/TestMmtfRoundTrip.java
@@ -29,6 +29,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.Atom;
 import org.biojava.nbio.structure.Bond;
 import org.biojava.nbio.structure.Chain;
@@ -44,6 +45,7 @@ import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.cif.CifStructureConverter;
 import org.biojava.nbio.structure.quaternary.BioAssemblyInfo;
 import org.biojava.nbio.structure.quaternary.BiologicalAssemblyTransformation;
+import org.junit.Rule;
 import org.junit.Test;
 import org.rcsb.mmtf.decoder.StructureDataToAdapter;
 import org.rcsb.mmtf.encoder.AdapterToStructureData;
@@ -57,8 +59,8 @@ import static org.junit.Assert.*;
  *
  */
 public class TestMmtfRoundTrip {
-
-	/**
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();	/**
 	 * Test that we can round trip a simple structure.
 	 *
 	 * @throws IOException an error reading the file

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/secstruc/TestDSSPParser.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/secstruc/TestDSSPParser.java
@@ -25,9 +25,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
+import nz.ac.wgtn.saflate.network.junit4.SanitiseNetworkDependenciesRule;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.StructureException;
 import org.biojava.nbio.structure.align.util.AtomCache;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -40,7 +42,8 @@ import static org.junit.Assert.*;
  *
  */
 public class TestDSSPParser {
-
+	@Rule
+	public SanitiseNetworkDependenciesRule rule = new SanitiseNetworkDependenciesRule();
 	@Test
 	public void testDSSPParser() throws IOException, StructureException {
 

--- a/pom.xml
+++ b/pom.xml
@@ -470,6 +470,13 @@
 				<version>2.3.5</version>
 				<scope>runtime</scope>
 			</dependency>
+			<dependency>
+				<groupId>io.github.jensdietrich.saflate</groupId>
+				<artifactId>saflate-network-junit4</artifactId>
+				<version>1.0.0</version>
+				<scope>test</scope>
+			</dependency>
+
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
Adds junit-4 extension, saflate, which provides a rule to skip network flaky tests on network related exceptions during test execution. 