### PR TITLE
Fix Sonar S1130 throws declarations should not be superfluous

### DIFF
--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/AminoAcidCompositionTable.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/AminoAcidCompositionTable.java
@@ -132,7 +132,7 @@ public class AminoAcidCompositionTable {
 	 * @throws NullPointerException
 	 * 	thrown if AminoAcidCompositionTable.computeMolecularWeight(ElementTable) is not called before this method
 	 */
-	public double getMolecularWeight(Character aaSymbol) throws NullPointerException{
+	public double getMolecularWeight(Character aaSymbol) {
 		if(this.aaSymbol2MolecularWeight == null){
 			throw new NullPointerException("Please call AminoAcidCompositionTable.computeMolecularWeight(ElementTable) before this method");
 		}

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmFileParser.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmFileParser.java
@@ -283,7 +283,7 @@ public class StockholmFileParser {
 	 * @throws ParserException
 	 *             if unexpected format is encountered
 	 */
-	public StockholmStructure parse(String filename) throws IOException, ParserException {
+	public StockholmStructure parse(String filename) throws IOException {
 		InputStream inStream = new InputStreamProvider().getInputStream(filename);
 		StockholmStructure structure = parse(inStream);
 		inStream.close();
@@ -307,7 +307,7 @@ public class StockholmFileParser {
 	 * @throws ParserException
 	 *             if unexpected format is encountered
 	 */
-	public List<StockholmStructure> parse(String filename, int max) throws IOException, ParserException {
+	public List<StockholmStructure> parse(String filename, int max) throws IOException {
 		InputStreamProvider isp = new InputStreamProvider();
 		InputStream inStream = isp.getInputStream(filename);
 		return parse(inStream, max);
@@ -325,7 +325,7 @@ public class StockholmFileParser {
 	 * @throws IOException
 	 * @throws ParserException
 	 */
-	public StockholmStructure parse(InputStream inStream) throws ParserException, IOException {
+	public StockholmStructure parse(InputStream inStream) throws IOException {
 		return parse(inStream, 1).get(0);
 	}
 
@@ -391,7 +391,7 @@ public class StockholmFileParser {
 	 * @throws IOException
 	 * @throws Exception
 	 */
-	StockholmStructure parse(Scanner scanner) throws ParserException, IOException {
+	StockholmStructure parse(Scanner scanner) throws IOException {
 		if (scanner == null) {
 			if (internalScanner != null) {
 				scanner = internalScanner;
@@ -528,7 +528,7 @@ public class StockholmFileParser {
 	 *            the line to be parsed
 	 * @throws Exception
 	 */
-	private void handleSequenceLine(String line) throws ParserException {
+	private void handleSequenceLine(String line) {
 		String[] lineContent = line.split("\\s+");
 		if (lineContent.length != 2) {
 			throw new ParserException("Could not split sequence line into sequence name and sequence:\n" + line);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -165,7 +165,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 * The last accession passed to this routine will always be the one used.
 	 */
-	public void setVersion(int version) throws ParserException {
+	public void setVersion(int version) {
 		if (this.versionSeen) throw new ParserException("Current BioEntry already has a version");
 		else {
 			try {
@@ -182,7 +182,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	 * {@inheritDoc}
 	 * The last accession passed to this routine will always be the one used.
 	 */
-	public void setAccession(String accession) throws ParserException {
+	public void setAccession(String accession) {
 		if (accession==null) throw new ParserException("Accession cannot be null");
 		this.accession = accession;
 	}
@@ -190,7 +190,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	/**
 	 * {@inheritDoc}
 	 */
-	public void setDescription(String description) throws ParserException {
+	public void setDescription(String description) {
 		if (this.description!=null) throw new ParserException("Current BioEntry already has a description");
 		this.description = description;
 	}
@@ -198,7 +198,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	/**
 	 * {@inheritDoc}
 	 */
-	public void setIdentifier(String identifier) throws ParserException {
+	public void setIdentifier(String identifier) {
 		if (identifier==null) throw new ParserException("Identifier cannot be null");
 		if (this.identifier!=null) throw new ParserException("Current BioEntry already has a identifier");
 		this.identifier = identifier;
@@ -207,7 +207,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	/**
 	 * {@inheritDoc}
 	 */
-	public void setName(String name) throws ParserException {
+	public void setName(String name) {
 		if (name==null) throw new ParserException("Name cannot be null");
 		if (this.name!=null) throw new ParserException("Current BioEntry already has a name");
 		this.name = name;
@@ -216,7 +216,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 	/**
 	 * {@inheritDoc}
 	 */
-	public void setComment(String comment) throws ParserException {
+	public void setComment(String comment) {
 		if (comment==null) throw new ParserException("Comment cannot be null");
 		this.comments.add(comment);
 	}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/IUPACParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/IUPACParser.java
@@ -242,7 +242,7 @@ public class IUPACParser {
 		 * {@link #getCodons(CompoundSet, CompoundSet)} was not called first.
 		 */
 				@Override
-		public boolean isStart(AminoAcidCompound compound) throws IllegalStateException {
+		public boolean isStart(AminoAcidCompound compound) {
 			if(this.codons.isEmpty()) {
 				throw new IllegalStateException("Codons are empty; please request getCodons() fist before asking this");
 			}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/util/IOUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/util/IOUtils.java
@@ -87,7 +87,7 @@ public class IOUtils {
 	 * @param processor The processor to invoke on all lines
 	 * @throws ParserException Can throw this if we cannot parse the given reader
 	 */
-	public static void processReader(BufferedReader br, ReaderProcessor processor) throws ParserException {
+	public static void processReader(BufferedReader br, ReaderProcessor processor) {
 		String line;
 		try {
 			while( (line = br.readLine()) != null ) {
@@ -109,7 +109,7 @@ public class IOUtils {
 	 * @return List of Strings
 	 * @throws ParserException Can throw this if we cannot parse the given reader
 	 */
-	public static List<String> getList(BufferedReader br) throws ParserException {
+	public static List<String> getList(BufferedReader br) {
 		final List<String> list = new ArrayList<String>();
 		processReader(br, new ReaderProcessor() {
 			@Override
@@ -130,7 +130,7 @@ public class IOUtils {
 	 * @throws ParserException Can throw this if the file is not a file or we
 	 * cannot parse it
 	 */
-	public static List<String> getList(InputStream is) throws ParserException {
+	public static List<String> getList(InputStream is) {
 		return getList(new BufferedReader(new InputStreamReader(is)));
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/UniprotProxySequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/UniprotProxySequenceReader.java
@@ -638,7 +638,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @throws IOException
 	 */
 	private StringBuilder fetchFromCache(String key)
-			throws FileNotFoundException, IOException {
+			throws IOException {
 		int index;
 		File f = new File(uniprotDirectoryCache + File.separatorChar + key + ".xml");
 		StringBuilder sb = new StringBuilder();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
@@ -131,7 +131,7 @@ public class InsdcParser {
 	 * @return The parsed location
 	 * @throws ParserException thrown in the event of any error during parsing
 	 */
-	public Location parse(String locationString) throws ParserException {
+	public Location parse(String locationString) {
 		featureGlobalStart = Integer.MAX_VALUE;
 		featureGlobalEnd = 1;
 
@@ -151,7 +151,7 @@ public class InsdcParser {
 		return l;
 	}
 
-	private List<Location> parseLocationString(String string, int versus) throws ParserException {
+	private List<Location> parseLocationString(String string, int versus) {
 		Matcher m;
 		List<Location> boundedLocationsCollection = new ArrayList<Location>();
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/BitSequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/BitSequenceReader.java
@@ -368,7 +368,7 @@ public class BitSequenceReader<C extends Compound> implements ProxySequenceReade
 		 * @return Byte representation of the compound
 		 * @throws IllegalStateException Done whenever this method is invoked
 		 */
-		protected byte processUnknownCompound(C compound, int position) throws IllegalStateException {
+		protected byte processUnknownCompound(C compound, int position) {
 			throw new IllegalStateException("Do not know how to translate the compound " + compound + " to a " + bitsPerCompound() + "bit representation");
 		}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/JoiningSequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/JoiningSequenceReader.java
@@ -263,7 +263,7 @@ public class JoiningSequenceReader<C extends Compound> implements ProxySequenceR
 
 
 			@Override
-			public void remove() throws UnsupportedOperationException {
+			public void remove() {
 				throw new UnsupportedOperationException("Cannot remove from this Sequence");
 			}
 		};
@@ -289,7 +289,7 @@ public class JoiningSequenceReader<C extends Compound> implements ProxySequenceR
 
 
 	@Override
-	public AccessionID getAccession() throws UnsupportedOperationException {
+	public AccessionID getAccession() {
 		throw new UnsupportedOperationException();
 	}
 

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/IntegerOntology.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/IntegerOntology.java
@@ -96,7 +96,7 @@ implements Ontology {
 	}
 
 	@Override
-	public Term getTerm(String s) throws NoSuchElementException {
+	public Term getTerm(String s) {
 		int val = Integer.parseInt(s);
 		return resolveInt(val);
 	}
@@ -117,37 +117,37 @@ implements Ontology {
 	}
 
 	@Override
-	public Term createTerm(String name) throws AlreadyExistsException,  IllegalArgumentException {
+	public Term createTerm(String name) throws AlreadyExistsException  {
 		throw new IllegalArgumentException(getName() + " is immutable");
 	}
 
 	@Override
 	public Term createTerm(String name, String description)
 			throws
-			AlreadyExistsException,
+			AlreadyExistsException
 
-			IllegalArgumentException
-			{
+	
+		{
 		throw new IllegalArgumentException(getName() + " is immutable");
 			}
 
 	@Override
 	public Term createTerm(String name, String description, Object[] synonyms)
 			throws
-			AlreadyExistsException,
+			AlreadyExistsException
 
-			IllegalArgumentException
-			{
+	
+		{
 		throw new IllegalArgumentException(getName() + " is immutable");
 			}
 
 	@Override
 	public Variable createVariable(String name, String description)
 			throws
-			AlreadyExistsException,
+			AlreadyExistsException
 
-			IllegalArgumentException
-			{
+	
+		{
 		throw new IllegalArgumentException(getName() + " is immutable");
 			}
 

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Ontology.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Ontology.java
@@ -91,7 +91,7 @@ public interface Ontology  {
 	 * @throws NoSuchElementException if no term exists with that name
 	 */
 
-	public Term getTerm(String name) throws NoSuchElementException;
+	public Term getTerm(String name);
 
 	/**
 	 * Return all triples from this ontology which match the supplied
@@ -134,9 +134,9 @@ public interface Ontology  {
 
 	public Term createTerm(String name)
 			throws
-			AlreadyExistsException,
+			AlreadyExistsException
 
-			IllegalArgumentException;
+	;
 
 	/**
 	 * Create a new term in this ontology.
@@ -153,9 +153,9 @@ public interface Ontology  {
 
 	public Term createTerm(String name, String description)
 			throws
-			AlreadyExistsException,
+			AlreadyExistsException
 
-			IllegalArgumentException;
+	;
 
 	/**
 	 * Create a new term in this ontology.
@@ -173,9 +173,9 @@ public interface Ontology  {
 
 	public Term createTerm(String name, String description, Object[] synonyms)
 			throws
-			AlreadyExistsException,
+			AlreadyExistsException
 
-			IllegalArgumentException;
+	;
 
 	/**
 	 * Create a new term in this ontology that is used as a variable.
@@ -192,9 +192,9 @@ public interface Ontology  {
 
 	public Variable createVariable(String name, String description)
 			throws
-			AlreadyExistsException,
+			AlreadyExistsException
 
-			IllegalArgumentException;
+	;
 
 	/**
 	 * Create a view of a term from another ontology.  If the requested term
@@ -213,9 +213,9 @@ public interface Ontology  {
 	 */
 
 	public Term importTerm(Term t, String localName)
-			throws
+		
 
-			IllegalArgumentException;
+	;
 
 	/**
 	 * Creates a new Triple.
@@ -342,8 +342,8 @@ public interface Ontology  {
 
 		@Override
 		public Term getTerm(String name)
-				throws NoSuchElementException
-				{
+		
+			{
 			Term t = terms.get(name);
 			if (t == null) {
 				throw new NoSuchElementException("No term named '" + name + "'");
@@ -402,8 +402,8 @@ public interface Ontology  {
 		}
 
 		private void addTerm(Term t)
-				throws AlreadyExistsException, IllegalArgumentException
-				{
+				throws AlreadyExistsException 
+			{
 			if (terms.containsKey(t.getName())) {
 				throw new AlreadyExistsException("Ontology " + getName() + " already contains " + t.toString());
 			}
@@ -415,8 +415,8 @@ public interface Ontology  {
 
 		@Override
 		public Term createTerm(String name)
-				throws AlreadyExistsException, IllegalArgumentException
-				{
+				throws AlreadyExistsException 
+			{
 			Term t = new Term.Impl(this, name);
 			addTerm(t);
 			return t;
@@ -424,8 +424,8 @@ public interface Ontology  {
 
 		@Override
 		public Term createTerm(String name, String description)
-				throws AlreadyExistsException, IllegalArgumentException
-				{
+				throws AlreadyExistsException 
+			{
 			Term t = new Term.Impl(this, name, description);
 			addTerm(t);
 			return t;
@@ -433,8 +433,8 @@ public interface Ontology  {
 
 		@Override
 		public Term createTerm(String name, String description, Object[] synonyms)
-				throws AlreadyExistsException, IllegalArgumentException
-				{
+				throws AlreadyExistsException 
+			{
 			Term t = new Term.Impl(this, name, description, synonyms);
 			addTerm(t);
 			return t;
@@ -443,9 +443,9 @@ public interface Ontology  {
 		@Override
 		public Variable createVariable(String name, String description)
 				throws
-				AlreadyExistsException,
+				AlreadyExistsException
 
-				IllegalArgumentException {
+	 {
 			Variable var = new Variable.Impl(this, name, description);
 			addTerm(var);
 			return var;
@@ -462,8 +462,8 @@ public interface Ontology  {
 
 		@Override
 		public Term importTerm(Term t, String name)
-				throws IllegalArgumentException
-				{
+		
+			{
 			// unpack any potential indirection - belt & braces
 			while(t instanceof RemoteTerm) {
 				t = ((RemoteTerm) t).getRemoteTerm();
@@ -530,11 +530,11 @@ public interface Ontology  {
 				String name,
 				String description)
 						throws
-						AlreadyExistsException,
-						IllegalArgumentException,
-						NullPointerException,
-						IllegalArgumentException
-						{
+						AlreadyExistsException
+		
+		
+		
+					{
 			Triple t = new Triple.Impl(subject, object, predicate, name, description);
 			if (!containsTerm(subject)) {
 				throw new IllegalArgumentException("Ontology " + getName() + " doesn't contain " + subject);

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/utils/AbstractAnnotation.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/utils/AbstractAnnotation.java
@@ -84,7 +84,7 @@ public abstract class AbstractAnnotation
 
 
 	@Override
-	public Object getProperty(Object key) throws NoSuchElementException {
+	public Object getProperty(Object key) {
 		if(propertiesAllocated()) {
 			Map prop = getProperties();
 			if(prop.containsKey(key)) {
@@ -104,8 +104,8 @@ public abstract class AbstractAnnotation
 
 	@Override
 	public void removeProperty(Object key)
-		throws  NoSuchElementException
-	{
+ 
+{
 		if (!getProperties().containsKey(key)) {
 				throw new NoSuchElementException("Can't remove key " + key.toString());
 		}

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/utils/Annotation.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/utils/Annotation.java
@@ -78,7 +78,7 @@ public interface Annotation  {
 	 *
 	 *
 	 */
-	Object getProperty(Object key) throws NoSuchElementException;
+	Object getProperty(Object key);
 
 	/**
 	 * <p>
@@ -100,7 +100,7 @@ public interface Annotation  {
 	 *         if the change was vetoed.
 	 */
 	void setProperty(Object key, Object value)
-			throws IllegalArgumentException;
+	;
 
 	/**
 	 * Delete a property. Normal raw access to the property. For cleverer access, use
@@ -114,7 +114,7 @@ public interface Annotation  {
 	 */
 
 	public void removeProperty(Object key)
-			throws NoSuchElementException;
+	;
 
 	/**
 	 * Returns whether there the property is defined. Normal raw access to the property. For cleverer access, use

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/utils/EmptyAnnotation.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/utils/EmptyAnnotation.java
@@ -41,7 +41,7 @@ class EmptyAnnotation
 
 implements Annotation, Serializable {
 	@Override
-	public Object getProperty(Object key) throws NoSuchElementException {
+	public Object getProperty(Object key) {
 		throw new NoSuchElementException(
 			"There are no keys in the Empty Annotation object: " +
 			key

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/Jronn.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/Jronn.java
@@ -272,7 +272,7 @@ public class Jronn implements Serializable {
 	 * @see #getDisorder(FastaSequence)
 	 * @see #Jronn.Range
 	 */
-	public static Map<FastaSequence,Range[]> getDisorder(String fastaFile) throws FileNotFoundException, IOException {
+	public static Map<FastaSequence,Range[]> getDisorder(String fastaFile) throws IOException {
 		final List<FastaSequence> sequences = SequenceUtil.readFasta(new FileInputStream(fastaFile));
 		return getDisorder(sequences);
 	}

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ModelLoader.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ModelLoader.java
@@ -161,7 +161,7 @@ public final class ModelLoader {
 	return ModelLoader.models.get(modelNum);
 	}
 
-	void loadModels() throws NumberFormatException, IOException {
+	void loadModels() throws IOException {
 
 		for (int i = 0; i < 10; i++) {
 			final BufferedReader bfr = new BufferedReader(
@@ -191,8 +191,8 @@ public final class ModelLoader {
 		}
 	}
 
-	public static void main(final String[] args) throws NumberFormatException,
-		IOException {
+	public static void main(final String[] args) throws 
+	IOException {
 	final ModelLoader loader = new ModelLoader();
 	loader.loadModels();
 	logger.info("{}", ModelLoader.models.get(0));

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonn.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonn.java
@@ -138,7 +138,7 @@ public final class ORonn implements Callable<ORonn> {
 	}
 
 	@Override
-	public ORonn call() throws NumberFormatException, IOException {
+	public ORonn call() throws IOException {
 		final String seq = sequence.getSequence();
 		// Calculate for each model
 		Stream.iterate(0, n -> n +1).limit(NUMBER_OF_MODELS).map(modelNumber -> mloader.getModel(modelNumber))
@@ -277,8 +277,8 @@ public final class ORonn implements Callable<ORonn> {
 		return prms;
 	}
 
-	public static void main(final String[] args) throws NumberFormatException,
-	IOException {
+	public static void main(final String[] args) throws 
+IOException {
 
 		if ((args.length == 0) || (args.length > 5)) {
 			ORonn.printUsage();
@@ -332,7 +332,7 @@ public final class ORonn implements Callable<ORonn> {
 
 	static void predictSerial(final List<FastaSequence> fsequences,
 			final InputParameters prms, final ModelLoader mloader)
-					throws NumberFormatException, IOException {
+					throws IOException {
 		for (final FastaSequence sequence : fsequences) {
 			if (!ORonn.isValidSequenceForRonn(sequence, prms.getStatWriter())) {
 				continue;
@@ -345,7 +345,7 @@ public final class ORonn implements Callable<ORonn> {
 
 	static void predictParallel(final List<FastaSequence> fsequences,
 			final InputParameters prms, final ModelLoader mloader)
-					throws NumberFormatException, IOException {
+					throws IOException {
 		final PrintWriter stat = prms.getStatWriter();
 
 		// Do parallel execution

--- a/biojava-structure-gui/src/main/java/demo/AFPFromFasta.java
+++ b/biojava-structure-gui/src/main/java/demo/AFPFromFasta.java
@@ -48,7 +48,7 @@ import java.io.IOException;
  */
 public class AFPFromFasta {
 
-	public static void main(String[] args) throws IOException, StructureException, Exception {
+	public static void main(String[] args) throws Exception {
 		Structure structure1 = StructureTools.getStructure("1w0p");
 		Structure structure2 = StructureTools.getStructure("1w0p");
 		String first = "alfdynatgdtefdspakqgwmqdntnngsgvltnadgmpawlvqgiggraqwtyslstnqhaqassfgwrmttemkvlsggmitnyyangtqrvlpiisldssgnlvvefegqtgrtvlatgtaateyhkfelvflpgsnpsasfyfdgklirdniqptaskQNMIVWGNGSSntdgvaayrdikfei------------------------------------------------------------------------------------------------------------------QGDVIf------------RGPDRIPSIVASsvTPGVVTAFAEKRVGGgdpgalsntNDIITRTSRDGGITWDTELNLTEQinvsdeFDFSDPRPIYDPs---SNTVLVSYARWPtdaaqngdrikpwmpNGIFYSVYDVASgnWQAPIDVTdqvkersfqiagwggselyrrntslnsqqdwqsnakirivdgaanqiqvadgsrkyvvtlsidesgglvanlngvsapiilqsehakvhsfhdyelqysalnhtttlfvdgqqittwagevsqenniqfgnadaqidgrlhvqkivltqqghnlvefdafylaqqtpevekdleklgwtkiktgntmslygNASVNPGpgHGITLtrqqnisgsqNGRLIYPAIVLdrfFLNVMSIYSDDGgsnwq-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------TGSTLpipfrwksssileTLEPSEADMVELQN--GDLLLTARLDFNQivngvny--SPRQQFLSKDGGITWSLLEANNANvfsnistgTVDASITRFEqsdgSHFLLFTNPQGnpagTNgr------------QNLGLWFSFDEG--VTWKGPIQ--LVNGasaysdiyqldsenaivivetdnsnmrilrmpitllkqklt";

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomIterator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomIterator.java
@@ -146,7 +146,7 @@ public class AtomIterator implements Iterator<Atom> {
 	 */
 	@Override
 	public Atom next()
-	throws NoSuchElementException
+
 	{
 		current_atom_pos++ ;
 		if ( current_atom_pos >= group.size() ) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Element.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Element.java
@@ -385,7 +385,7 @@ public enum Element {
 	 * @param elementSymbol element symbol to specify Element.
 	 * @return the Element specified by the element symbol.
 	 */
-	public static Element valueOfIgnoreCase(String elementSymbol) throws IllegalArgumentException {
+	public static Element valueOfIgnoreCase(String elementSymbol) {
 
 		Element e = allElements.get(elementSymbol.toLowerCase());
 		if ( e != null)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/GroupIterator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/GroupIterator.java
@@ -159,7 +159,7 @@ public class GroupIterator implements Iterator<Group> {
 	 */
 	@Override
 	public Group next()
-	throws NoSuchElementException
+
 	{
 
 		return getNextGroup(current_model_pos,current_chain_pos,current_group_pos+1);
@@ -170,7 +170,7 @@ public class GroupIterator implements Iterator<Group> {
 	 * @see #next
 	 */
 	private Group getNextGroup(int tmp_model,int tmp_chain,int tmp_group)
-	throws NoSuchElementException
+
 	{
 
 		if ( tmp_model >= structure.nrModels()){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PdbId.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PdbId.java
@@ -218,7 +218,7 @@ public class PdbId implements Comparable<PdbId>, Serializable{
 		return intId.substring(0, 4).equals(STRING_0000);
 	}
 	
-	private static String toInternalFormat(String id) throws IllegalArgumentException {
+	private static String toInternalFormat(String id) {
 		if (isValidShortPdbId(id)) {
 			return STRING_0000  + id.toUpperCase();
 		}else if (isValidExtendedPdbId(id)) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/AlignmentResult.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/AlignmentResult.java
@@ -166,7 +166,7 @@ public String toString(){
 		this.ioTime = ioTime;
 	}
 	public void serialize (File output)
-	throws FileNotFoundException, IOException{
+	throws IOException{
 		// save alignment result:
 
 		FileOutputStream outStream = new FileOutputStream(output);
@@ -177,7 +177,7 @@ public String toString(){
 	}
 
 	public static AlignmentResult deserialize(File output)
-	throws FileNotFoundException, IOException, ClassNotFoundException{
+	throws IOException, ClassNotFoundException{
 		FileInputStream fin = new FileInputStream(output);
 		ObjectInputStream objIn = new ObjectInputStream(fin);
 		AlignmentResult result = (AlignmentResult) objIn.readObject();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BioAssemblyTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BioAssemblyTools.java
@@ -58,11 +58,11 @@ public class BioAssemblyTools {
 		return ! (first == 0 && last > first);
 	}
 
-	public static List<String> parseUnaryOperatorExpression(String operatorExpression) throws IllegalArgumentException {
+	public static List<String> parseUnaryOperatorExpression(String operatorExpression) {
 		return parseSubExpression(operatorExpression);
 	}
 
-	private static List<String> parseSubExpression(String expression) throws IllegalArgumentException {
+	private static List<String> parseSubExpression(String expression) {
 		// remove parenthesis, if any
 		String tmp = expression.replace("(", "");
 		tmp = tmp.replace(")", "");
@@ -93,7 +93,7 @@ public class BioAssemblyTools {
 	 * @return list of items in range
 	 * @throws IllegalArgumentException
 	 */
-	private static List<String> expandRange(String expression) throws IllegalArgumentException {
+	private static List<String> expandRange(String expression) {
 		int first = 0;
 		int last = 0;
 		try {
@@ -112,7 +112,7 @@ public class BioAssemblyTools {
 	}
 
 	public static List<OrderedPair<String>> parseBinaryOperatorExpression(String expression)
-			throws IllegalArgumentException {
+ {
 		// split operator expression, i.e. (1,2,3)(4,5) into two subexpressions
 		String[] subExpressions = null;
 		try {
@@ -267,7 +267,7 @@ public class BioAssemblyTools {
 	 * @throws IllegalArgumentException if structure is null
 	 */
 
-	public static double[] getBiologicalMoleculeCentroid( final Structure asymUnit,List<BiologicalAssemblyTransformation> transformations ) throws IllegalArgumentException {
+	public static double[] getBiologicalMoleculeCentroid( final Structure asymUnit,List<BiologicalAssemblyTransformation> transformations ) {
 		if ( asymUnit == null ) {
 			throw new IllegalArgumentException( "null structure" );
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/OperatorResolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/OperatorResolver.java
@@ -60,7 +60,7 @@ public class OperatorResolver {
 	 *
 	 * @param operatorExpression the operator expression to be parsed
 	 */
-	public  void parseOperatorExpressionString(String operatorExpression) throws IllegalArgumentException {
+	public  void parseOperatorExpressionString(String operatorExpression) {
 		String expression = operatorExpression.trim();
 
 		// remove single quotes, i.e. '(1-49)' in 1CGM

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
@@ -284,7 +284,7 @@ public class ScopInstallation implements LocalScopDatabase {
 	 * @see org.biojava.nbio.structure.scop.ScopDatabase#filterByDescription(java.lang.String)
 	 */
 	@Override
-	public List<ScopDescription> filterByDescription(String query) throws ScopIOException {
+	public List<ScopDescription> filterByDescription(String query) {
 		try {
 			ensureDesInstalled();
 		} catch (IOException e) {
@@ -654,7 +654,7 @@ public class ScopInstallation implements LocalScopDatabase {
 		return ranges;
 	}
 
-	protected void downloadClaFile() throws FileNotFoundException, IOException{
+	protected void downloadClaFile() throws IOException{
 		if(mirrors.size()<1) {
 			initScopURLs();
 		}
@@ -675,7 +675,7 @@ public class ScopInstallation implements LocalScopDatabase {
 		throw new IOException("Unable to download SCOP .cla file",exception);
 	}
 
-	protected void downloadDesFile() throws FileNotFoundException, IOException{
+	protected void downloadDesFile() throws IOException{
 		if(mirrors.size()<1) {
 			initScopURLs();
 		}
@@ -718,7 +718,7 @@ public class ScopInstallation implements LocalScopDatabase {
 
 	}
 
-	protected void downloadComFile() throws FileNotFoundException, IOException{
+	protected void downloadComFile() throws IOException{
 		if(mirrors.size()<1) {
 			initScopURLs();
 		}


### PR DESCRIPTION
This is a fix on https://github.com/biojava/biojava/issues/1061

The goal is to remove all unnecessary exception declarations or that overload the method declaration. All RuntimeExceptions are suppressed as they are automatically propagated by Java. When the method declaration contains a checked exception as well as a parent exception, only the parent exception is kept because the derived exception is also automatically picked up by the parent exception declaration.

Our automatic defect correction solution detected and corrected 72 violations of the Sonar S1130 rule '"throws" declarations should not be superfluous'. According to Sonar, it would have taken 6 hours to identify and correct these violations.

We hope that this PR suits you and allows you to improve the quality of your project.