### PR TITLE
Aromaticity calculation (Protein) #1037

### DIFF
--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/IPeptideProperties.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/IPeptideProperties.java
@@ -312,4 +312,15 @@ public interface IPeptideProperties{
 	 * @see AminoAcidCompound
 	 */
 	public Map<AminoAcidCompound, Double> getAAComposition(ProteinSequence sequence);
+        
+        /**
+         * Calculates the aromaticity value of a protein according to Lobry, 1994. 
+         * It is simply the relative frequency of Phe+Trp+Tyr.
+         * 
+         * @param sequence
+         *              a protein sequence consisting of non-ambiguous characters only
+         * @return the aromaticity of a protein sequence
+         * @see ProteinSequence
+         */
+	public double getAromaticity(ProteinSequence sequence);
 }

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptideProperties.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptideProperties.java
@@ -590,4 +590,28 @@ public class PeptideProperties {
 		}
 		return polarity;
 	}
+        
+        /**
+	 * An adaptor method to return the aromaticity value of sequence. The sequence argument
+	 * must be a protein sequence consisting of only non-ambiguous characters.
+	 * 
+         * Calculates the aromaticity value of a protein according to Lobry, 1994. 
+         * It is simply the relative frequency of Phe+Trp+Tyr.
+         * 	 *
+	 * @param sequence
+	 * 		a protein sequence consisting of non-ambiguous characters only
+	 * @return the aromaticity value of sequence
+	 */
+	public static final double getAromaticity(String sequence) {
+		sequence = Utils.checkSequence(sequence);
+		ProteinSequence pSequence = null;
+		try {
+			pSequence = new ProteinSequence(sequence);
+		} catch (CompoundNotFoundException e) {
+			// the sequence was checked with Utils.checkSequence, this shouldn't happen
+			logger.error("The protein sequence contains invalid characters ({}), this should not happen. This is most likely a bug in Utils.checkSequence()", e.getMessage());
+		}
+		IPeptideProperties pp = new PeptidePropertiesImpl();
+		return pp.getAromaticity(pSequence);
+	}
 }

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptidePropertiesImpl.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptidePropertiesImpl.java
@@ -582,4 +582,35 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 		}
 		return aa2Composition;
 	}
+        
+        
+	@Override
+	public double getAromaticity(ProteinSequence sequence) {
+                int validLength = sequence.getSequenceAsString().length();
+		
+		if (validLength==0) {
+			logger.warn("Valid length of sequence is 0, can't divide by 0 to calculate aromaticity: setting aromaticity to 0");
+			return 0.0;
+		}
+                
+                //Phe - Phenylalanine
+                int totalF=0;
+                //Tyr - Tyrosine
+                int totalY=0;
+                //Trp - Tryptophan
+                int totalW=0;
+                
+		char[] seq = this.getSequence(sequence.toString(), true);
+		for(char aa:seq){
+                    char amino = Character.toUpperCase(aa);
+                    switch(amino){
+                        case 'F' : totalF++;break;
+                        case 'Y' : totalY++;break;
+                        case 'W' : totalW++;break;
+                    }
+		}
+                
+                return (totalF+totalY+totalW)/(double)(validLength);        
+	}
 }
+

--- a/biojava-aa-prop/src/test/java/org/biojava/nbio/aaproperties/PeptidePropertiesImplTest.java
+++ b/biojava-aa-prop/src/test/java/org/biojava/nbio/aaproperties/PeptidePropertiesImplTest.java
@@ -358,4 +358,12 @@ public class PeptidePropertiesImplTest {
 	public void testNetChargeNull(){
 		assertEquals(8.6, PeptideProperties.getNetCharge(null), delta);
 	}
+        
+        @Test
+	public void testAromaticity(){
+                assertEquals(1, PeptideProperties.getAromaticity("WWWYYYYFFFWWWYYYYFFF"), 0.001);
+		assertEquals(0.5, PeptideProperties.getAromaticity("WWWYYYYFFFAAAAAAAAAA"), 0.001);
+		assertEquals(0.08, PeptideProperties.getAromaticity(sequence), 0.001);
+		assertEquals(0.0, PeptideProperties.getAromaticity(fullInvalidSequence), 0.001);
+	}
 }


### PR DESCRIPTION
Calculates the aromaticity value of a protein according to Lobry, 1994.
It is simply the relative frequency of Phe(F)+Trp(W)+Tyr(Y).