### PR TITLE
Second fix for sonar rule 's1130' throws declarations should not be superfluous

### DIFF
--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonn.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonn.java
@@ -81,8 +81,8 @@ public final class ORonn implements Callable<ORonn> {
 
 
 	ORonn(final FastaSequence sequence, final ModelLoader mloader,
-			final InputParameters params) throws NumberFormatException,
-			IOException {
+			final InputParameters params) throws 
+		IOException {
 		this.sequence = sequence;
 		this.mloader = mloader;
 		out = params.getOutputWriter();
@@ -93,8 +93,8 @@ public final class ORonn implements Callable<ORonn> {
 		timer = new Timer(TimeUnit.MILLISECONDS);
 	}
 	//This constructor is for API calls where the caller collects the results directly
-	ORonn(final FastaSequence sequence, final ModelLoader mloader) throws NumberFormatException,
-	IOException {
+	ORonn(final FastaSequence sequence, final ModelLoader mloader) throws 
+IOException {
 		this.sequence = sequence;
 		this.mloader = mloader;
 		out = new PrintWriter(new NullOutputStream());

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonnModel.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ORonnModel.java
@@ -169,7 +169,7 @@ public final class ORonnModel {
 	}
 
 	public ORonnModel(final String sequence, final Model model,
-		final float disorder) throws NumberFormatException {
+		final float disorder) {
 	this.disorder_weight = disorder;
 	this.model = model;
 	query = sequence.toCharArray();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/SynchronizedOutFile.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/SynchronizedOutFile.java
@@ -43,7 +43,7 @@ public class SynchronizedOutFile {
 	 * @throws FileNotFoundException
 	 * @throws IOException
 	 */
-	public SynchronizedOutFile(File f, boolean gzipCompress) throws FileNotFoundException, IOException{
+	public SynchronizedOutFile(File f, boolean gzipCompress) throws IOException{
 		if ( f.isDirectory())
 			throw new FileNotFoundException("please provide a file and not a directory");
 
@@ -62,7 +62,7 @@ public class SynchronizedOutFile {
 	 *
 	 * @param f
 	 */
-	public SynchronizedOutFile(File f) throws FileNotFoundException, IOException{
+	public SynchronizedOutFile(File f) throws IOException{
 
 		this(f,false);
 


### PR DESCRIPTION
 This fix is specific to constructor declarations.