### PR TITLE
Bump dependency ciftools-java-jdk8 to 4.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<log4j.version>2.17.2</log4j.version>
 		<junit-jupiter.version>5.7.2</junit-jupiter.version>
 		<ciftools.artifact>ciftools-java-jdk8</ciftools.artifact>
-		<ciftools.version>4.0.3</ciftools.version>
+		<ciftools.version>4.0.5</ciftools.version>
 	</properties>
 	<scm>
 		<connection>scm:git:git://github.com/biojava/biojava.git</connection>


### PR DESCRIPTION
Bump dependency 4.0.5 to Fix cif writing in non-US locales.

Thanks @JonStargaryen for fixing the bug at **ciftools-java**.
Fixes #1049. 