### PR TITLE
GenBankWriter does not use information in the original header #942

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/DBReferenceInfo.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/DBReferenceInfo.java
@@ -47,7 +47,7 @@ public class DBReferenceInfo extends Qualifier {
 	 * @param id
 	 */
 	public DBReferenceInfo(String database, String id){
-		super("dbxref","");
+		super("db_xref","");
 		this.database = database;
 		this.id = id;
 	}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReader.java
@@ -170,7 +170,7 @@ public class GenbankReader<S extends AbstractSequence<C>, C extends Compound> {
 			String id = genbankHeaderParser.getAccession();
 			int version = genbankHeaderParser.getVersion();
 			String identifier = genbankHeaderParser.getIdentifier();
-			AccessionID accession = new AccessionID(id , DataSource.UNKNOWN, version, identifier);
+			AccessionID accession = new AccessionID(id , DataSource.GENBANK, version, identifier);
 			sequence.setAccession(accession);
 			
 			// add features to new sequence

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReader.java
@@ -163,10 +163,8 @@ public class GenbankReader<S extends AbstractSequence<C>, C extends Compound> {
 			if(seqString==null) break;
 			@SuppressWarnings("unchecked")
 			S sequence = (S) sequenceCreator.getSequence(seqString, 0);
-			GenericGenbankHeaderParser<S, C> genbankHeaderParser = genbankParser.getSequenceHeaderParser();
-			
-			genbankHeaderParser.parseHeader(genbankParser.getHeader(), sequence);
-			
+			GenericGenbankHeaderParser<S, C> genbankHeaderParser = genbankParser.getSequenceHeaderParser();			
+			genbankHeaderParser.parseHeader(genbankParser.getHeader(), sequence);			
 			String id = genbankHeaderParser.getAccession();
 			int version = genbankHeaderParser.getVersion();
 			String identifier = genbankHeaderParser.getIdentifier();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReader.java
@@ -26,6 +26,7 @@
 package org.biojava.nbio.core.sequence.io;
 
 import org.biojava.nbio.core.exceptions.CompoundNotFoundException;
+import org.biojava.nbio.core.sequence.AccessionID;
 import org.biojava.nbio.core.sequence.DataSource;
 import org.biojava.nbio.core.sequence.TaxonomyID;
 import org.biojava.nbio.core.sequence.features.DBReferenceInfo;
@@ -162,8 +163,16 @@ public class GenbankReader<S extends AbstractSequence<C>, C extends Compound> {
 			if(seqString==null) break;
 			@SuppressWarnings("unchecked")
 			S sequence = (S) sequenceCreator.getSequence(seqString, 0);
-			genbankParser.getSequenceHeaderParser().parseHeader(genbankParser.getHeader(), sequence);
-
+			GenericGenbankHeaderParser<S, C> genbankHeaderParser = genbankParser.getSequenceHeaderParser();
+			
+			genbankHeaderParser.parseHeader(genbankParser.getHeader(), sequence);
+			
+			String id = genbankHeaderParser.getAccession();
+			int version = genbankHeaderParser.getVersion();
+			String identifier = genbankHeaderParser.getIdentifier();
+			AccessionID accession = new AccessionID(id , DataSource.UNKNOWN, version, identifier);
+			sequence.setAccession(accession);
+			
 			// add features to new sequence
 			genbankParser.getFeatures().values().stream()
 			.flatMap(List::stream)

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
@@ -271,7 +271,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 		headerParser.addReference(genbankReference);
 	}
 
-	private void parseVersionTag(List<String[]> section) {		
+	private void parseVersionTag(List<String[]> section) {
 		String ver = section.get(0)[1];
 		Matcher m = vp.matcher(ver);
 		if (m.matches()) {
@@ -384,7 +384,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 	// key->value tuples
 	// reads an indented section, combining split lines and creating a list of
 	// key->value tuples
-	private List<String[]> readSection(BufferedReader bufferedReader) {		
+	private List<String[]> readSection(BufferedReader bufferedReader) {
 		List<String[]> section = new ArrayList<>();
 		String line;
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
@@ -203,9 +203,10 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 				Boolean needsQuotes = false;
 				key = key.substring(1); // strip leading slash
 				val = val.replaceAll("\\s*[\\n\\r]+\\s*", " ").trim();
+				
 				if (val.endsWith("\"")) {
 					val = val.substring(1, val.length() - 1); // strip quotes
-					needsQuotes = true; // as the value has quotes then set that it needs quotes when written back out					
+					needsQuotes = true; // as the value has quotes then set that it needs quotes when written back out
 				}
 				// parameter on old feature
 				if (key.equals("db_xref")) {
@@ -214,6 +215,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 						String dbname = m.group(1);
 						String raccession = m.group(2);
 						DBReferenceInfo xref = new DBReferenceInfo(dbname, raccession);
+						xref.setNeedsQuotes(needsQuotes);
 						gbFeature.addQualifier(key, xref);
 
 						ArrayList<DBReferenceInfo> listDBEntry = new ArrayList<>();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
@@ -109,8 +109,10 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 	protected static final String PRIMARY = "PRIMARY";
 	protected static final String DBLINK = "DBLINK";
 	protected static final String END_SEQUENCE_TAG = "//";
-	// locus line
-	protected static final Pattern lp = Pattern.compile("^(\\S+)\\s+(\\d+)\\s+(bp|BP|aa|AA)\\s{0,4}(([dmsDMS][sS]-)?(\\S+))?\\s*(circular|CIRCULAR|linear|LINEAR)?\\s*(\\S+)?\\s*(\\S+)?$");
+	// locus line with name that may contain spaces but must start and end with non whitespace character
+	protected static final Pattern lp = Pattern.compile("^(\\S+[\\S ]*\\S*)\\s+(\\d+)\\s+(bp|BP|aa|AA)\\s{0,4}(([dmsDMS][sS]-)?(\\S+))?\\s*(circular|CIRCULAR|linear|LINEAR)?\\s*(\\S+)?\\s*(\\S+)?$");
+	// locus line with no name
+	protected static final Pattern lp2 = Pattern.compile("^(\\d+)\\s+(bp|BP|aa|AA)\\s{0,4}(([dmsDMS][sS]-)?(\\S+))?\\s*(circular|CIRCULAR|linear|LINEAR)?\\s*(\\S+)?\\s*(\\S+)?$");	
 	// version line
 	protected static final Pattern vp = Pattern.compile("^(\\S*?)(\\.(\\d+))?(\\s+GI:(\\S+))?$");
 	// reference line
@@ -267,6 +269,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 	}
 
 	private void parseVersionTag(List<String[]> section) {
+		
 		String ver = section.get(0)[1];
 		Matcher m = vp.matcher(ver);
 		if (m.matches()) {
@@ -304,9 +307,13 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 		String loc = section.get(0)[1];
 		header = loc;
 		Matcher m = lp.matcher(loc);
+		Matcher m2 = lp2.matcher(loc);
+		
 		if (m.matches()) {
-			headerParser.setName(m.group(1));
-			headerParser.setAccession(m.group(1)); // default if no accession found
+			//remove any preceding or trailing whitespace from the locus name
+			String name = m.group(1).trim().replaceAll(" ","_");		
+			headerParser.setName(name);
+			headerParser.setAccession(name); // default if no accession found			
 			long sequenceLength = Long.valueOf(m.group(2));
 			String lengthUnits = m.group(3);
 			String type = m.group(6);
@@ -333,6 +340,37 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 
 			log.debug("compound type: {}", compoundType.getClass().getSimpleName());
 
+		} else if (m2.matches()) {
+			// Locus Name Missing - use different Locus regex
+			headerParser.setName("");
+			headerParser.setAccession(""); // default if no accession found			
+			long sequenceLength = Long.valueOf(m2.group(1));
+			String lengthUnits = m2.group(2);
+			String type = m2.group(5);
+
+			if (lengthUnits.equalsIgnoreCase("aa")) {
+				compoundType = AminoAcidCompoundSet.getAminoAcidCompoundSet();
+			} else if (lengthUnits.equalsIgnoreCase("bp")) {
+				if (type != null) {
+					if (type.contains("RNA")) {
+						compoundType = RNACompoundSet.getRNACompoundSet();
+					} else {
+						compoundType = DNACompoundSet.getDNACompoundSet();
+					}
+				} else {
+					compoundType = DNACompoundSet.getDNACompoundSet();
+				}
+			}
+
+			if (m2.group(6) != null) isCircularSequence = m2.group(6).equalsIgnoreCase("circular");
+
+			// configure location parser with needed information
+			locationParser.setSequenceLength(sequenceLength);
+			locationParser.setSequenceCircular(isCircularSequence);
+
+			log.debug("compound type: {}", compoundType.getClass().getSimpleName());
+			
+			
 		} else {
 			throw new ParserException("Bad locus line");
 		}
@@ -346,6 +384,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 	// reads an indented section, combining split lines and creating a list of
 	// key->value tuples
 	private List<String[]> readSection(BufferedReader bufferedReader) {
+		
 		List<String[]> section = new ArrayList<>();
 		String line;
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
@@ -200,10 +200,12 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 				if (gbFeature == null) {
 					throw new ParserException("Malformed GenBank file: found a qualifier without feature.");
 				}
+				Boolean needsQuotes = false;
 				key = key.substring(1); // strip leading slash
 				val = val.replaceAll("\\s*[\\n\\r]+\\s*", " ").trim();
 				if (val.endsWith("\"")) {
 					val = val.substring(1, val.length() - 1); // strip quotes
+					needsQuotes = true; // as the value has quotes then set that it needs quotes when written back out					
 				}
 				// parameter on old feature
 				if (key.equals("db_xref")) {
@@ -221,17 +223,17 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 						throw new ParserException("Bad dbxref");
 					}
 				} else if (key.equalsIgnoreCase("organism")) {
-					Qualifier q = new Qualifier(key, val.replace('\n', ' '));
+					Qualifier q = new Qualifier(key, val.replace('\n', ' '), needsQuotes);
 					gbFeature.addQualifier(key, q);
 				} else {
 					if (key.equalsIgnoreCase("translation") || key.equals("anticodon")
 							|| key.equals("transl_except")) {
 						// strip spaces from sequence
 						val = val.replaceAll("\\s+", "");
-						Qualifier q = new Qualifier(key, val);
+						Qualifier q = new Qualifier(key, val, needsQuotes);
 						gbFeature.addQualifier(key, q);
 					} else {
-						Qualifier q = new Qualifier(key, val);
+						Qualifier q = new Qualifier(key, val, needsQuotes);
 						gbFeature.addQualifier(key, q);
 					}
 				}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
@@ -202,8 +202,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 				}
 				Boolean needsQuotes = false;
 				key = key.substring(1); // strip leading slash
-				val = val.replaceAll("\\s*[\\n\\r]+\\s*", " ").trim();
-				
+				val = val.replaceAll("\\s*[\\n\\r]+\\s*", " ").trim();				
 				if (val.endsWith("\"")) {
 					val = val.substring(1, val.length() - 1); // strip quotes
 					needsQuotes = true; // as the value has quotes then set that it needs quotes when written back out
@@ -272,8 +271,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 		headerParser.addReference(genbankReference);
 	}
 
-	private void parseVersionTag(List<String[]> section) {
-		
+	private void parseVersionTag(List<String[]> section) {		
 		String ver = section.get(0)[1];
 		Matcher m = vp.matcher(ver);
 		if (m.matches()) {
@@ -311,8 +309,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 		String loc = section.get(0)[1];
 		header = loc;
 		Matcher m = lp.matcher(loc);
-		Matcher m2 = lp2.matcher(loc);
-		
+		Matcher m2 = lp2.matcher(loc);		
 		if (m.matches()) {
 			//remove any preceding or trailing whitespace from the locus name
 			String name = m.group(1).trim().replaceAll(" ","_");		
@@ -387,8 +384,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 	// key->value tuples
 	// reads an indented section, combining split lines and creating a list of
 	// key->value tuples
-	private List<String[]> readSection(BufferedReader bufferedReader) {
-		
+	private List<String[]> readSection(BufferedReader bufferedReader) {		
 		List<String[]> section = new ArrayList<>();
 		String line;
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankWriter.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankWriter.java
@@ -94,8 +94,7 @@ public class GenbankWriter<S extends Sequence<?>, C extends Compound> {
 			String header = headerFormat.getHeader(sequence);
 			writer.print(header);
 			writer.println();
-			// os.write(lineSep);
-			
+			// os.write(lineSep);			
 			/*
 			 * if isinstance(record.seq, UnknownSeq): #We have already recorded
 			 * the length, and there is no need #to record a long sequence of

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankWriter.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankWriter.java
@@ -92,10 +92,10 @@ public class GenbankWriter<S extends Sequence<?>, C extends Compound> {
 		PrintWriter writer = new PrintWriter(os);
 		for (S sequence : sequences) {
 			String header = headerFormat.getHeader(sequence);
-			writer.format(header);
+			writer.print(header);
 			writer.println();
 			// os.write(lineSep);
-
+			
 			/*
 			 * if isinstance(record.seq, UnknownSeq): #We have already recorded
 			 * the length, and there is no need #to record a long sequence of

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankWriterHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankWriterHelper.java
@@ -136,6 +136,24 @@ public class GenbankWriterHelper {
 	}
 
 	/**
+	 * Write a collection of NucleotideSequences to a file using the NucleotideSequences
+	 * original header as the LOCUS line rather than generating it
+	 *
+	 * @param outputStream
+	 * @param dnaSequences
+	 * @throws Exception
+	 */
+
+	public static void writeNucleotideSequenceOriginal(OutputStream outputStream, Collection<DNASequence> dnaSequences)
+			throws Exception {
+		GenericGenbankHeaderFormat<DNASequence, NucleotideCompound> genericGenbankHeaderFormat = new GenericGenbankHeaderFormat<DNASequence, NucleotideCompound>(
+				true);
+		GenbankWriter<DNASequence, NucleotideCompound> genbankWriter = new GenbankWriter<DNASequence, NucleotideCompound>(
+				outputStream, dnaSequences, genericGenbankHeaderFormat);
+		genbankWriter.process();
+	}
+	
+	/**
 	 * Write a sequence to a file
 	 *
 	 * @param file

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderFormat.java
@@ -39,7 +39,7 @@ public class GenericGenbankHeaderFormat<S extends AbstractSequence<C>, C extends
 	private static final int HEADER_WIDTH = 12;
 	private static final String lineSep = "%n";
 	private String seqType = null;
-	private Boolean useOriginalHeader = false;
+	private boolean useOriginalHeader = false;
 
 	public GenericGenbankHeaderFormat() {
 		seqType = null;
@@ -49,7 +49,7 @@ public class GenericGenbankHeaderFormat<S extends AbstractSequence<C>, C extends
 		this.seqType = seqType;
 	}
 	
-	public GenericGenbankHeaderFormat(Boolean useOriginalHeader) {
+	public GenericGenbankHeaderFormat(boolean useOriginalHeader) {
 		this.useOriginalHeader = useOriginalHeader;
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -161,7 +161,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 		}
 	}
 
-	
+
 	/**
 	 * {@inheritDoc}
 	 * The last accession passed to this routine will always be the one used.

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -35,8 +35,7 @@ import java.util.List;
 
 import org.biojava.nbio.core.sequence.DataSource;
 
-public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends Compound>
-		implements SequenceHeaderParserInterface<S, C> {
+public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends Compound> implements SequenceHeaderParserInterface<S, C> {
 
 	@SuppressWarnings("unused")
 
@@ -151,8 +150,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * The last accession passed to this routine will always be the one used.
 	 */
 	public void setVersion(int version) throws ParserException {
-		if (this.versionSeen)
-			throw new ParserException("Current BioEntry already has a version");
+		if (this.versionSeen) throw new ParserException("Current BioEntry already has a version");
 		else {
 			try {
 				this.version = version;
@@ -164,12 +162,11 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	}
 
 	/**
-	 * {@inheritDoc} The last accession passed to this routine will always be the
-	 * one used.
+	 * {@inheritDoc} 
+	 * The last accession passed to this routine will always be the one used.
 	 */
 	public void setAccession(String accession) throws ParserException {
-		if (accession == null)
-			throw new ParserException("Accession cannot be null");
+		if (accession == null) throw new ParserException("Accession cannot be null");
 		this.accession = accession;
 	}
 
@@ -177,8 +174,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setDescription(String description) throws ParserException {
-		if (this.description != null)
-			throw new ParserException("Current BioEntry already has a description");
+		if (this.description != null) throw new ParserException("Current BioEntry already has a description");
 		this.description = description;
 	}
 
@@ -186,10 +182,8 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setIdentifier(String identifier) throws ParserException {
-		if (identifier == null)
-			throw new ParserException("Identifier cannot be null");
-		if (this.identifier != null)
-			throw new ParserException("Current BioEntry already has a identifier");
+		if (identifier == null) throw new ParserException("Identifier cannot be null");
+		if (this.identifier != null) throw new ParserException("Current BioEntry already has a identifier");
 		this.identifier = identifier;
 	}
 
@@ -197,10 +191,8 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setName(String name) throws ParserException {
-		if (name == null)
-			throw new ParserException("Name cannot be null");
-		if (this.name != null)
-			throw new ParserException("Current BioEntry already has a name");
+		if (name == null) throw new ParserException("Name cannot be null");
+		if (this.name != null) throw new ParserException("Current BioEntry already has a name");
 		this.name = name;
 	}
 
@@ -208,8 +200,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setComment(String comment) throws ParserException {
-		if (comment == null)
-			throw new ParserException("Comment cannot be null");
+		if (comment == null) throw new ParserException("Comment cannot be null");
 		this.comments.add(comment);
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 import org.biojava.nbio.core.sequence.DataSource;
 
-public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends Compound> implements SequenceHeaderParserInterface<S, C> {
+public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends Compound> implements SequenceHeaderParserInterface<S,C> {
 
 	@SuppressWarnings("unused")
 
@@ -162,11 +162,11 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	}
 
 	/**
-	 * {@inheritDoc} 
+	 * {@inheritDoc}
 	 * The last accession passed to this routine will always be the one used.
 	 */
 	public void setAccession(String accession) throws ParserException {
-		if (accession == null) throw new ParserException("Accession cannot be null");
+		if (accession==null) throw new ParserException("Accession cannot be null");
 		this.accession = accession;
 	}
 
@@ -174,7 +174,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setDescription(String description) throws ParserException {
-		if (this.description != null) throw new ParserException("Current BioEntry already has a description");
+		if (this.description!=null) throw new ParserException("Current BioEntry already has a description");
 		this.description = description;
 	}
 
@@ -182,8 +182,8 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setIdentifier(String identifier) throws ParserException {
-		if (identifier == null) throw new ParserException("Identifier cannot be null");
-		if (this.identifier != null) throw new ParserException("Current BioEntry already has a identifier");
+		if (identifier==null) throw new ParserException("Identifier cannot be null");
+		if (this.identifier!=null) throw new ParserException("Current BioEntry already has a identifier");
 		this.identifier = identifier;
 	}
 
@@ -191,8 +191,8 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setName(String name) throws ParserException {
-		if (name == null) throw new ParserException("Name cannot be null");
-		if (this.name != null) throw new ParserException("Current BioEntry already has a name");
+		if (name==null) throw new ParserException("Name cannot be null");
+		if (this.name!=null) throw new ParserException("Current BioEntry already has a name");
 		this.name = name;
 	}
 
@@ -200,11 +200,11 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setComment(String comment) throws ParserException {
-		if (comment == null) throw new ParserException("Comment cannot be null");
+		if (comment==null) throw new ParserException("Comment cannot be null");
 		this.comments.add(comment);
 	}
 
-	public void addReference(AbstractReference abstractReference) {
+	public void addReference(AbstractReference abstractReference){
 		this.references.add(abstractReference);
 	}
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -161,6 +161,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 		}
 	}
 
+	
 	/**
 	 * {@inheritDoc}
 	 * The last accession passed to this routine will always be the one used.

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -39,53 +39,69 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 
 	@SuppressWarnings("unused")
 
-	// Brief description of sequence; includes information such as source organism,
-	// gene name/protein name, or some description of the sequence's function (if
-	// the sequence is non-coding). If the sequence has a coding region (CDS),
-	// description may be followed by a completeness qualifier, such as "complete
-	// cds".
+	/**
+	 * Brief description of sequence; includes information such as source
+	 * organism,gene name/protein name, or some description of the sequence's
+	 * function (if the sequence is non-coding). If the sequence has a coding region
+	 * (CDS), description may be followed by a completeness qualifier, such as
+	 * "complete CDS".
+	 */
 	private String description;
 	
-	// The unique identifier for a sequence record
+	/** 
+	 * The unique identifier for a sequence record
+	 */
 	private String accession = null;
 
 	private String identifier = null;
 
 	private String name = null;
 
-	// A nucleotide sequence identification number that represents a single,
-	// specific sequence in the GenBank database. This identification number uses
-	// the accession.version format implemented by GenBank/EMBL/DDBJ in February
-	// 1999.
+	/**
+	 * A nucleotide sequence identification number that represents a single,
+	 * specific sequence in the GenBank database. This identification number uses
+	 * the accession.version format implemented by GenBank/EMBL/DDBJ in February
+	 * 1999.
+	 */
 	private int version;
 
 	private boolean versionSeen;
 
 	private ArrayList<String> comments = new ArrayList<>();
 
-	// Publications by the authors of the sequence that discuss the data reported in
-	// the record. References are automatically sorted within the record based on
-	// date of publication, showing the oldest references first.
+	/**
+	 * Publications by the authors of the sequence that discuss the data reported in
+	 * the record. References are automatically sorted within the record based on
+	 * date of publication, showing the oldest references first.
+	 */
 	private List<AbstractReference> references = new ArrayList<>();
 
-	// Word or phrase describing the sequence. If no keywords are included in the
-	// entry, the field contains only a period.
-	private List<String> keywords = new ArrayList();
+	/**
+	 * Word or phrase describing the sequence. If no keywords are included in the
+	 * entry, the field contains only a period.
+	 */
+	private List<String> keywords = new ArrayList<>();
 
-	// Free-format information including an abbreviated form of the organism name,
-	// sometimes followed by a molecule type. (See section 3.4.10 of the GenBank
-	// release notes for more info.)
+	/**
+	 * Free-format information including an abbreviated form of the organism name,
+	 * sometimes followed by a molecule type. (See section 3.4.10 of the GenBank
+	 * release notes for more info.)
+	 */	
 	private String source = null;
 
-	// The formal scientific name for the source organism (genus and species, where
-	// appropriate) and its lineage, based on the phylogenetic classification scheme
-	// used in the NCBI Taxonomy Database. If the complete lineage of an organism is
-	// very long, an abbreviated lineage will be shown in the GenBank record and the
-	// complete lineage will be available in the Taxonomy Database. (See also the
-	// /db_xref=taxon:nnnn Feature qualifer, below.)
-	private List<String> organism = new ArrayList();
+	/**
+	 * The formal scientific name for the source organism (genus and species, where
+	 * appropriate) and its lineage, based on the phylogenetic classification scheme
+	 * used in the NCBI Taxonomy Database. If the complete lineage of an organism is
+	 * very long, an abbreviated lineage will be shown in the GenBank record and the
+	 * complete lineage will be available in the Taxonomy Database. (See also the
+	 * /db_xref=taxon:nnnn Feature qualifer, below.)
+	 */
+	private List<String> organism = new ArrayList<>();
 	
-	// GI sequence identifier
+	/**
+	 * GI sequence identifier
+	 */
 	private String gi = null;
 
 	/**

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -97,7 +97,6 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	@Override
 	public void parseHeader(String header, S sequence) {
 		sequence.setOriginalHeader(header);
-		sequence.setLocusName(name);
 		sequence.setAccession(new AccessionID(accession, DataSource.GENBANK, version, identifier));
 		sequence.setDescription(description);
 		sequence.setComments(comments);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -35,16 +35,59 @@ import java.util.List;
 
 import org.biojava.nbio.core.sequence.DataSource;
 
-public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends Compound> implements SequenceHeaderParserInterface<S,C> {
+public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends Compound>
+		implements SequenceHeaderParserInterface<S, C> {
 
-	private String accession = null;
-	private String identifier = null;
-	private String name = null;
 	@SuppressWarnings("unused")
+
+	// Brief description of sequence; includes information such as source organism,
+	// gene name/protein name, or some description of the sequence's function (if
+	// the sequence is non-coding). If the sequence has a coding region (CDS),
+	// description may be followed by a completeness qualifier, such as "complete
+	// cds".
+	private String description;
+	
+	// The unique identifier for a sequence record
+	private String accession = null;
+
+	private String identifier = null;
+
+	private String name = null;
+
+	// A nucleotide sequence identification number that represents a single,
+	// specific sequence in the GenBank database. This identification number uses
+	// the accession.version format implemented by GenBank/EMBL/DDBJ in February
+	// 1999.
 	private int version;
+
 	private boolean versionSeen;
+
 	private ArrayList<String> comments = new ArrayList<>();
+
+	// Publications by the authors of the sequence that discuss the data reported in
+	// the record. References are automatically sorted within the record based on
+	// date of publication, showing the oldest references first.
 	private List<AbstractReference> references = new ArrayList<>();
+
+	// Word or phrase describing the sequence. If no keywords are included in the
+	// entry, the field contains only a period.
+	private List<String> keywords = new ArrayList();
+
+	// Free-format information including an abbreviated form of the organism name,
+	// sometimes followed by a molecule type. (See section 3.4.10 of the GenBank
+	// release notes for more info.)
+	private String source = null;
+
+	// The formal scientific name for the source organism (genus and species, where
+	// appropriate) and its lineage, based on the phylogenetic classification scheme
+	// used in the NCBI Taxonomy Database. If the complete lineage of an organism is
+	// very long, an abbreviated lineage will be shown in the GenBank record and the
+	// complete lineage will be available in the Taxonomy Database. (See also the
+	// /db_xref=taxon:nnnn Feature qualifer, below.)
+	private List<String> organism = new ArrayList();
+	
+	// GI sequence identifier
+	private String gi = null;
 
 	/**
 	 * Parse the header and set the values in the sequence
@@ -54,10 +97,39 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	@Override
 	public void parseHeader(String header, S sequence) {
 		sequence.setOriginalHeader(header);
+		sequence.setLocusName(name);
 		sequence.setAccession(new AccessionID(accession, DataSource.GENBANK, version, identifier));
 		sequence.setDescription(description);
 		sequence.setComments(comments);
 		sequence.setReferences(references);
+	}
+
+	public String getAccession() {
+		return accession;
+	}
+
+	public String getIdentifier() {
+		return identifier;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public int getVersion() {
+		return version;
+	}
+
+	public ArrayList<String> getComments() {
+		return comments;
+	}
+
+	public List<AbstractReference> getReferences() {
+		return references;
+	}
+
+	public String getDescription() {
+		return description;
 	}
 
 	/**
@@ -77,9 +149,11 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 
 	/**
 	 * {@inheritDoc}
+	 * The last accession passed to this routine will always be the one used.
 	 */
 	public void setVersion(int version) throws ParserException {
-		if (this.versionSeen) throw new ParserException("Current BioEntry already has a version");
+		if (this.versionSeen)
+			throw new ParserException("Current BioEntry already has a version");
 		else {
 			try {
 				this.version = version;
@@ -90,13 +164,13 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 		}
 	}
 
-
 	/**
-	 * {@inheritDoc}
-	 * The last accession passed to this routine will always be the one used.
+	 * {@inheritDoc} The last accession passed to this routine will always be the
+	 * one used.
 	 */
 	public void setAccession(String accession) throws ParserException {
-		if (accession==null) throw new ParserException("Accession cannot be null");
+		if (accession == null)
+			throw new ParserException("Accession cannot be null");
 		this.accession = accession;
 	}
 
@@ -104,17 +178,19 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setDescription(String description) throws ParserException {
-		if (this.description!=null) throw new ParserException("Current BioEntry already has a description");
+		if (this.description != null)
+			throw new ParserException("Current BioEntry already has a description");
 		this.description = description;
 	}
-	private String description;
 
 	/**
 	 * {@inheritDoc}
 	 */
 	public void setIdentifier(String identifier) throws ParserException {
-		if (identifier==null) throw new ParserException("Identifier cannot be null");
-		if (this.identifier!=null) throw new ParserException("Current BioEntry already has a identifier");
+		if (identifier == null)
+			throw new ParserException("Identifier cannot be null");
+		if (this.identifier != null)
+			throw new ParserException("Current BioEntry already has a identifier");
 		this.identifier = identifier;
 	}
 
@@ -122,8 +198,10 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setName(String name) throws ParserException {
-		if (name==null) throw new ParserException("Name cannot be null");
-		if (this.name!=null) throw new ParserException("Current BioEntry already has a name");
+		if (name == null)
+			throw new ParserException("Name cannot be null");
+		if (this.name != null)
+			throw new ParserException("Current BioEntry already has a name");
 		this.name = name;
 	}
 
@@ -131,11 +209,12 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 */
 	public void setComment(String comment) throws ParserException {
-		if (comment==null) throw new ParserException("Comment cannot be null");
+		if (comment == null)
+			throw new ParserException("Comment cannot be null");
 		this.comments.add(comment);
 	}
 
-	public void addReference(AbstractReference abstractReference){
+	public void addReference(AbstractReference abstractReference) {
 		this.references.add(abstractReference);
 	}
 }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -235,7 +235,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 			}			
 		}
 		// As noted above, treat reverse complement strand features carefully:
-		if(feature.getLocations().getStrand() == Strand.NEGATIVE) {			
+		if(feature.getLocations().getStrand() == Strand.NEGATIVE) {
 			for(FeatureInterface<?, ?> f  : feature.getChildrenFeatures()) {
 				if(f.getLocations().getStrand() != Strand.NEGATIVE) {
 					StringBuilder sb = new StringBuilder();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -116,7 +116,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 	 * @param record_length
 	 */
 	protected String _write_feature(FeatureInterface<AbstractSequence<C>, C> feature, int record_length) {
-		String location = _insdc_feature_location_string(feature, record_length);		
+		String location = _insdc_feature_location_string(feature, record_length);
 		String f_type = feature.getType().replace(" ", "_");
 		StringBuilder sb = new StringBuilder();
 		Formatter formatter = new Formatter(sb,Locale.US);
@@ -235,8 +235,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 			}			
 		}
 		// As noted above, treat reverse complement strand features carefully:
-		if(feature.getLocations().getStrand() == Strand.NEGATIVE) {
-			
+		if(feature.getLocations().getStrand() == Strand.NEGATIVE) {			
 			for(FeatureInterface<?, ?> f  : feature.getChildrenFeatures()) {
 				if(f.getLocations().getStrand() != Strand.NEGATIVE) {
 					StringBuilder sb = new StringBuilder();
@@ -283,7 +282,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 	else:
 		ref = ""
 	assert not location.ref_db
-	*/		
+	*/
 		String ref = "";
 		if(!sequenceLocation.getStart().isUncertain() && !sequenceLocation.getEnd().isUncertain() && sequenceLocation.getStart() == sequenceLocation.getEnd()) {
 			//Special case, for 12:12 return 12^13

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -116,8 +116,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 	 * @param record_length
 	 */
 	protected String _write_feature(FeatureInterface<AbstractSequence<C>, C> feature, int record_length) {
-		String location = _insdc_feature_location_string(feature, record_length);
-		
+		String location = _insdc_feature_location_string(feature, record_length);		
 		String f_type = feature.getType().replace(" ", "_");
 		StringBuilder sb = new StringBuilder();
 		Formatter formatter = new Formatter(sb,Locale.US);
@@ -176,11 +175,8 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 	 * @param record_length
 	 */
 	private String _insdc_feature_location_string(FeatureInterface<AbstractSequence<C>, C> feature, int record_length) {
-		
-		if(feature.getChildrenFeatures().isEmpty()) {
-			
+		if(feature.getChildrenFeatures().isEmpty()) {			
 			if(feature.getLocations().getSubLocations().isEmpty()) {
-				
 				//Non-recursive.
 				String location = _insdc_location_string_ignoring_strand_and_subfeatures(feature.getLocations(), record_length);
 				if(feature.getLocations().getStrand() == Strand.NEGATIVE) {
@@ -236,8 +232,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 				String output = formatter.toString();
 				formatter.close();
 				return output;
-			}
-			
+			}			
 		}
 		// As noted above, treat reverse complement strand features carefully:
 		if(feature.getLocations().getStrand() == Strand.NEGATIVE) {
@@ -288,9 +283,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 	else:
 		ref = ""
 	assert not location.ref_db
-	*/
-		
-		
+	*/		
 		String ref = "";
 		if(!sequenceLocation.getStart().isUncertain() && !sequenceLocation.getEnd().isUncertain() && sequenceLocation.getStart() == sequenceLocation.getEnd()) {
 			//Special case, for 12:12 return 12^13

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -24,6 +24,7 @@
 package org.biojava.nbio.core.sequence.io;
 
 import org.biojava.nbio.core.sequence.Strand;
+import org.biojava.nbio.core.sequence.features.DBReferenceInfo;
 import org.biojava.nbio.core.sequence.features.FeatureInterface;
 import org.biojava.nbio.core.sequence.features.Qualifier;
 import org.biojava.nbio.core.sequence.location.template.AbstractLocation;
@@ -127,7 +128,12 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 		//Now the qualifiers...
 		for(List<Qualifier>  qualifiers : feature.getQualifiers().values()) {
 			for(Qualifier q : qualifiers){
-				line += _write_feature_qualifier(q.getName().replaceAll("%","%%"), q.getValue().replaceAll("%","%%"), q.needsQuotes());
+				if (q instanceof DBReferenceInfo) {
+					DBReferenceInfo db = (DBReferenceInfo) q;
+					line += _write_feature_qualifier(q.getName().replaceAll("%","%%"), db.getDatabase().replaceAll("%","%%") + ":" + db.getId().replaceAll("%","%%"), db.needsQuotes());	
+				} else {
+					line += _write_feature_qualifier(q.getName().replaceAll("%","%%"), q.getValue().replaceAll("%","%%"), q.needsQuotes());
+				}
 			}
 		}
 		return line;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -283,6 +283,8 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 		ref = ""
 	assert not location.ref_db
 	*/
+		
+		
 		String ref = "";
 		if(!sequenceLocation.getStart().isUncertain() && !sequenceLocation.getEnd().isUncertain() && sequenceLocation.getStart() == sequenceLocation.getEnd()) {
 			//Special case, for 12:12 return 12^13
@@ -338,7 +340,20 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 			}
 		} else {
 			//Typical case, e.g. 12..15 gets mapped to 11:15
-			return ref + _insdc_feature_position_string(sequenceLocation.getStart(), 0) + ".." + _insdc_feature_position_string(sequenceLocation.getEnd());
+			String start = _insdc_feature_position_string(sequenceLocation.getStart());
+			String end = _insdc_feature_position_string(sequenceLocation.getEnd()); 
+			
+			if (sequenceLocation.isPartial()) {
+				if (sequenceLocation.isPartialOn5prime()) {
+					start = "<" + start;
+				}
+				
+				if (sequenceLocation.isPartialOn3prime()) {
+					end = ">" + end;
+				}	
+			}
+			
+			return ref + start + ".." + end;
 		}
 	}
 	private String _insdc_feature_position_string(Point location) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
@@ -66,7 +66,7 @@ public class InsdcParser {
 	 * complement(location,location...location): consider locations in their
 	 * complement versus
 	 *
-	 * takes in input a comma splitted location string. The split must be done
+	 * takes in input a comma split location string. The split must be done
 	 * for outer level commas group(1) is the qualifier group(2) is the location
 	 * string to getFeatures. In case of complex splits it will contain the
 	 * nested expression
@@ -74,7 +74,7 @@ public class InsdcParser {
 	 * Not really sure that they are not declared obsolete but they are still in
 	 * several files.
 	 */
-	protected static final Pattern genbankSplitPattern = Pattern.compile("^\\s?(join|order|bond|complement|)\\(?(.+)\\)?");
+	protected static final Pattern genbankSplitPattern = Pattern.compile("^\\s?(join|order|bond|complement|)\\(?([\\s\\S]+)\\)?");
 	/**
 	 * designed to recursively split a location string in tokens. Valid tokens
 	 * are those divided by coma that are not inside a bracket. I. e. split on

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
@@ -160,69 +160,54 @@ public class GenbankWriterTest {
 		
 		assertEquals("join1, getType()", "CDS", join1.getType());
 		assertEquals("join1, getLocations().getStrand()", "POSITIVE", join1.getLocations().getStrand().toString());
-		assertEquals("join1, getLocations().getSubLocations().size()", 8, join1SubLocs.size());
+		assertEquals("join1, getLocations().getSubLocations().size()", 6, join1SubLocs.size());
 		
-		assertEquals("join1, SubLocation 1)", 3356, join1SubLocs.get(0).getStart().getPosition().intValue());
-		assertEquals("join1, SubLocation 1)", 3356, join1SubLocs.get(0).getEnd().getPosition().intValue());
+		assertEquals("join1, SubLocation 1)", 1, join1SubLocs.get(0).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 1)", 1, join1SubLocs.get(0).getEnd().getPosition().intValue());
 		
-		assertEquals("join1, SubLocation 2)", 3500, join1SubLocs.get(1).getStart().getPosition().intValue());
-		assertEquals("join1, SubLocation 2)", 3792, join1SubLocs.get(1).getEnd().getPosition().intValue());
+		assertEquals("join1, SubLocation 2)", 10, join1SubLocs.get(1).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 2)", 12, join1SubLocs.get(1).getEnd().getPosition().intValue());
 		
-		assertEquals("join1, SubLocation 3)", 3793, join1SubLocs.get(2).getStart().getPosition().intValue());
-		assertEquals("join1, SubLocation 3)", 3793, join1SubLocs.get(2).getEnd().getPosition().intValue());
+		assertEquals("join1, SubLocation 3)", 30, join1SubLocs.get(2).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 3)", 30, join1SubLocs.get(2).getEnd().getPosition().intValue());
 		
-		assertEquals("join1, SubLocation 4)", 4185, join1SubLocs.get(3).getStart().getPosition().intValue());
-		assertEquals("join1, SubLocation 4)", 4228, join1SubLocs.get(3).getEnd().getPosition().intValue());
+		assertEquals("join1, SubLocation 3)", 35, join1SubLocs.get(3).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 3)", 38, join1SubLocs.get(3).getEnd().getPosition().intValue());
 		
-		assertEquals("join1, SubLocation 5)", 4229, join1SubLocs.get(4).getStart().getPosition().intValue());
-		assertEquals("join1, SubLocation 5)", 4229, join1SubLocs.get(4).getEnd().getPosition().intValue());
+		assertEquals("join1, SubLocation 5)", 43, join1SubLocs.get(4).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 5)", 46, join1SubLocs.get(4).getEnd().getPosition().intValue());
 		
-		assertEquals("join1, SubLocation 6)", 4348, join1SubLocs.get(5).getStart().getPosition().intValue());
-		assertEquals("join1, SubLocation 6)", 4676, join1SubLocs.get(5).getEnd().getPosition().intValue());
-		
-		assertEquals("join1, SubLocation 7)", 4677, join1SubLocs.get(6).getStart().getPosition().intValue());
-		assertEquals("join1, SubLocation 7)", 4677, join1SubLocs.get(6).getEnd().getPosition().intValue());
-		
-		assertEquals("join1, SubLocation 8)", 4775, join1SubLocs.get(7).getStart().getPosition().intValue());
-		assertEquals("join1, SubLocation 8)", 5094, join1SubLocs.get(7).getEnd().getPosition().intValue());
+		assertEquals("join1, SubLocation 6)", 47, join1SubLocs.get(5).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 6)", 50, join1SubLocs.get(5).getEnd().getPosition().intValue());
 		
 		//qualifiers
 		assertEquals("join1, getType()", "Joined feature", join1.getQualifiers().get("standard_name").get(0).getValue());
 		
 		//Join 2
 		FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound> join2 = features.get(1);
-		List<Location> join2SubLocs = join1.getLocations().getSubLocations();
+		List<Location> join2SubLocs = join2.getLocations().getSubLocations();
 		
-		assertEquals("join1, getType()", "CDS", join2.getType());
-		assertEquals("join1, getLocations().getStrand()", "NEGATIVE", join2.getLocations().getStrand().toString());
-		assertEquals("join1, getLocations().getSubLocations().size()", 8, join2SubLocs.size());
+		assertEquals("join2, getType()", "CDS", join2.getType());
+		assertEquals("join2, getLocations().getStrand()", "NEGATIVE", join2.getLocations().getStrand().toString());
+		assertEquals("join2, getLocations().getSubLocations().size()", 5, join2SubLocs.size());
 		
-		assertEquals("join2, SubLocation 1)", 3356, join2SubLocs.get(0).getStart().getPosition().intValue());
-		assertEquals("join2, SubLocation 1)", 3356, join2SubLocs.get(0).getEnd().getPosition().intValue());
+		assertEquals("join2, SubLocation 1)", 33, join2SubLocs.get(0).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 1)", 33, join2SubLocs.get(0).getEnd().getPosition().intValue());
 		
-		assertEquals("join2, SubLocation 2)", 3500, join2SubLocs.get(1).getStart().getPosition().intValue());
-		assertEquals("join2, SubLocation 2)", 3792, join2SubLocs.get(1).getEnd().getPosition().intValue());
+		assertEquals("join2, SubLocation 2)", 35, join2SubLocs.get(1).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 2)", 37, join2SubLocs.get(1).getEnd().getPosition().intValue());
 		
-		assertEquals("join2, SubLocation 3)", 3793, join2SubLocs.get(2).getStart().getPosition().intValue());
-		assertEquals("join2, SubLocation 3)", 3793, join2SubLocs.get(2).getEnd().getPosition().intValue());
+		assertEquals("join2, SubLocation 3)", 41, join2SubLocs.get(2).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 3)", 43, join2SubLocs.get(2).getEnd().getPosition().intValue());
 		
-		assertEquals("join2, SubLocation 4)", 4185, join2SubLocs.get(3).getStart().getPosition().intValue());
-		assertEquals("join2, SubLocation 4)", 4228, join2SubLocs.get(3).getEnd().getPosition().intValue());
+		assertEquals("join2, SubLocation 4)", 44, join2SubLocs.get(3).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 4)", 46, join2SubLocs.get(3).getEnd().getPosition().intValue());
 		
-		assertEquals("join2, SubLocation 5)", 4229, join2SubLocs.get(4).getStart().getPosition().intValue());
-		assertEquals("join2, SubLocation 5)", 4229, join2SubLocs.get(4).getEnd().getPosition().intValue());
-	
-		assertEquals("join2, SubLocation 6)", 4348, join2SubLocs.get(5).getStart().getPosition().intValue());
-		assertEquals("join2, SubLocation 6)", 4676, join2SubLocs.get(5).getEnd().getPosition().intValue());
-		
-		assertEquals("join2, SubLocation 7)", 4677, join2SubLocs.get(6).getStart().getPosition().intValue());
-		assertEquals("join2, SubLocation 7)", 4677, join2SubLocs.get(6).getEnd().getPosition().intValue());
-		
-		assertEquals("join2, SubLocation 8)", 4775, join2SubLocs.get(7).getStart().getPosition().intValue());
-		assertEquals("join2, SubLocation 8)", 5094, join2SubLocs.get(7).getEnd().getPosition().intValue());
+		assertEquals("join2, SubLocation 5)", 47, join2SubLocs.get(4).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 5)", 50, join2SubLocs.get(4).getEnd().getPosition().intValue());
 		
 		//qualifiers
-		assertEquals("join1, getType()", "Joined feature on complement", join2.getQualifiers().get("standard_name").get(0).getValue());
+		assertEquals("join2, getType()", "Joined feature on complement", join2.getQualifiers().get("standard_name").get(0).getValue());
 		
 		// Now write the joins back to a file using the GenbankWriterHelper
 		ByteArrayOutputStream fragwriter = new ByteArrayOutputStream();
@@ -231,7 +216,7 @@ public class GenbankWriterTest {
 				Arrays.asList(sequence));
 		fragwriter.close();
 		
-		//System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
+		System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
 		
 		// Read the output file and test that no information is lost
 		InputStream readerInputStream = new ByteArrayInputStream(fragwriter.toByteArray());
@@ -242,17 +227,17 @@ public class GenbankWriterTest {
 		// Check the output matches the original sequence feature
 		for (int i=0; i < features.size(); i++ ) {
 			assertEquals("getFeatures(), getType()", features.get(i).getType(), newFeatures.get(i).getType());
-			assertEquals("getFeatures(), getLocations()", features.get(i).getLocations(), newFeatures.get(i).getLocations());
+			assertEquals("getFeatures(), getStart()", features.get(i).getLocations().getStart(), newFeatures.get(i).getLocations().getStart());
+			assertEquals("getFeatures(), getEnd()", features.get(i).getLocations().getEnd(), newFeatures.get(i).getLocations().getEnd());
 			assertEquals("getFeatures(), getStrand()", features.get(i).getLocations().getStrand(), newFeatures.get(i).getLocations().getStrand());
 
 			List<Location> subLocations = features.get(i).getLocations().getSubLocations();
 			List<Location> newSubLocations = newFeatures.get(i).getLocations().getSubLocations();
 			assertEquals("getSubLocations()", subLocations.size(), newSubLocations.size());
-		
-			assertEquals("getSubLocations()", subLocations, newSubLocations);
-			
-			for (int j=0; j < subLocations.size(); j++ ) {
-				assertEquals("getSubLocations()", subLocations.get(j).toString(), newSubLocations.get(j).toString());
+		for (int j=0; j < subLocations.size(); j++ ) {
+				assertEquals("getSubLocations(), getStart()",  subLocations.get(j).getStart(), newSubLocations.get(j).getStart());
+				assertEquals("getSubLocations(), getEnd()",    subLocations.get(j).getEnd(), newSubLocations.get(j).getEnd());
+				assertEquals("getSubLocations(), getStrand()", subLocations.get(j).getStrand(), newSubLocations.get(j).getStrand());
 			}
 			
 			Map<String, List<Qualifier>> qualifiers = features.get(i).getQualifiers();

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
@@ -216,7 +216,7 @@ public class GenbankWriterTest {
 				Arrays.asList(sequence));
 		fragwriter.close();
 		
-		System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
+		//System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
 		
 		// Read the output file and test that no information is lost
 		InputStream readerInputStream = new ByteArrayInputStream(fragwriter.toByteArray());

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
@@ -46,7 +46,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
@@ -231,7 +231,7 @@ public class GenbankWriterTest {
 				Arrays.asList(sequence));
 		fragwriter.close();
 		
-		System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
+		//System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
 		
 		// Read the output file and test that no information is lost
 		InputStream readerInputStream = new ByteArrayInputStream(fragwriter.toByteArray());
@@ -279,7 +279,7 @@ public class GenbankWriterTest {
 		// First read the sample GenBank file from
 		// https://www.ncbi.nlm.nih.gov/Sitemap/samplerecord.html using the
 		// GenbankReaderHelper
-		InputStream inStream = GenbankWriterTest.class.getResourceAsStream("/NC_000913.gb");
+		InputStream inStream = GenbankWriterTest.class.getResourceAsStream("/NM_000266.gb");
 		DNASequence sequence = GenbankReaderHelper.readGenbankDNASequence(inStream).values().iterator().next();
 
 		// Then write sequence back to a file using the GenbankWriterHelper

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
@@ -27,10 +27,14 @@ package org.biojava.nbio.core.sequence.io;
 import org.biojava.nbio.core.sequence.AccessionID;
 import org.biojava.nbio.core.sequence.DNASequence;
 import org.biojava.nbio.core.sequence.features.AbstractFeature;
+import org.biojava.nbio.core.sequence.features.FeatureInterface;
 import org.biojava.nbio.core.sequence.features.Qualifier;
 import org.biojava.nbio.core.sequence.features.TextFeature;
 import org.biojava.nbio.core.sequence.location.SimpleLocation;
+import org.biojava.nbio.core.sequence.location.template.Location;
+import org.biojava.nbio.core.sequence.template.AbstractSequence;
 import org.biojava.nbio.core.sequence.Strand;
+import org.biojava.nbio.core.sequence.compound.NucleotideCompound;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -110,7 +114,7 @@ public class GenbankWriterTest {
 				Arrays.asList(seq), 
 				GenbankWriterHelper.LINEAR_DNA);
 		fragwriter.close();
-		System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
+		//System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
 		
 		// now read in the file that was created and check that the qualifiers were created correctly
 		InputStream readerInputStream = new ByteArrayInputStream(fragwriter.toByteArray());
@@ -138,6 +142,200 @@ public class GenbankWriterTest {
 		
 		assertEquals("note7", newQualifiers.get("note7").get(0).getName());
 		assertEquals("50%", newQualifiers.get("note7").get(0).getValue());
+		
+	}
+	
+	@Test
+	public void testLocationJoins() throws Exception {
+		
+		// First read a GenBank file containing location joins
+		InputStream inStream = GenbankWriterTest.class.getResourceAsStream("/with_joins.gb");
+		DNASequence sequence = GenbankReaderHelper.readGenbankDNASequence(inStream).values().iterator().next();
+		
+		// Check the joins are read correctly
+		List<FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound>> features = sequence.getFeatures();
+		
+		FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound> join1 = features.get(0);
+		List<Location> join1SubLocs = join1.getLocations().getSubLocations();
+		
+		assertEquals("join1, getType()", "CDS", join1.getType());
+		assertEquals("join1, getLocations().getStrand()", "POSITIVE", join1.getLocations().getStrand().toString());
+		assertEquals("join1, getLocations().getSubLocations().size()", 8, join1SubLocs.size());
+		
+		assertEquals("join1, SubLocation 1)", 3356, join1SubLocs.get(0).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 1)", 3356, join1SubLocs.get(0).getEnd().getPosition().intValue());
+		
+		assertEquals("join1, SubLocation 2)", 3500, join1SubLocs.get(1).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 2)", 3792, join1SubLocs.get(1).getEnd().getPosition().intValue());
+		
+		assertEquals("join1, SubLocation 3)", 3793, join1SubLocs.get(2).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 3)", 3793, join1SubLocs.get(2).getEnd().getPosition().intValue());
+		
+		assertEquals("join1, SubLocation 4)", 4185, join1SubLocs.get(3).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 4)", 4228, join1SubLocs.get(3).getEnd().getPosition().intValue());
+		
+		assertEquals("join1, SubLocation 5)", 4229, join1SubLocs.get(4).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 5)", 4229, join1SubLocs.get(4).getEnd().getPosition().intValue());
+		
+		assertEquals("join1, SubLocation 6)", 4348, join1SubLocs.get(5).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 6)", 4676, join1SubLocs.get(5).getEnd().getPosition().intValue());
+		
+		assertEquals("join1, SubLocation 7)", 4677, join1SubLocs.get(6).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 7)", 4677, join1SubLocs.get(6).getEnd().getPosition().intValue());
+		
+		assertEquals("join1, SubLocation 8)", 4775, join1SubLocs.get(7).getStart().getPosition().intValue());
+		assertEquals("join1, SubLocation 8)", 5094, join1SubLocs.get(7).getEnd().getPosition().intValue());
+		
+		//qualifiers
+		assertEquals("join1, getType()", "Joined feature", join1.getQualifiers().get("standard_name").get(0).getValue());
+		
+		//Join 2
+		FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound> join2 = features.get(1);
+		List<Location> join2SubLocs = join1.getLocations().getSubLocations();
+		
+		assertEquals("join1, getType()", "CDS", join2.getType());
+		assertEquals("join1, getLocations().getStrand()", "NEGATIVE", join2.getLocations().getStrand().toString());
+		assertEquals("join1, getLocations().getSubLocations().size()", 8, join2SubLocs.size());
+		
+		assertEquals("join2, SubLocation 1)", 3356, join2SubLocs.get(0).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 1)", 3356, join2SubLocs.get(0).getEnd().getPosition().intValue());
+		
+		assertEquals("join2, SubLocation 2)", 3500, join2SubLocs.get(1).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 2)", 3792, join2SubLocs.get(1).getEnd().getPosition().intValue());
+		
+		assertEquals("join2, SubLocation 3)", 3793, join2SubLocs.get(2).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 3)", 3793, join2SubLocs.get(2).getEnd().getPosition().intValue());
+		
+		assertEquals("join2, SubLocation 4)", 4185, join2SubLocs.get(3).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 4)", 4228, join2SubLocs.get(3).getEnd().getPosition().intValue());
+		
+		assertEquals("join2, SubLocation 5)", 4229, join2SubLocs.get(4).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 5)", 4229, join2SubLocs.get(4).getEnd().getPosition().intValue());
+	
+		assertEquals("join2, SubLocation 6)", 4348, join2SubLocs.get(5).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 6)", 4676, join2SubLocs.get(5).getEnd().getPosition().intValue());
+		
+		assertEquals("join2, SubLocation 7)", 4677, join2SubLocs.get(6).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 7)", 4677, join2SubLocs.get(6).getEnd().getPosition().intValue());
+		
+		assertEquals("join2, SubLocation 8)", 4775, join2SubLocs.get(7).getStart().getPosition().intValue());
+		assertEquals("join2, SubLocation 8)", 5094, join2SubLocs.get(7).getEnd().getPosition().intValue());
+		
+		//qualifiers
+		assertEquals("join1, getType()", "Joined feature on complement", join2.getQualifiers().get("standard_name").get(0).getValue());
+		
+		// Now write the joins back to a file using the GenbankWriterHelper
+		ByteArrayOutputStream fragwriter = new ByteArrayOutputStream();
+		GenbankWriterHelper.writeNucleotideSequenceOriginal(
+				fragwriter, 
+				Arrays.asList(sequence));
+		fragwriter.close();
+		
+		System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
+		
+		// Read the output file and test that no information is lost
+		InputStream readerInputStream = new ByteArrayInputStream(fragwriter.toByteArray());
+		DNASequence newSequence = GenbankReaderHelper.readGenbankDNASequence(readerInputStream).values().iterator().next();
+		
+		List<FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound>> newFeatures = newSequence.getFeatures();
+		
+		// Check the output matches the original sequence feature
+		for (int i=0; i < features.size(); i++ ) {
+			assertEquals("getFeatures(), getType()", features.get(i).getType(), newFeatures.get(i).getType());
+			assertEquals("getFeatures(), getLocations()", features.get(i).getLocations(), newFeatures.get(i).getLocations());
+			assertEquals("getFeatures(), getStrand()", features.get(i).getLocations().getStrand(), newFeatures.get(i).getLocations().getStrand());
+
+			List<Location> subLocations = features.get(i).getLocations().getSubLocations();
+			List<Location> newSubLocations = newFeatures.get(i).getLocations().getSubLocations();
+			assertEquals("getSubLocations()", subLocations.size(), newSubLocations.size());
+		
+			assertEquals("getSubLocations()", subLocations, newSubLocations);
+			
+			for (int j=0; j < subLocations.size(); j++ ) {
+				assertEquals("getSubLocations()", subLocations.get(j).toString(), newSubLocations.get(j).toString());
+			}
+			
+			Map<String, List<Qualifier>> qualifiers = features.get(i).getQualifiers();
+			Map<String, List<Qualifier>> newQualifiers = newFeatures.get(i).getQualifiers();
+			
+			for (String qualifierType:  qualifiers.keySet()) {
+				assertEquals("getSubLocations()", qualifiers.get(qualifierType).get(0).getValue(), newQualifiers.get(qualifierType).get(0).getValue());				
+			}
+			
+		}
+		
+	}
+	
+	/**
+	 * Going from GenBank file -> DNASequence object -> GenBank file looses information
+	 * https://github.com/biojava/biojava/issues/942
+	 */
+	@Test
+	public void testGithub942() throws Exception {
+		
+		// Important information is lost when reading and writing a
+		// GenBank file through GenbankReaderHelper & GenbankWriterHelper
+
+		// First read the sample GenBank file from
+		// https://www.ncbi.nlm.nih.gov/Sitemap/samplerecord.html using the
+		// GenbankReaderHelper
+		InputStream inStream = GenbankWriterTest.class.getResourceAsStream("/NC_000913.gb");
+		DNASequence sequence = GenbankReaderHelper.readGenbankDNASequence(inStream).values().iterator().next();
+
+		// Then write sequence back to a file using the GenbankWriterHelper
+		ByteArrayOutputStream fragwriter = new ByteArrayOutputStream();
+		GenbankWriterHelper.writeNucleotideSequenceOriginal(
+				fragwriter, 
+				Arrays.asList(sequence));
+		fragwriter.close();
+		
+		// Test no important information is lost
+		InputStream readerInputStream = new ByteArrayInputStream(fragwriter.toByteArray());
+		DNASequence newSequence = GenbankReaderHelper.readGenbankDNASequence(readerInputStream).values().iterator().next();
+		
+		//System.out.println(fragwriter.toString().replaceAll("\r\n", "\n"));
+
+		assertEquals("getOriginalHeader()", sequence.getOriginalHeader(), newSequence.getOriginalHeader());
+		assertEquals("getLength()", sequence.getLength(), newSequence.getLength());
+		assertEquals("getAccession().getID()", sequence.getAccession().getID(), newSequence.getAccession().getID());
+		assertEquals("getAccession().getVersion()", sequence.getAccession().getVersion(), newSequence.getAccession().getVersion());
+		assertEquals("getDescription()", sequence.getDescription(), newSequence.getDescription());
+		assertEquals("getSource()", sequence.getSource(), newSequence.getSource());
+		assertEquals("getDNAType()", sequence.getDNAType(), newSequence.getDNAType());
+		assertEquals("getTaxonomy()", sequence.getTaxonomy(), newSequence.getTaxonomy());		
+		assertEquals("getReferences()", sequence.getReferences(), newSequence.getReferences());
+		assertEquals("getComments()", sequence.getComments(), newSequence.getComments());
+		assertEquals("getNotesList()", sequence.getNotesList(), newSequence.getNotesList());
+		
+		List<FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound>> features = sequence.getFeatures();
+		List<FeatureInterface<AbstractSequence<NucleotideCompound>, NucleotideCompound>> newFeatures = newSequence.getFeatures();
+				
+		//feature locations and qualifiers
+		for (int i=0; i < features.size(); i++ ) {
+			assertEquals("getFeatures(), getType()", features.get(i).getType(), newFeatures.get(i).getType());
+			assertEquals("getFeatures(), getLocations()", features.get(i).getLocations(), newFeatures.get(i).getLocations());
+			assertEquals("getFeatures(), getStrand()", features.get(i).getLocations().getStrand(), newFeatures.get(i).getLocations().getStrand());
+
+			List<Location> subLocations = features.get(i).getLocations().getSubLocations();
+			List<Location> newSubLocations = newFeatures.get(i).getLocations().getSubLocations();
+			assertEquals("getSubLocations()", subLocations.size(), newSubLocations.size());
+		
+			assertEquals("getSubLocations()", subLocations, newSubLocations);
+			
+			for (int j=0; j < subLocations.size(); j++ ) {
+				assertEquals("getSubLocations()", subLocations.get(j).toString(), newSubLocations.get(j).toString());
+			}
+			
+			Map<String, List<Qualifier>> qualifiers = features.get(i).getQualifiers();
+			Map<String, List<Qualifier>> newQualifiers = newFeatures.get(i).getQualifiers();
+			
+			for (String qualifierType:  qualifiers.keySet()) {
+				assertEquals("getSubLocations()", qualifiers.get(qualifierType).get(0).getValue(), newQualifiers.get(qualifierType).get(0).getValue());				
+			}
+			
+		}
+		
+		assertEquals("getSequenceAsString()", sequence.getSequenceAsString(), newSequence.getSequenceAsString());
 		
 	}
 }

--- a/biojava-core/src/test/resources/with_joins.gb
+++ b/biojava-core/src/test/resources/with_joins.gb
@@ -1,0 +1,15 @@
+LOCUS                         4 bp    DNA     circular SYN 26-SEP-2022
+DEFINITION  .
+ACCESSION   .
+VERSION     .
+KEYWORDS    .
+SOURCE      .      
+FEATURES             Location/Qualifiers
+     CDS             join(3356,3500..3792,3793,4185..4228,4229,4348..4676,4677,
+                     4775..5094)
+                     /standard_name="Joined feature"
+     CDS             complement(join(3356,3500..3792,3793,4185..4228,4229,4348..4676,4677,4775..5094))
+                     /standard_name="Joined feature on complement"                     
+ORIGIN      
+        1 acgg
+//

--- a/biojava-core/src/test/resources/with_joins.gb
+++ b/biojava-core/src/test/resources/with_joins.gb
@@ -9,7 +9,7 @@ FEATURES             Location/Qualifiers
                      4775..5094)
                      /standard_name="Joined feature"
      CDS             complement(join(3356,3500..3792,3793,4185..4228,4229,4348..4676,4677,4775..5094))
-                     /standard_name="Joined feature on complement"                     
+                     /standard_name="Joined feature on complement"
 ORIGIN      
         1 acgg
 //

--- a/biojava-core/src/test/resources/with_joins.gb
+++ b/biojava-core/src/test/resources/with_joins.gb
@@ -5,10 +5,11 @@ VERSION     .
 KEYWORDS    .
 SOURCE      .      
 FEATURES             Location/Qualifiers
-     CDS             join(3356,3500..3792,3793,4185..4228,4229,4348..4676,4677,
-                     4775..5094)
+     CDS             join(1,10..12,30,41..42,43..46,
+                     47..50)
                      /standard_name="Joined feature"
-     CDS             complement(join(3356,3500..3792,3793,4185..4228,4229,4348..4676,4677,4775..5094))
+     CDS             complement(join(33,35..37,41..42,
+                     43..46,47..50))
                      /standard_name="Joined feature on complement"
 ORIGIN      
         1 acgg

--- a/biojava-core/src/test/resources/with_joins.gb
+++ b/biojava-core/src/test/resources/with_joins.gb
@@ -5,11 +5,9 @@ VERSION     .
 KEYWORDS    .
 SOURCE      .      
 FEATURES             Location/Qualifiers
-     CDS             join(1,10..12,30,41..42,43..46,
-                     47..50)
+     CDS             join(1,10..12,30,35..38,43..46,47..50)
                      /standard_name="Joined feature"
-     CDS             complement(join(33,35..37,41..42,
-                     43..46,47..50))
+     CDS             complement(join(33,35..37,41..43,44..46,47..50))
                      /standard_name="Joined feature on complement"
 ORIGIN      
         1 acgg


### PR DESCRIPTION
Hello, 
I have been working on the issue that a GenBank file read in through the parser and then written back out will result in loss of information from the original file. While looking into this I have also fixed a few other issues with the parser and writer for Genbank files. The highlights of this work includes:
- added a new writer helper method that will retain the information in the original locus line
- fixed writing out db_xref feature qualifiers which was not working
- fixed writing out the accession version and GI ID
- allow locus ids that contain spaces
- allow the locus id to be empty
- fixed writing out feature locations containing joins and partial locations
- fixed reading and writing locations on multiple lines
- Maintained quotes around feature qualifier values in files that are written out
- Added a test and test file for feature locations containing joins
- Added a test to check for differences between an original file and one that had been written out by the writer