### PR TITLE
Some more categories written out to CIF 

### DIFF
--- a/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/cif/CifFileSupplierIntegrationTest.java
+++ b/biojava-integrationtest/src/test/java/org/biojava/nbio/structure/test/io/cif/CifFileSupplierIntegrationTest.java
@@ -59,6 +59,12 @@ public class CifFileSupplierIntegrationTest {
     	// a structure with insertion codes
     	testRoundTrip("6ELW");
     }
+
+    @Test
+    public void test4HHB() throws IOException {
+        // a structure with multiple poly entities
+        testRoundTrip("4HHB");
+    }
     
     private static void testRoundTrip(String pdbId) throws IOException {
         URL url = new URL("https://files.rcsb.org/download/" + pdbId + ".cif");
@@ -121,6 +127,14 @@ public class CifFileSupplierIntegrationTest {
         // Test cell and symmetry
         assertEquals(originalStruct.getCrystallographicInfo().getSpaceGroup(),
                 readStruct.getCrystallographicInfo().getSpaceGroup());
+
+        // entity
+        assertEquals(originalStruct.getEntityInfos().size(), readStruct.getEntityInfos().size());
+        for (int i=0; i<originalStruct.getEntityInfos().size(); i++) {
+            assertEquals(originalStruct.getEntityInfos().get(i).getMolId(), readStruct.getEntityInfos().get(i).getMolId());
+            assertEquals(originalStruct.getEntityInfos().get(i).getType(), readStruct.getEntityInfos().get(i).getType());
+        }
+
     }
 
     /**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/SeqRes2AtomAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/SeqRes2AtomAligner.java
@@ -819,18 +819,14 @@ public class SeqRes2AtomAligner {
 	 */
 	public static void storeUnAlignedSeqRes(Structure structure, List<Chain> seqResChains, boolean headerOnly) {
 
-
 		if (headerOnly) {
-
 			List<Chain> atomChains = new ArrayList<>();
 			for (Chain seqRes: seqResChains) {
 				// In header-only mode skip ATOM records.
 				// Here we store chains with SEQRES instead of AtomGroups.
 				seqRes.setSeqResGroups(seqRes.getAtomGroups());
 				seqRes.setAtomGroups(new ArrayList<>()); // clear out the atom groups.
-
 				atomChains.add(seqRes);
-
 			}
 			structure.setChains(0, atomChains);
 
@@ -838,21 +834,20 @@ public class SeqRes2AtomAligner {
 
 			for (int i = 0; i < structure.nrModels(); i++) {
 				List<Chain> atomChains   = structure.getModel(i);
-
+				if (seqResChains.isEmpty()) {
+					// in files without SEQRES, seqResChains object is empty: we replace by atomChains resulting below in a trivial alignment and a copy of atom groups to seqres groups
+					seqResChains = atomChains;
+				}
 				for (Chain seqRes: seqResChains){
-					Chain atomRes;
-
 					// Otherwise, we find a chain with AtomGroups
 					// and set this as SEQRES groups.
 					// TODO no idea if new parameter useChainId should be false or true here, used true as a guess - JD 2016-05-09
-					atomRes = SeqRes2AtomAligner.getMatchingAtomRes(seqRes,atomChains,true);
+					Chain atomRes = SeqRes2AtomAligner.getMatchingAtomRes(seqRes,atomChains,true);
 					if ( atomRes != null)
 						atomRes.setSeqResGroups(seqRes.getAtomGroups());
 					else
 						logger.warn("Could not find atom records for chain " + seqRes.getId());
 				}
-
-
 			}
 		}
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/AbstractCifFileSupplier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/AbstractCifFileSupplier.java
@@ -100,11 +100,11 @@ public abstract class AbstractCifFileSupplier<S> implements CifFileSupplier<S> {
                 EntityInfo e = entityInfos.get(i);
                 entityIds[i] = Integer.toString(e.getMolId());
                 entityTypes[i] = e.getType().getEntityType();
-                entityDescriptions[i] = e.getDescription();
+                entityDescriptions[i] = e.getDescription() == null? "?" : e.getDescription();
             }
 
             String[] polyEntityIds = entityInfos.stream().filter(e -> e.getType() == EntityType.POLYMER).map(e -> Integer.toString(e.getMolId())).collect(Collectors.toList()).toArray(new String[]{});
-            String[] entitySeqs = entityInfos.stream().filter(e -> e.getType() == EntityType.POLYMER).map(e -> e.getChains().get(0).getSeqResSequence()).collect(Collectors.toList()).toArray(new String[]{});
+            String[] polyEntitySeqs = entityInfos.stream().filter(e -> e.getType() == EntityType.POLYMER).map(e -> e.getChains().get(0).getSeqResSequence()).collect(Collectors.toList()).toArray(new String[]{});
 
             blockBuilder.enterEntity()
                     .enterId()
@@ -127,7 +127,7 @@ public abstract class AbstractCifFileSupplier<S> implements CifFileSupplier<S> {
                     .leaveColumn()
 
                     .enterPdbxSeqOneLetterCodeCan()
-                    .add(entitySeqs)
+                    .add(polyEntitySeqs)
                     .leaveColumn()
 
                     .leaveCategory();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/AbstractCifFileSupplier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/AbstractCifFileSupplier.java
@@ -103,8 +103,8 @@ public abstract class AbstractCifFileSupplier<S> implements CifFileSupplier<S> {
                 entityDescriptions[i] = e.getDescription() == null? "?" : e.getDescription();
             }
 
-            String[] polyEntityIds = entityInfos.stream().filter(e -> e.getType() == EntityType.POLYMER).map(e -> Integer.toString(e.getMolId())).collect(Collectors.toList()).toArray(new String[]{});
-            String[] polyEntitySeqs = entityInfos.stream().filter(e -> e.getType() == EntityType.POLYMER).map(e -> e.getChains().get(0).getSeqResSequence()).collect(Collectors.toList()).toArray(new String[]{});
+            String[] polyEntityIds = entityInfos.stream().filter(e -> e.getType() == EntityType.POLYMER).map(e -> Integer.toString(e.getMolId())).toArray(String[]::new);
+            String[] polyEntitySeqs = entityInfos.stream().filter(e -> e.getType() == EntityType.POLYMER).map(e -> e.getChains().get(0).getSeqResSequence()).toArray(String[]::new);
 
             blockBuilder.enterEntity()
                     .enterId()

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
@@ -1612,7 +1612,12 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
         // fix SEQRES residue numbering for all models
 
         for (int model = 0; model < structure.nrModels(); model++) {
-            List<Chain> atomList   = structure.getModel(model);
+            List<Chain> atomList   = structure.getPolyChains(model);
+
+            if (seqResChains.isEmpty()) {
+                // in files without _entity, seqResChains object is empty: we replace by atomChains resulting below in a trivial alignment and a copy of atom groups to seqres groups
+                seqResChains = atomList;
+            }
 
             for (Chain seqResChain : seqResChains){
 

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/TestNonDepositedFiles.java
@@ -99,7 +99,8 @@ public class TestNonDepositedFiles {
 		//System.out.println("Chains from incomplete header file: ");
 		//checkChains(s);
 
-
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
 
 		// trying without seqAlignSeqRes
 		params.setAlignSeqRes(false);
@@ -145,6 +146,9 @@ public class TestNonDepositedFiles {
 		assertTrue(s.nrModels()>1);
 		assertNull(s.getPDBHeader().getExperimentalTechniques());
 
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
+
 	}
 
 	@Test
@@ -165,6 +169,8 @@ public class TestNonDepositedFiles {
 		assertTrue(s.nrModels()>1);
 		assertNull(s.getPDBHeader().getExperimentalTechniques());
 
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
 	}
 
 	@Test
@@ -187,6 +193,9 @@ public class TestNonDepositedFiles {
 
 		// testing that on single chain pdb files we assign an entity type, issue #767
 		assertEquals(EntityType.POLYMER, s.getEntityById(1).getType());
+
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
 	}
 
 	private void checkChains(Structure s) {
@@ -227,6 +236,8 @@ public class TestNonDepositedFiles {
 		assertEquals(1, counts[1]);
 		assertEquals(1, counts[2]);
 
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
 
 	}
 
@@ -255,6 +266,8 @@ public class TestNonDepositedFiles {
 		assertEquals(1, counts[1]);
 		assertEquals(1, counts[2]);
 
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
 	}
 
 	@Test
@@ -275,6 +288,9 @@ public class TestNonDepositedFiles {
 		assertEquals(2, s.getChains().size());
 
 		assertEquals(1, s.getEntityInfos().size());
+
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
 	}
 
 
@@ -303,6 +319,9 @@ public class TestNonDepositedFiles {
 		assertEquals(1, counts[1]);
 		assertEquals(1, counts[2]);
 
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
+
 	}
 
 	/**
@@ -329,6 +348,9 @@ public class TestNonDepositedFiles {
 		assertSame(s.getEntityById(2), s.getPolyChains().get(4).getEntityInfo());
 		assertSame(s.getEntityById(2), s.getPolyChains().get(5).getEntityInfo());
 		assertSame(s.getEntityById(2), s.getPolyChains().get(6).getEntityInfo());
+
+		// we should have seqres groups (testing getSeqResSequence() is equivalent)
+		assertFalse(s.getPolyChains().get(0).getSeqResSequence().isEmpty());
 	}
 
 	/**

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/cif/CifFileSupplierImplTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/cif/CifFileSupplierImplTest.java
@@ -29,6 +29,7 @@ public class CifFileSupplierImplTest {
         assertTrue(cifText.contains("_entity.type"));
         assertTrue(cifText.contains("_entity_poly.pdbx_seq_one_letter_code_can"));
         assertFalse(cifText.contains("null"));
+        assertTrue(cifText.contains("MSEQLTDQVLVERVQKGDQKAFNLLVVRYQHKVASLVSRYVPSGDVPDVVQEAFIKA"));
 
         InputStream inputStream = new ByteArrayInputStream(cifText.getBytes());
         Structure readStruct = CifStructureConverter.fromInputStream(inputStream);

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/cif/CifFileSupplierImplTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/cif/CifFileSupplierImplTest.java
@@ -1,0 +1,43 @@
+package org.biojava.nbio.structure.io.cif;
+
+import org.biojava.nbio.structure.Structure;
+import org.biojava.nbio.structure.io.FileParsingParameters;
+import org.biojava.nbio.structure.io.PDBFileParser;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.GZIPInputStream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CifFileSupplierImplTest {
+
+    @Test
+    public void shouldReadRawPdbOutputtingCifWithEntity() throws IOException {
+        InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream("/org/biojava/nbio/structure/io/4lup_phaser_output.pdb.gz"));
+
+        PDBFileParser pdbpars = new PDBFileParser();
+        FileParsingParameters params = new FileParsingParameters();
+        params.setAlignSeqRes(true);
+        pdbpars.setFileParsingParameters(params);
+
+        Structure s = pdbpars.parsePDBFile(inStream);
+
+        String cifText = CifStructureConverter.toText(s);
+        assertTrue(cifText.contains("_entity.type"));
+        assertTrue(cifText.contains("_entity_poly.pdbx_seq_one_letter_code_can"));
+
+        InputStream inputStream = new ByteArrayInputStream(cifText.getBytes());
+        Structure readStruct = CifStructureConverter.fromInputStream(inputStream);
+
+        assertEquals(s.getEntityInfos().size(), readStruct.getEntityInfos().size());
+        for (int i=0; i<s.getEntityInfos().size(); i++) {
+            assertEquals(s.getEntityInfos().get(i).getMolId(), readStruct.getEntityInfos().get(i).getMolId());
+            assertEquals(s.getEntityInfos().get(i).getType(), readStruct.getEntityInfos().get(i).getType());
+        }
+
+    }
+}

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/cif/CifFileSupplierImplTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/cif/CifFileSupplierImplTest.java
@@ -10,8 +10,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.GZIPInputStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class CifFileSupplierImplTest {
 
@@ -29,6 +28,7 @@ public class CifFileSupplierImplTest {
         String cifText = CifStructureConverter.toText(s);
         assertTrue(cifText.contains("_entity.type"));
         assertTrue(cifText.contains("_entity_poly.pdbx_seq_one_letter_code_can"));
+        assertFalse(cifText.contains("null"));
 
         InputStream inputStream = new ByteArrayInputStream(cifText.getBytes());
         Structure readStruct = CifStructureConverter.fromInputStream(inputStream);

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<log4j.version>2.17.2</log4j.version>
 		<junit-jupiter.version>5.7.2</junit-jupiter.version>
 		<ciftools.artifact>ciftools-java</ciftools.artifact>
-		<ciftools.version>5.0.0</ciftools.version>
+		<ciftools.version>5.0.1</ciftools.version>
 	</properties>
 	<scm>
 		<connection>scm:git:git://github.com/biojava/biojava.git</connection>


### PR DESCRIPTION
Adding `_entity` and `_entity_poly` to CIF output, so that some more metadata is available for consumers.

Also: 

- now adding seqres groups to `Chain`s when no entity info is present in input file
- upgrading to latest ciftools-java