### PR TITLE
Fix local align score vector

### DIFF
--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/routines/AlignerHelper.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/routines/AlignerHelper.java
@@ -581,7 +581,7 @@ public class AlignerHelper {
 		if (x == xb) {
 			pointers = new Last[ye + 1][1];
 		} else {
-			pointers = new Last[ye + 1][];
+			pointers = new Last[ye + 1][1];
 			pointers[0] = new Last[1];
 			for (int y = 1; y < scores[x].length; y++) {
 				pointers[y][0] = setScorePoint(x, y, gep, subs[y], scores);

--- a/biojava-alignment/src/test/java/org/biojava/nbio/alignment/TestDNAAlignment.java
+++ b/biojava-alignment/src/test/java/org/biojava/nbio/alignment/TestDNAAlignment.java
@@ -165,4 +165,16 @@ public class TestDNAAlignment {
 		PairwiseSequenceAligner<DNASequence, NucleotideCompound> aligner = Alignments.getPairwiseAligner(query, target, PairwiseSequenceAlignerType.GLOBAL, gapP, matrix);
 		Assert.assertEquals(String.format("GTAAAA-G----------%nG-AAAACGTTTTTTTTTT%n"), aligner.getPair().toString());;
 	}
+	/**
+	* @author aegugup
+	*/
+	@Test
+	public void testLinearAlignmentLocal() throws CompoundNotFoundException {
+		DNASequence query = new DNASequence("TGTTACGG", DNACompoundSet.getDNACompoundSet());
+		DNASequence target = new DNASequence("GGTTGACTA", DNACompoundSet.getDNACompoundSet());
+		SubstitutionMatrix<NucleotideCompound> matrix = SubstitutionMatrixHelper.getNuc4_4();
+		SimpleGapPenalty gapP = new SimpleGapPenalty((short)0, (short)8);
+		PairwiseSequenceAligner<DNASequence, NucleotideCompound> aligner = Alignments.getPairwiseAligner(query, target, PairwiseSequenceAlignerType.LOCAL, gapP, matrix);
+		Assert.assertEquals(String.format("GTT-AC%nGTTGAC%n"), aligner.getPair().toString());;
+	}
 }


### PR DESCRIPTION
Using a local alignment with linear gap penalty resulted in the failure trace below. Setting pointers to dimension (ye+1,1) fixed the error. Added a test "testLinearAlignmentLocal()" in TestDNAAlignment.java to verify results. 

java.lang.NullPointerException: Cannot store to object array because "pointers[y]" is null
	at org.biojava.nbio.alignment.routines.AlignerHelper.setScoreVector(AlignerHelper.java:587)
	at org.biojava.nbio.alignment.routines.AlignerHelper.setScoreVector(AlignerHelper.java:560)
	at org.biojava.nbio.alignment.template.AbstractMatrixAligner.align(AbstractMatrixAligner.java:347)
	at org.biojava.nbio.alignment.template.AbstractPairwiseSequenceAligner.getPair(AbstractPairwiseSequenceAligner.java:114)
	at org.biojava.nbio.alignment.TestDNAAlignment.testLinearAlignmentLocal(TestDNAAlignment.java:178)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:577)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:93)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:40)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:529)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:756)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:452)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:210)
