### PR TITLE
POM Cleanup: Add Maven descriptors & remove mention of Travis CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -359,7 +359,6 @@
 
 				<configuration>
 					<archive>
-						<addMavenDescriptor>false</addMavenDescriptor>
 						<manifest>
 							<addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
 							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
@@ -692,8 +691,4 @@
 		<system>Github</system>
 		<url>https://github.com/biojava/biojava/issues</url>
 	</issueManagement>
-	<ciManagement>
-			<system>Travis</system>
-			<url>https://travis-ci.org/biojava/biojava</url>
-	</ciManagement>
 </project>


### PR DESCRIPTION
- need Maven descriptors for `pom.properties` files when using BioJava as dependency
- this ensures that they are added to the artifacts