### PR TITLE
Prevent XXE (Xml eXternal Entity) injection when parsing XML data

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/XMLHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/XMLHelper.java
@@ -34,6 +34,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.XMLConstants;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
@@ -105,6 +106,7 @@ public class XMLHelper {
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
 		DocumentBuilder db = dbf.newDocumentBuilder();
+		dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 
 		Document doc = db.parse(inputStream);
 		doc.getDocumentElement().normalize();


### PR DESCRIPTION
Biojava is vulnerable to XXE injection due to accepting XXEs from an untrusted source. This change configures the DocumentBuilder to use secure processing to prevent this. See https://docs.oracle.com/en/java/javase/13/security/java-api-xml-processing-jaxp-security-guide.html

Another user created a PR for this last year, but it's targeting their own fork, so I'm sure it was never seen: https://github.com/srikanthprathi/biojava/pull/1

[JFrog's Xray scan](https://jfrog.com/xray/) flags this as a medium severity vulnerability (but there's no CVE registered for it), and cites srikanthprathi's PR (above) as the only reference.
