### PR TITLE
Refactoring : Extract method getBackboneAtomArray changes to reduce the cyclomatic complexity

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -167,6 +167,9 @@ public class StructureTools {
 
 	private static final Set<Element> hBondDonorAcceptors;
 
+	private static final Set<String> NUCLEOTIDE_BACKBONE_ATOMS;
+	private static final Set<String> AMINOACID_BACKBONE_ATOMS;
+
 	static {
 		nucleotides30 = new HashMap<String, Character>();
 		nucleotides30.put("DA", 'A');
@@ -255,6 +258,9 @@ public class StructureTools {
 		hBondDonorAcceptors.add(Element.N);
 		hBondDonorAcceptors.add(Element.O);
 		hBondDonorAcceptors.add(Element.S);
+
+		NUCLEOTIDE_BACKBONE_ATOMS = new HashSet<>(Arrays.asList(C1_ATOM_NAME, C2_ATOM_NAME, C3_ATOM_NAME, C4_ATOM_NAME, O2_ATOM_NAME, O3_ATOM_NAME, O4_ATOM_NAME, O5_ATOM_NAME, OP1_ATOM_NAME, OP2_ATOM_NAME, P_ATOM_NAME));
+		AMINOACID_BACKBONE_ATOMS = new HashSet<>(Arrays.asList(CA_ATOM_NAME, C_ATOM_NAME, N_ATOM_NAME, O_ATOM_NAME));
 
 	}
 
@@ -1129,16 +1135,13 @@ public class StructureTools {
 	 */
 	public static Atom[] getBackboneAtomArray(Structure s) {
 		List<Atom> atoms = new ArrayList<>();
-		Set<String> nucleotideAtomNames = new HashSet<>(Arrays.asList(C1_ATOM_NAME, C2_ATOM_NAME, C3_ATOM_NAME, C4_ATOM_NAME, O2_ATOM_NAME, O3_ATOM_NAME, O4_ATOM_NAME, O5_ATOM_NAME, OP1_ATOM_NAME, OP2_ATOM_NAME, P_ATOM_NAME));
-		Set<String> aminoAcidAtomNames = new HashSet<>(Arrays.asList(CA_ATOM_NAME, C_ATOM_NAME, N_ATOM_NAME, O_ATOM_NAME));
-
 		for (Chain c : s.getChains()) {
 			for (Group g : c.getAtomGroups()) {
 				if (g.hasAminoAtoms()) {
 					if (g.getType() == GroupType.NUCLEOTIDE) {
-						addNucleotideAndAminoAtoms(atoms, g, nucleotideAtomNames);
+						addNucleotideAndAminoAtoms(atoms, g, NUCLEOTIDE_BACKBONE_ATOMS);
 					} else {
-						addNucleotideAndAminoAtoms(atoms, g, aminoAcidAtomNames);
+						addNucleotideAndAminoAtoms(atoms, g, AMINOACID_BACKBONE_ATOMS);
 					}
 				}
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -1128,64 +1128,38 @@ public class StructureTools {
 	 * @return an Atom[] array
 	 */
 	public static Atom[] getBackboneAtomArray(Structure s) {
-
 		List<Atom> atoms = new ArrayList<>();
+		Set<String> nucleotideAtomNames = new HashSet<>(Arrays.asList(C1_ATOM_NAME, C2_ATOM_NAME, C3_ATOM_NAME, C4_ATOM_NAME, O2_ATOM_NAME, O3_ATOM_NAME, O4_ATOM_NAME, O5_ATOM_NAME, OP1_ATOM_NAME, OP2_ATOM_NAME, P_ATOM_NAME));
+		Set<String> aminoAcidAtomNames = new HashSet<>(Arrays.asList(CA_ATOM_NAME, C_ATOM_NAME, N_ATOM_NAME, O_ATOM_NAME));
 
 		for (Chain c : s.getChains()) {
 			for (Group g : c.getAtomGroups()) {
 				if (g.hasAminoAtoms()) {
-					// this means we will only take atoms grom groups that have
-					// complete backbones
-					for (Atom a : g.getAtoms()) {
-						switch (g.getType()) {
-						case NUCLEOTIDE:
-							// Nucleotide backbone
-							if (a.getName().equals(C1_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(C2_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(C3_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(C4_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(O2_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(O3_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(O4_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(O5_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(OP1_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(OP2_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(P_ATOM_NAME))
-								atoms.add(a);
-							// TODO Allow C4* names as well as C4'? -SB 3/2015
-							break;
-						case AMINOACID:
-						default:
-							// we do it this way instead of with g.getAtom() to
-							// be sure we always use the same order as original
-							if (a.getName().equals(CA_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(C_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(N_ATOM_NAME))
-								atoms.add(a);
-							if (a.getName().equals(O_ATOM_NAME))
-								atoms.add(a);
-							break;
-						}
+					if (g.getType() == GroupType.NUCLEOTIDE) {
+						addNucleotideAndAminoAtoms(atoms, g, nucleotideAtomNames);
+					} else {
+						addNucleotideAndAminoAtoms(atoms, g, aminoAcidAtomNames);
 					}
 				}
 			}
-
 		}
-
 		return atoms.toArray(new Atom[0]);
 	}
+
+	/**
+	 * This method will be used to add the Nucleotide and Amino atoms to the backbone Atom arrays based on the pre-defined Atom names.
+	 * @param atoms
+	 * @param g
+	 * @param atomNames
+	 */
+	private static void addNucleotideAndAminoAtoms(List<Atom> atoms, Group g, Set<String> atomNames) {
+		for (Atom a : g.getAtoms()) {
+			if (atomNames.contains(a.getName())) {
+				atoms.add(a);
+			}
+		}
+	}
+
 
 	/**
 	 * Convert three character amino acid codes into single character e.g.

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
@@ -616,10 +616,7 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 		Pair<EntityInfo> thisCompounds = new Pair<EntityInfo>(thisChains.getFirst().getEntityInfo(), thisChains.getSecond().getEntityInfo());
 		Pair<EntityInfo> otherCompounds = new Pair<EntityInfo>(otherChains.getFirst().getEntityInfo(), otherChains.getSecond().getEntityInfo());
 
-		if ( (  (thisCompounds.getFirst().getMolId() == otherCompounds.getFirst().getMolId()) &&
-				(thisCompounds.getSecond().getMolId() == otherCompounds.getSecond().getMolId())   )  ||
-			 (  (thisCompounds.getFirst().getMolId() == otherCompounds.getSecond().getMolId()) &&
-				(thisCompounds.getSecond().getMolId() == otherCompounds.getFirst().getMolId())   )	) {
+		if (checkMolIdMatch(thisCompounds,otherCompounds)) {
 
 			int common = 0;
 			GroupContactSet thisContacts = getGroupContacts();
@@ -653,6 +650,17 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 		}
 	}
 
+	/**
+	 * This method check if two compounds have same MolIds or not.
+	 * @param thisCompounds
+	 * @param otherCompounds
+	 * @return
+	 */
+	private boolean checkMolIdMatch(Pair<EntityInfo> thisCompounds, Pair<EntityInfo> otherCompounds){
+		boolean firstMatch = thisCompounds.getFirst().getMolId() == otherCompounds.getFirst().getMolId() && thisCompounds.getSecond().getMolId() == otherCompounds.getSecond().getMolId();
+		boolean secondMatch = thisCompounds.getFirst().getMolId() == otherCompounds.getSecond().getMolId() && thisCompounds.getSecond().getMolId() == otherCompounds.getFirst().getMolId();
+		return firstMatch || secondMatch;
+	}
 	public GroupContactSet getGroupContacts() {
 		if (groupContacts==null) {
 			this.groupContacts  = new GroupContactSet(contacts);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalTransform.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalTransform.java
@@ -180,24 +180,27 @@ public class CrystalTransform implements Serializable {
 	 */
 	public boolean isPureTranslation() {
 		if (isPureCrystalTranslation()) return true;
-		if (SpaceGroup.deltaComp(matTransform.m00,1,SpaceGroup.DELTA) &&
-			SpaceGroup.deltaComp(matTransform.m01,0,SpaceGroup.DELTA) &&
-			SpaceGroup.deltaComp(matTransform.m02,0,SpaceGroup.DELTA) &&
-
-			SpaceGroup.deltaComp(matTransform.m10,0,SpaceGroup.DELTA) &&
-			SpaceGroup.deltaComp(matTransform.m11,1,SpaceGroup.DELTA) &&
-			SpaceGroup.deltaComp(matTransform.m12,0,SpaceGroup.DELTA) &&
-
-			SpaceGroup.deltaComp(matTransform.m20,0,SpaceGroup.DELTA) &&
-			SpaceGroup.deltaComp(matTransform.m21,0,SpaceGroup.DELTA) &&
-			SpaceGroup.deltaComp(matTransform.m22,1,SpaceGroup.DELTA) &&
-			(	Math.abs(matTransform.m03-0.0)>SpaceGroup.DELTA ||
-				Math.abs(matTransform.m13-0.0)>SpaceGroup.DELTA ||
-				Math.abs(matTransform.m23-0.0)>SpaceGroup.DELTA)) {
-			return true;
-		}
-
+		if (isPureMatrixTranslation()) return true;
 		return false;
+	}
+
+	/**
+	 * This method will help check if the matrix translation is pure or not.
+	 * @return boolean
+	 */
+	private boolean isPureMatrixTranslation(){
+		return 	SpaceGroup.deltaComp(matTransform.m00,1,SpaceGroup.DELTA) &&
+				SpaceGroup.deltaComp(matTransform.m01,0,SpaceGroup.DELTA) &&
+				SpaceGroup.deltaComp(matTransform.m02,0,SpaceGroup.DELTA) &&
+
+				SpaceGroup.deltaComp(matTransform.m10,0,SpaceGroup.DELTA) &&
+				SpaceGroup.deltaComp(matTransform.m11,1,SpaceGroup.DELTA) &&
+				SpaceGroup.deltaComp(matTransform.m12,0,SpaceGroup.DELTA) &&
+
+				SpaceGroup.deltaComp(matTransform.m20,0,SpaceGroup.DELTA) &&
+				SpaceGroup.deltaComp(matTransform.m21,0,SpaceGroup.DELTA) &&
+				SpaceGroup.deltaComp(matTransform.m22,1,SpaceGroup.DELTA) &&
+				(Math.abs(matTransform.m03-0.0)>SpaceGroup.DELTA || Math.abs(matTransform.m13-0.0)>SpaceGroup.DELTA || Math.abs(matTransform.m23-0.0)>SpaceGroup.DELTA);
 	}
 
 	/**


### PR DESCRIPTION
The method getBackboneAtomArray had a cyclomatic complexity of 22, hence refactored the method was to optimize the code.
This refactoring can be qualified as extract method refactoring.
The logic and the output after refactoring remain the same.