### PR TITLE
Sonar S4973 '==' and '!=' should not be used when 'equals' is overridden

### DIFF
--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/homology/GFF3FromUniprotBlastHits.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/homology/GFF3FromUniprotBlastHits.java
@@ -140,7 +140,7 @@ public class GFF3FromUniprotBlastHits {
 						}
 
 						proteinIndex = proteinIndex + seq.length();
-						if (startIndex != null && endIndex != null && startIndex != endIndex) {
+						if (startIndex != null && endIndex != null && !startIndex.equals(endIndex)) {
 							CDSSequence cdsSequence = cdsSequenceList.get(i);
 							String hitLabel = "";
 							if (transcriptSequence.getStrand() == Strand.POSITIVE) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
@@ -373,7 +373,7 @@ public class EcodInstallation implements EcodDatabase {
 				return false;
 
 			// Re-download old copies of "latest"
-			if(updateFrequency != null && requestedVersion == DEFAULT_VERSION ) {
+			if(updateFrequency != null && requestedVersion.equals(DEFAULT_VERSION) ) {
 				long mod = f.lastModified();
 				// Time of last update
 				Date lastUpdate = new Date();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/BondMaker.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/BondMaker.java
@@ -215,7 +215,7 @@ public class BondMaker {
 			for (Atom a2:a2s) {
 				if (a1.getAltLoc() != null && a2.getAltLoc()!=null &&
 						a1.getAltLoc()!=' ' && a2.getAltLoc()!=' ' &&
-						a1.getAltLoc() != a2.getAltLoc()) {
+						!a1.getAltLoc().equals(a2.getAltLoc())) {
 					logger.debug("Skipping bond between atoms with differently named alt locs {} (altLoc '{}') -- {} (altLoc '{}')",
 							a1.toString(), a1.getAltLoc(), a2.toString(), a2.getAltLoc());
 					continue;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixSolver.java
@@ -366,7 +366,7 @@ public class HelixSolver {
 			int permutation = -1;
 			double minDistSq = Double.MAX_VALUE;
 			for (int j = 0; j < centers.size(); j++) {
-				if (seqClusterId.get(i) == seqClusterId.get(j)) {
+				if (seqClusterId.get(i) != null && seqClusterId.get(i).equals(seqClusterId.get(j))) {
 					if (!used[j]) {
 						double dSq = tCenter.distanceSquared(centers.get(j));
 						if (dSq < minDistSq && dSq <= rmsdThresholdSq) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/RotationSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/RotationSolver.java
@@ -334,7 +334,7 @@ public class RotationSolver implements QuatSymmetrySolver {
 		int selfaligned = 0;
 		for (int i = 0; i < permutation.size(); i++) {
 			int j = permutation.get(i);
-			if ( seqClusterId.get(i) != seqClusterId.get(j)) {
+			if ( seqClusterId.get(i) != null && !seqClusterId.get(i).equals(seqClusterId.get(j))) {
 				return false;
 			}
 			if(i == j ) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/SystematicSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/SystematicSolver.java
@@ -176,7 +176,7 @@ public class SystematicSolver implements QuatSymmetrySolver {
 		List<Integer> seqClusterId = subunits.getClusterIds();
 		for (int i = 0; i < permutation.size(); i++) {
 			int j = permutation.get(i);
-			if (seqClusterId.get(i) != seqClusterId.get(j)) {
+			if (seqClusterId.get(i) != null && !seqClusterId.get(i).equals(seqClusterId.get(j))) {
 				return false;
 			}
 		}


### PR DESCRIPTION
These modifications were made by an automatic java code remediation software. They are related to the rule S4973 "==" and "!=" should not be used when "equals" is overridden.

https://rules.sonarsource.com/java/RSPEC-1698

**General rule for comparing object**

It is equivalent to use the equality == operator and the equals method to compare two objects if the equals method inherited from Object has not been overridden. In this case both checks compare the **object references**.
But as soon as equals is overridden, two objects not having the same reference but having the same value can be equal.

**Why should this rule also be applied to primitive types?**

Because in the case of classes wrapping primitive types, the operation of the equality test depends on the implementation of the JVM and the optimizations that have been made.

Usage of the == and != operators for comparing the values of fully memoized boxed primitive types is permitted. 
But usage of the == and != operators for comparing the values of boxed primitive types that are not fully memoized is permitted only when the range of values represented is guaranteed to be within the ranges specified by the JLS to be fully memoized.
And usage of the == and != operators for comparing the values of boxed primitive types is not allowed in all other cases.

JLS explanation is here https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.1.7
