### PR TITLE
Update ciftools-java-jdk8 Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<log4j.version>2.17.1</log4j.version>
 		<junit-jupiter.version>5.7.2</junit-jupiter.version>
 		<ciftools.artifact>ciftools-java-jdk8</ciftools.artifact>
-		<ciftools.version>3.0.0</ciftools.version>
+		<ciftools.version>4.0.2</ciftools.version>
 	</properties>
 	<scm>
 		<connection>scm:git:git://github.com/biojava/biojava.git</connection>


### PR DESCRIPTION
- bring in some recent bug fixes (https://github.com/rcsb/ciftools-java/blob/master/CHANGELOG.md)