### PR TITLE
Add file download validation

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
@@ -195,7 +195,7 @@ public class FileDownloadUtils {
 	 * @param resourceUrlConnection the remote file URLConnection to download
 	 * @param localDestination the local file to download into
 	 * @param hashURL the URL of the hash file to download. Can be <code>null</code>.
-	 * @since 6.0.6
+	 * @since 6.1.1
 	 */
 	public static void createValidationFiles(URLConnection resourceUrlConnection, File localDestination, URL hashURL){
 		long size = resourceUrlConnection.getContentLengthLong();
@@ -234,8 +234,8 @@ public class FileDownloadUtils {
 	 * <p>
 	 * This function does not implement hash code verification yet.
 	 * @param localFile The file to validate
-	 * @return <code>false</code> if any of the size or hash code metadata files exists but its contents does not match the expected value in the file, <code>true'</code> otherwise.
-	 * @since 6.0.6
+	 * @return <code>false</code> if any of the size or hash code metadata files exists but its contents does not match the expected value in the file, <code>true</code> otherwise.
+	 * @since 6.1.1
 	 */
 	public static boolean validateFile(File localFile) {
 		File sizeFile = new File(localFile.getParentFile(), localFile.getName()+".size");

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
@@ -199,14 +199,16 @@ public class FileDownloadUtils {
 	 */
 	public static void createValidationFiles(URLConnection resourceUrlConnection, File localDestination, URL hashURL){
 		long size = resourceUrlConnection.getContentLengthLong();
-		if(size != -1) {
+		if(size == -1) {
+			logger.warn("could not find expected file size for resource {}.", resourceUrlConnection.getURL());
+		} else {
 			System.out.println("Content-Length: " + size);
 			File sizeFile = new File(localDestination.getParentFile(), localDestination.getName()+".size");
 			try (PrintStream sizePrintStream = new PrintStream(sizeFile)) {
 				sizePrintStream.print(size);
 				sizePrintStream.close();
 			} catch (FileNotFoundException e) {
-				logger.warn("could not write validation size file due to exception", e);
+				logger.warn("could not write size validation file due to exception", e);
 			}
 		}
 		

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
@@ -165,6 +165,17 @@ public class FileDownloadUtils {
 
 	}
 	
+	/**
+	 * Creates validation files beside a file to be downloaded.<br>
+	 * Whenever possible, for a <code>file.ext</code> file, it creates 
+	 * <code>file.ext.size</code> and <code>file.hash</code> for in the same 
+	 * folder where <code>file.ext</code> exists.
+	 * If the file connection size could not be deduced from the URL, no size file is created. 
+	 * If <code>hashURL</code> is <code>null</code>, no hash file is created.
+	 * @param url the remote file URL to download
+	 * @param localDestination the local file to download into
+	 * @param hashURL the URL of the hash file to download. Can be <code>null</code>.
+	 */
 	public static void createValidationFiles(URL url, File localDestination, URL hashURL){
 		try {
 			URLConnection resourceConnection = url.openConnection();
@@ -173,6 +184,19 @@ public class FileDownloadUtils {
 			logger.warn("could not open connection to resource file due to exception", e);
 		}
 	}
+	/**
+	 * Creates validation files beside a file to be downloaded.<br>
+	 * Whenever possible, for a <code>file.ext</code> file, it creates 
+	 * <code>file.ext.size</code> and <code>file.hash</code> for in the same 
+	 * folder where <code>file.ext</code> exists.
+	 * If the file connection size could not be deduced from the resourceUrlConnection 
+	 * {@link URLConnection}, no size file is created. 
+	 * If <code>hashURL</code> is <code>null</code>, no hash file is created.
+	 * @param resourceUrlConnection the remote file URLConnection to download
+	 * @param localDestination the local file to download into
+	 * @param hashURL the URL of the hash file to download. Can be <code>null</code>.
+	 * @since 6.0.6
+	 */
 	public static void createValidationFiles(URLConnection resourceUrlConnection, File localDestination, URL hashURL){
 		long size = resourceUrlConnection.getContentLengthLong();
 		if(size != -1) {
@@ -197,6 +221,20 @@ public class FileDownloadUtils {
 		}
 	}
 	
+	/**
+	 * Validate a local file based on pre-existing metadata files for size and hash.<br>
+	 * If the passed in <code>localFile</code> parameter is a file named <code>file.ext</code>, the function searches in the same folder for:
+	 * <ul>
+	 * <li><code>file.ext.size</code>: if found, it compares the size stored in it to the length of <code>localFile</code> (in bytes).</li>
+	 * <li><code>file.ext.hash</code>: if found, it compares the size stored in it to the hash code of <code>localFile</code>.</li>
+	 * </ul>
+	 * If any of these comparisons fail, the function returns <code>false</code>. otherwise it returns true.
+	 * <p>
+	 * This function does not implement hash code verification yet.
+	 * @param localFile The file to validate
+	 * @return <code>false</code> if any of the size or hash code metadata files exists but its contents does not match the expected value in the file, <code>true'</code> otherwise.
+	 * @since 6.0.6
+	 */
 	public static boolean validateFile(File localFile) {
 		File sizeFile = new File(localFile.getParentFile(), localFile.getName()+".size");
 		if(sizeFile.exists()) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
@@ -189,7 +189,7 @@ public class FileDownloadUtils {
 			URLConnection resourceConnection = url.openConnection();
 			createValidationFiles(resourceConnection, localDestination, hashURL, FileDownloadUtils.Hash.UNKNOWN);
 		} catch (IOException e) {
-			logger.warn("could not open connection to resource file due to exception:\n\t", e.getMessage());
+			logger.warn("could not open connection to resource file due to exception: {}", e.getMessage());
 		}
 	}
 	/**
@@ -205,7 +205,7 @@ public class FileDownloadUtils {
 	 * @param localDestination the local file to download into
 	 * @param hashURL the URL of the hash file to download. Can be <code>null</code>.
 	 * @param hash The Hashing algorithm. Ignored if <code>hashURL</code> is <code>null</code>.
-	 * @since 6.1.1
+	 * @since 7.0.0
 	 */
 	public static void createValidationFiles(URLConnection resourceUrlConnection, File localDestination, URL hashURL, Hash hash){
 		long size = resourceUrlConnection.getContentLengthLong();
@@ -218,7 +218,7 @@ public class FileDownloadUtils {
 				sizePrintStream.print(size);
 				sizePrintStream.close();
 			} catch (FileNotFoundException e) {
-				logger.warn("could not write size validation file due to exception:\n\t", e.getMessage());
+				logger.warn("could not write size validation file due to exception: {}", e.getMessage());
 			}
 		}
 		
@@ -231,7 +231,7 @@ public class FileDownloadUtils {
 			File hashFile = new File(localDestination.getParentFile(), String.format("%s%s_%s", localDestination.getName(), HASH_EXT, hash));
 			downloadFile(hashURL, hashFile);
 		} catch (IOException e) {
-			logger.warn("could not write validation hash file due to exception:\n\t{}", e.getMessage());
+			logger.warn("could not write validation hash file due to exception: {}", e.getMessage());
 		}
 	}
 	
@@ -247,7 +247,7 @@ public class FileDownloadUtils {
 	 * <b>N.B.</b> None of the 3 common verification hashing algorithms are implement yet.
 	 * @param localFile The file to validate
 	 * @return <code>false</code> if any of the size or hash code metadata files exists but its contents does not match the expected value in the file, <code>true</code> otherwise.
-	 * @since 6.1.1
+	 * @since 7.0.0
 	 */
 	public static boolean validateFile(File localFile) {
 		File sizeFile = new File(localFile.getParentFile(), localFile.getName() + SIZE_EXT);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
@@ -51,6 +52,10 @@ public class FileDownloadUtils {
 	private static final String SIZE_EXT = ".size";
 	private static final String HASH_EXT = ".hash";
 	private static final Logger logger = LoggerFactory.getLogger(FileDownloadUtils.class);
+
+	public enum Hash{
+		MD5, SHA1, SHA256, UNKNOWN
+	}
 
 	/**
 	 * Copy the content of file src to dst TODO since java 1.7 this is provided
@@ -177,11 +182,12 @@ public class FileDownloadUtils {
 	 * @param url the remote file URL to download
 	 * @param localDestination the local file to download into
 	 * @param hashURL the URL of the hash file to download. Can be <code>null</code>.
+	 * @param hash The Hashing algorithm. Ignored if <code>hashURL</code> is <code>null</code>.
 	 */
-	public static void createValidationFiles(URL url, File localDestination, URL hashURL){
+	public static void createValidationFiles(URL url, File localDestination, URL hashURL, Hash hash){
 		try {
 			URLConnection resourceConnection = url.openConnection();
-			createValidationFiles(resourceConnection, localDestination, hashURL);
+			createValidationFiles(resourceConnection, localDestination, hashURL, FileDownloadUtils.Hash.UNKNOWN);
 		} catch (IOException e) {
 			logger.warn("could not open connection to resource file due to exception:\n\t", e.getMessage());
 		}
@@ -189,17 +195,19 @@ public class FileDownloadUtils {
 	/**
 	 * Creates validation files beside a file to be downloaded.<br>
 	 * Whenever possible, for a <code>file.ext</code> file, it creates 
-	 * <code>file.ext.size</code> and <code>file.hash</code> for in the same 
-	 * folder where <code>file.ext</code> exists.
+	 * <code>file.ext.size</code> and <code>file.hash_XXXX</code> in the same 
+	 * folder where <code>file.ext</code> exists (XXXX may be DM5, SHA1, or SHA256).
 	 * If the file connection size could not be deduced from the resourceUrlConnection 
 	 * {@link URLConnection}, no size file is created. 
-	 * If <code>hashURL</code> is <code>null</code>, no hash file is created.
+	 * If <code>hashURL</code> is <code>null</code>, no hash file is created.<br>
+	 * <b>N.B.</b> None of the hashing algorithms is implemented (yet), because we did not need any of them yet.
 	 * @param resourceUrlConnection the remote file URLConnection to download
 	 * @param localDestination the local file to download into
 	 * @param hashURL the URL of the hash file to download. Can be <code>null</code>.
+	 * @param hash The Hashing algorithm. Ignored if <code>hashURL</code> is <code>null</code>.
 	 * @since 6.1.1
 	 */
-	public static void createValidationFiles(URLConnection resourceUrlConnection, File localDestination, URL hashURL){
+	public static void createValidationFiles(URLConnection resourceUrlConnection, File localDestination, URL hashURL, Hash hash){
 		long size = resourceUrlConnection.getContentLengthLong();
 		if(size == -1) {
 			logger.warn("could not find expected file size for resource {}.", resourceUrlConnection.getURL());
@@ -217,8 +225,10 @@ public class FileDownloadUtils {
 		if(hashURL == null)
 			return;
 
+		if(hash == Hash.UNKNOWN)
+			throw new IllegalArgumentException("Hash URL given but algorithm is unknown");
 		try {
-			File hashFile = new File(localDestination.getParentFile(), localDestination.getName() + HASH_EXT);
+			File hashFile = new File(localDestination.getParentFile(), String.format("%s%s_%s", localDestination.getName(), HASH_EXT, hash));
 			downloadFile(hashURL, hashFile);
 		} catch (IOException e) {
 			logger.warn("could not write validation hash file due to exception:\n\t{}", e.getMessage());
@@ -229,12 +239,12 @@ public class FileDownloadUtils {
 	 * Validate a local file based on pre-existing metadata files for size and hash.<br>
 	 * If the passed in <code>localFile</code> parameter is a file named <code>file.ext</code>, the function searches in the same folder for:
 	 * <ul>
-	 * <li><code>file.ext.size</code>: if found, it compares the size stored in it to the length of <code>localFile</code> (in bytes).</li>
-	 * <li><code>file.ext.hash</code>: if found, it compares the size stored in it to the hash code of <code>localFile</code>.</li>
+	 * <li><code>file.ext.size</code>: If found, it compares the size stored in it to the length of <code>localFile</code> (in bytes).</li>
+	 * <li><code>file.ext.hash_XXXX (where XXXX is DM5, SHA1, or SHA256)</code>: If found, it compares the size stored in it to the hash code of <code>localFile</code>.</li>
 	 * </ul>
 	 * If any of these comparisons fail, the function returns <code>false</code>. otherwise it returns true.
 	 * <p>
-	 * This function does not implement hash code verification yet.
+	 * <b>N.B.</b> None of the 3 common verification hashing algorithms are implement yet.
 	 * @param localFile The file to validate
 	 * @return <code>false</code> if any of the size or hash code metadata files exists but its contents does not match the expected value in the file, <code>true</code> otherwise.
 	 * @since 6.1.1
@@ -258,9 +268,26 @@ public class FileDownloadUtils {
 			}
 		}
 
-		File hashFile = new File(localFile.getParentFile(), localFile.getName() + HASH_EXT);
-		if(hashFile.exists()) {
-			throw new UnsupportedOperationException("Not yet implemented");
+		File[] hashFiles = localFile.getParentFile().listFiles(new FilenameFilter() {
+			String hashPattern = String.format("%s%s_(%s|%s|%s)", localFile.getName(), HASH_EXT, Hash.MD5, Hash.SHA1, Hash.SHA256);
+			@Override
+			public boolean accept(File dir, String name) {
+				return name.matches(hashPattern);
+			}
+		});
+		if(hashFiles.length > 0) {
+			File hashFile = hashFiles[0];
+			String name = hashFile.getName();
+			String algo = name.substring(name.lastIndexOf('_') + 1);
+			switch (Hash.valueOf(algo)) {
+			case MD5:
+			case SHA1:
+			case SHA256:
+				throw new UnsupportedOperationException("Not yet implemented");
+			case UNKNOWN:
+			default: // No need. Already checked above
+				throw new IllegalArgumentException("Hashing algorithm not known: " + algo);
+			}
 		}
 		
 		return true;

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
@@ -214,7 +214,7 @@ class FileDownloadUtilsTest {
     		FileDownloadUtils.downloadFile(sourceUrl, destFile);
     		assertTrue(destFile.exists(), "couldn't create dest file");
 
-    		assertTrue(FileDownloadUtils.validateFile(destFile), "file not detected to be invalid although there are no validation files");
+    		assertTrue(FileDownloadUtils.validateFile(destFile), "file detected to be invalid although there are no validation files");
 
     		PrintStream temp1 = new PrintStream(sizeFile);
     		temp1.print(15); // some wrong size value
@@ -232,7 +232,7 @@ class FileDownloadUtilsTest {
     		//This is not yet implemented. I am using this test for documentation purpose.
     		assertThrows(UnsupportedOperationException.class, 
     				() -> FileDownloadUtils.validateFile(destFile), 
-    				"file not detected to be invalid although size value is wrong.");
+    				"file not detected to be invalid although hash value is wrong.");
     		
     		destFile.delete();
     		sizeFile.delete();

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
@@ -4,12 +4,15 @@ import static org.biojava.nbio.core.util.FileDownloadUtils.getFileExtension;
 import static org.biojava.nbio.core.util.FileDownloadUtils.getFilePrefix;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URL;
 import java.nio.file.Files;
 
 import org.junit.jupiter.api.Nested;
@@ -189,5 +192,51 @@ class FileDownloadUtilsTest {
             FileDownloadUtils.deleteDirectory(toDelete.getAbsolutePath());
             assertFalse(toDelete.exists());
         }
+    }
+    
+    @Nested
+    class CreateValidationFiles{
+    	
+    	@Test
+    	void testValidationFiles() throws IOException{
+    		URL sourceUrl = new URL("https://ftp.wwpdb.org/pub/pdb/data/structures/divided/mmCIF/45/145d.cif.gz");
+    		File destFile = new File(System.getProperty("java.io.tmpdir"), "145d.cif.gz");
+    		File sizeFile = new File(destFile.getParentFile(), destFile.getName()+".size");
+    		File hashFile = new File(destFile.getParentFile(), destFile.getName()+".hash");
+    		System.out.println(destFile.getAbsolutePath());
+    		destFile.delete();
+    		sizeFile.delete();
+    		hashFile.delete();
+    		assertFalse(destFile.exists(), "couldn't delete dest file");
+    		assertFalse(sizeFile.exists(), "couldn't delete size file");
+    		assertFalse(hashFile.exists(), "couldn't delete hash file");
+    		
+    		FileDownloadUtils.downloadFile(sourceUrl, destFile);
+    		assertTrue(destFile.exists(), "couldn't create dest file");
+
+    		assertTrue(FileDownloadUtils.validateFile(destFile), "file not detected to be invalid although there are no validation files");
+
+    		PrintStream temp1 = new PrintStream(sizeFile);
+    		temp1.print(15); // some wrong size value
+    		temp1.close();
+    		assertFalse(FileDownloadUtils.validateFile(destFile), "file not detected to be invalid although size value is wrong.");
+    		System.out.println("Just ignore the previous warning. It is expected.");
+    		
+    		FileDownloadUtils.createValidationFiles(sourceUrl, destFile, null);
+    		assertTrue(sizeFile.exists(), "couldn't create size file");
+    		assertTrue(FileDownloadUtils.validateFile(destFile), "file not detected to be invalid although there is correct size validation file");
+
+    		PrintStream temp2 = new PrintStream(hashFile);
+    		temp2.print("ABCD"); // some wrong hash value
+    		temp2.close();
+    		//This is not yet implemented. I am using this test for documentation purpose.
+    		assertThrows(UnsupportedOperationException.class, 
+    				() -> FileDownloadUtils.validateFile(destFile), 
+    				"file not detected to be invalid although size value is wrong.");
+    		
+    		destFile.delete();
+    		sizeFile.delete();
+    		hashFile.delete();
+    	}
     }
 }

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/FileDownloadUtilsTest.java
@@ -202,7 +202,7 @@ class FileDownloadUtilsTest {
     		URL sourceUrl = new URL("https://ftp.wwpdb.org/pub/pdb/data/structures/divided/mmCIF/45/145d.cif.gz");
     		File destFile = new File(System.getProperty("java.io.tmpdir"), "145d.cif.gz");
     		File sizeFile = new File(destFile.getParentFile(), destFile.getName()+".size");
-    		File hashFile = new File(destFile.getParentFile(), destFile.getName()+".hash");
+    		File hashFile = new File(destFile.getParentFile(), destFile.getName()+".hash_MD5");
     		System.out.println(destFile.getAbsolutePath());
     		destFile.delete();
     		sizeFile.delete();
@@ -222,7 +222,7 @@ class FileDownloadUtilsTest {
     		assertFalse(FileDownloadUtils.validateFile(destFile), "file not detected to be invalid although size value is wrong.");
     		System.out.println("Just ignore the previous warning. It is expected.");
     		
-    		FileDownloadUtils.createValidationFiles(sourceUrl, destFile, null);
+    		FileDownloadUtils.createValidationFiles(sourceUrl, destFile, null, FileDownloadUtils.Hash.UNKNOWN);
     		assertTrue(sizeFile.exists(), "couldn't create size file");
     		assertTrue(FileDownloadUtils.validateFile(destFile), "file not detected to be invalid although there is correct size validation file");
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodFactory.java
@@ -89,6 +89,9 @@ public class EcodFactory {
 					}
 				} catch (IOException e) {
 					// For parsing errors, just use the requested version
+					// What about corrupted downloading errors?? Amr
+					logger.warn("Cound not get Ecod version, or file is corrupted", e);
+					return null;
 				}
 			}
 			logger.trace("Releasing EcodFactory lock after getting version "+version);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodFactory.java
@@ -89,8 +89,8 @@ public class EcodFactory {
 					}
 				} catch (IOException e) {
 					// For parsing errors, just use the requested version
-					// What about corrupted downloading errors?? Amr
-					logger.warn("Cound not get Ecod version, or file is corrupted", e);
+					// TODO What about corrupted downloading errors?? Amr
+					logger.warn("Could not get Ecod version, or file is corrupted", e);
 					return null;
 				}
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
@@ -406,7 +406,7 @@ public class EcodInstallation implements EcodDatabase {
 			File localFile = getDomainFile();
 
 			logger.info("Downloading {} to: {}",domainsURL, localFile);
-			FileDownloadUtils.createValidationFiles(domainsURL, localFile, null);
+			FileDownloadUtils.createValidationFiles(domainsURL, localFile, null, FileDownloadUtils.Hash.UNKNOWN);
 			FileDownloadUtils.downloadFile(domainsURL, localFile);
 			if(! FileDownloadUtils.validateFile(localFile))
 				throw new IOException("Downloaded file invalid: "+ localFile);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
@@ -369,7 +369,7 @@ public class EcodInstallation implements EcodDatabase {
 		try {
 			File f = getDomainFile();
 
-			if (!f.exists() || f.length() <= 0 )
+			if (! (f.exists() && FileDownloadUtils.validateFile(f)))
 				return false;
 
 			// Re-download old copies of "latest"
@@ -406,7 +406,10 @@ public class EcodInstallation implements EcodDatabase {
 			File localFile = getDomainFile();
 
 			logger.info("Downloading {} to: {}",domainsURL, localFile);
+			FileDownloadUtils.createValidationFiles(domainsURL, localFile, null);
 			FileDownloadUtils.downloadFile(domainsURL, localFile);
+			if(! FileDownloadUtils.validateFile(localFile))
+				throw new IOException("Downloaded file invalid: "+ localFile);
 		} catch (MalformedURLException e) {
 			logger.error("Malformed url: "+ url + DOMAINS_PATH + getDomainFilename(),e);
 		} finally {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
@@ -395,8 +395,8 @@ public class EcodInstallation implements EcodDatabase {
 	}
 
 	/**
-	 * Downloads the domains file, overwriting any existing file
-	 * @throws IOException
+	 * Downloads the domains file +/- its validation metadata, overwriting any existing file
+	 * @throws IOException in cases of file I/O, including failure to download a healthy (non-corrupted) file.
 	 */
 	private void downloadDomains() throws IOException {
 		domainsFileLock.writeLock().lock();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
@@ -581,7 +581,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 		logger.info("Fetching " + ftp);
 		logger.info("Writing to "+ realFile);
 
-		FileDownloadUtils.createValidationFiles(url, realFile, null);
+		FileDownloadUtils.createValidationFiles(url, realFile, null, FileDownloadUtils.Hash.UNKNOWN);
 		FileDownloadUtils.downloadFile(url, realFile);
 		if(! FileDownloadUtils.validateFile(realFile))
 			throw new IOException("Downloaded file invalid: "+realFile);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
@@ -362,7 +362,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 	 * for direct parsing.
 	 * @param pdbId
 	 * @return
-	 * @throws IOException
+	 * @throws IOException in cases of file I/O, including failure to download a healthy (non-corrupted) file.
 	 */
 	protected InputStream getInputStream(PdbId pdbId) throws IOException{
 
@@ -388,7 +388,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 	 *
 	 * Used to pre-fetch large numbers of structures.
 	 * @param pdbId
-	 * @throws IOException
+	 * @throws IOException in cases of file I/O, including failure to download a healthy (non-corrupted) file.
 	 */
 	public void prefetchStructure(String pdbId) throws IOException {
 		
@@ -530,14 +530,14 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 	}
 
 	/**
-	 * Download a file from the ftp server, replacing any existing files if needed
+	 * Download a file from the ftp server +/- its validation metadata, replacing any existing files if needed
 	 * @param pdbId PDB ID
 	 * @param pathOnServer Path on the FTP server, e.g. data/structures/divided/pdb
 	 * @param obsolete Whether or not file should be saved to the obsolete location locally
 	 * @param existingFile if not null and checkServerFileDate is true, the last modified date of the
 	 * server file and this file will be compared to decide whether to download or not
 	 * @return
-	 * @throws IOException
+	 * @throws IOException in cases of file I/O, including failure to download a healthy (non-corrupted) file.
 	 */
 	private File downloadStructure(PdbId pdbId, String pathOnServer, boolean obsolete, File existingFile)
 			throws IOException{

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
@@ -373,6 +373,9 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 			throw new IOException("Structure "+pdbId+" not found and unable to download.");
 		}
 
+		if(! FileDownloadUtils.validateFile(file))
+			throw new IOException("Downloaded file invalid: "+file);
+		
 		InputStreamProvider isp = new InputStreamProvider();
 
 		InputStream inputStream = isp.getInputStream(file);
@@ -395,6 +398,8 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 		if(!file.exists()) {
 			throw new IOException("Structure "+pdbId+" not found and unable to download.");
 		}
+		if(! FileDownloadUtils.validateFile(file))
+			throw new IOException("Downloaded file invalid: "+file);
 	}
 
 	/**
@@ -576,7 +581,10 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 		logger.info("Fetching " + ftp);
 		logger.info("Writing to "+ realFile);
 
+		FileDownloadUtils.createValidationFiles(url, realFile, null);
 		FileDownloadUtils.downloadFile(url, realFile);
+		if(! FileDownloadUtils.validateFile(realFile))
+			throw new IOException("Downloaded file invalid: "+realFile);
 
 		return realFile;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
@@ -88,7 +88,7 @@ public class SiftsMappingProvider {
 			String u = String.format(fileLoc,pdbId);
 			URL url = new URL(u);
 			logger.debug("Downloading SIFTS file {} validation metadata.",url);
-			FileDownloadUtils.createValidationFiles(url, dest, null);
+			FileDownloadUtils.createValidationFiles(url, dest, null, FileDownloadUtils.Hash.UNKNOWN);
 			logger.debug("Downloading SIFTS file {} to {}",url,dest);
 			FileDownloadUtils.downloadFile(url, dest);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
@@ -87,9 +87,14 @@ public class SiftsMappingProvider {
 		if ( ! dest.exists()){
 			String u = String.format(fileLoc,pdbId);
 			URL url = new URL(u);
+			logger.debug("Downloading SIFTS file {} validation metadata.",url);
+			FileDownloadUtils.createValidationFiles(url, dest, null);
 			logger.debug("Downloading SIFTS file {} to {}",url,dest);
 			FileDownloadUtils.downloadFile(url, dest);
 		}
+
+		if(! FileDownloadUtils.validateFile(dest))
+			throw new IOException("Downloaded file invalid: "+dest);
 
 		InputStreamProvider prov = new InputStreamProvider();
 		InputStream is = prov.getInputStream(dest);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
@@ -739,6 +739,12 @@ public class ScopInstallation implements LocalScopDatabase {
 		throw new IOException("Unable to download SCOP .com file",exception);
 	}
 
+	/**
+	 * Downloads the SCOP installation file +/- its validation metadata files.
+	 * @param remoteURL The remote file to download
+	 * @param localFile the local file to download to
+	 * @throws IOException in cases of file I/O, including failure to download a healthy (non-corrupted) file.
+	 */
 	protected void downloadFileFromRemote(URL remoteURL, File localFile) throws IOException{
 		logger.info("Downloading " + remoteURL + " to: " + localFile);
 		FileDownloadUtils.createValidationFiles(remoteURL, localFile, null);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
@@ -747,7 +747,7 @@ public class ScopInstallation implements LocalScopDatabase {
 	 */
 	protected void downloadFileFromRemote(URL remoteURL, File localFile) throws IOException{
 		logger.info("Downloading " + remoteURL + " to: " + localFile);
-		FileDownloadUtils.createValidationFiles(remoteURL, localFile, null);
+		FileDownloadUtils.createValidationFiles(remoteURL, localFile, null, FileDownloadUtils.Hash.UNKNOWN);
 		FileDownloadUtils.downloadFile(remoteURL, localFile);
 		if(! FileDownloadUtils.validateFile(localFile))
 			throw new IOException("Downloaded file invalid: "+localFile);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
@@ -741,7 +741,10 @@ public class ScopInstallation implements LocalScopDatabase {
 
 	protected void downloadFileFromRemote(URL remoteURL, File localFile) throws IOException{
 		logger.info("Downloading " + remoteURL + " to: " + localFile);
+		FileDownloadUtils.createValidationFiles(remoteURL, localFile, null);
 		FileDownloadUtils.downloadFile(remoteURL, localFile);
+		if(! FileDownloadUtils.validateFile(localFile))
+			throw new IOException("Downloaded file invalid: "+localFile);
 	}
 
 	private boolean claFileAvailable(){
@@ -749,14 +752,14 @@ public class ScopInstallation implements LocalScopDatabase {
 
 		File f = new File(fileName);
 
-		return f.exists() && f.length()>0;
+		return f.exists() && FileDownloadUtils.validateFile(f);
 	}
 
 	private boolean desFileAvailable(){
 		String fileName = getDesFilename();
 
 		File f = new File(fileName);
-		return f.exists() && f.length()>0;
+		return f.exists() && FileDownloadUtils.validateFile(f);
 	}
 
 	private boolean hieFileAvailable(){
@@ -764,7 +767,7 @@ public class ScopInstallation implements LocalScopDatabase {
 
 		File f = new File(fileName);
 
-		return f.exists() && f.length()>0;
+		return f.exists() && FileDownloadUtils.validateFile(f);
 	}
 
 	private boolean comFileAvailable(){
@@ -772,7 +775,7 @@ public class ScopInstallation implements LocalScopDatabase {
 
 		File f = new File(fileName);
 
-		return f.exists() && f.length()>0;
+		return f.exists() && FileDownloadUtils.validateFile(f);
 	}
 
 	protected String getClaFilename(){


### PR DESCRIPTION
When a file is being downloaded, two metadata files are created for size and hash (as possible).

I applied this validation framework to the files I know (structure files, SCOP installations, Ecod installation).
In case anybody knows something else where downloaded files can be validated, please advise.

I did not implement the hash code _at least yet_, because I don't know a place where a hash file is distributed with the resource file. In case anybody knows some example, please advise.

@sbliven was proposing to download to a temporary file before moving the load to the destination file. I found that `FileDownloadUtils.downloadFile()` does. Therefore, no need to do it ourselves. again, in case anybody knows a place which downloads files but does not use `FileDownloadUtils.downloadFile()` for download, please advise.

fixes #980.