### PR TITLE
Fix Sonar S2129 Constructors should not be used to instantiate 'String', …

### DIFF
--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmStructure.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmStructure.java
@@ -256,9 +256,8 @@ public class StockholmStructure {
 			}
 			String[] seqDetails = splitSeqName(sequencename);
 			seq.setDescription(seqDetails[0]);
-			seq.setBioBegin((seqDetails[1] == null || seqDetails[1].trim().equals("") ? null : new Integer(
-					seqDetails[1])));
-			seq.setBioEnd((seqDetails[2] == null || seqDetails[2].trim().equals("") ? null : new Integer(seqDetails[2])));
+			seq.setBioBegin((seqDetails[1] == null || seqDetails[1].trim().equals("") ? null : Integer.valueOf(seqDetails[1])));
+			seq.setBioEnd((seqDetails[2] == null || seqDetails[2].trim().equals("") ? null : Integer.valueOf(seqDetails[2])));
 
 			seqs.add(seq);
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastTabularParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastTabularParser.java
@@ -136,23 +136,23 @@ public class BlastTabularParser implements ResultFactory {
 
 					String currentSubjectId=subjectId;
 					while (currentSubjectId.equals(subjectId) && lineNumber < fileLinesCount){
-						if (new Double(evalue) > maxEScore) {
+						if (Double.valueOf(evalue) > maxEScore) {
 							line = fetchData(scanner);
 							lineNumber++;
 							continue;
 						}
 						BlastHspBuilder hspBuilder = new BlastHspBuilder();
 						hspBuilder
-							.setHspAlignLen(new Integer(alnLength))
-							.setHspGaps(new Integer(gapOpenCount))
-							.setHspQueryFrom(new Integer(queryStart))
-							.setHspQueryTo(new Integer(queryEnd))
-							.setHspHitFrom(new Integer(subjectStart))
-							.setHspHitTo(new Integer(subjectEnd))
-							.setHspEvalue(new Double(evalue))
-							.setHspBitScore(new Double(bitScore))
-							.setPercentageIdentity(new Double(percIdentity)/100)
-							.setMismatchCount(new Integer(mismatchCount));
+							.setHspAlignLen(Integer.valueOf(alnLength))
+							.setHspGaps(Integer.valueOf(gapOpenCount))
+							.setHspQueryFrom(Integer.valueOf(queryStart))
+							.setHspQueryTo(Integer.valueOf(queryEnd))
+							.setHspHitFrom(Integer.valueOf(subjectStart))
+							.setHspHitTo(Integer.valueOf(subjectEnd))
+							.setHspEvalue(Double.valueOf(evalue))
+							.setHspBitScore(Double.valueOf(bitScore))
+							.setPercentageIdentity(Double.valueOf(percIdentity)/100)
+							.setMismatchCount(Integer.valueOf(mismatchCount));
 						hsps.add(hspBuilder.createBlastHsp());
 						if (scanner.hasNext()) line = fetchData(scanner);
 						lineNumber++;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastXMLParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastXMLParser.java
@@ -117,10 +117,10 @@ public class BlastXMLParser implements ResultFactory {
 
 				// Iteration* section keys:
 				resultBuilder
-					.setIterationNumber(new Integer(XMLHelper.selectSingleElement(element,"Iteration_iter-num").getTextContent()))
+					.setIterationNumber(Integer.valueOf(XMLHelper.selectSingleElement(element,"Iteration_iter-num").getTextContent()))
 					.setQueryID(XMLHelper.selectSingleElement(element,"Iteration_query-ID").getTextContent())
 					.setQueryDef(XMLHelper.selectSingleElement(element, "Iteration_query-def").getTextContent())
-					.setQueryLength(new Integer(XMLHelper.selectSingleElement(element,"Iteration_query-len").getTextContent()));
+					.setQueryLength(Integer.valueOf(XMLHelper.selectSingleElement(element,"Iteration_query-len").getTextContent()));
 
 				if (queryReferences != null) resultBuilder.setQuerySequence(queryReferencesMap.get(
 						XMLHelper.selectSingleElement(element,"Iteration_query-ID").getTextContent()
@@ -135,11 +135,11 @@ public class BlastXMLParser implements ResultFactory {
 				for (Element hitElement : hitList) {
 					BlastHitBuilder blastHitBuilder = new BlastHitBuilder();
 					blastHitBuilder
-						.setHitNum(new Integer(XMLHelper.selectSingleElement(hitElement, "Hit_num").getTextContent()))
+						.setHitNum(Integer.valueOf(XMLHelper.selectSingleElement(hitElement, "Hit_num").getTextContent()))
 						.setHitId(XMLHelper.selectSingleElement(hitElement, "Hit_id").getTextContent())
 						.setHitDef(XMLHelper.selectSingleElement(hitElement, "Hit_def").getTextContent())
 						.setHitAccession(XMLHelper.selectSingleElement(hitElement, "Hit_accession").getTextContent())
-						.setHitLen(new Integer(XMLHelper.selectSingleElement(hitElement, "Hit_len").getTextContent()));
+						.setHitLen(Integer.valueOf(XMLHelper.selectSingleElement(hitElement, "Hit_len").getTextContent()));
 
 					if (databaseReferences != null) blastHitBuilder.setHitSequence(databaseReferencesMap.get(
 						XMLHelper.selectSingleElement(hitElement, "Hit_id").getTextContent()
@@ -150,26 +150,26 @@ public class BlastXMLParser implements ResultFactory {
 
 					hspsCollection = new ArrayList<Hsp>();
 					for (Element hspElement : hspList) {
-						Double evalue = new Double(XMLHelper.selectSingleElement(hspElement, "Hsp_evalue").getTextContent());
+						Double evalue = Double.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_evalue").getTextContent());
 
 						// add the new hsp only if it pass the specified threshold. It can save lot of memory and some parsing time
 						if (evalue <= maxEScore) {
 							BlastHspBuilder blastHspBuilder = new BlastHspBuilder();
 							blastHspBuilder
-								.setHspNum(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_num").getTextContent()))
-								.setHspBitScore(new Double(XMLHelper.selectSingleElement(hspElement, "Hsp_bit-score").getTextContent()))
-								.setHspScore(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_score").getTextContent()))
+								.setHspNum(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_num").getTextContent()))
+								.setHspBitScore(Double.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_bit-score").getTextContent()))
+								.setHspScore(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_score").getTextContent()))
 								.setHspEvalue(evalue)
-								.setHspQueryFrom(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_query-from").getTextContent()))
-								.setHspQueryTo(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_query-to").getTextContent()))
-								.setHspHitFrom(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_hit-from").getTextContent()))
-								.setHspHitTo(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_hit-to").getTextContent()))
-								.setHspQueryFrame(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_query-frame").getTextContent()))
-								.setHspHitFrame(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_hit-frame").getTextContent()))
-								.setHspIdentity(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_identity").getTextContent()))
-								.setHspPositive(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_positive").getTextContent()))
-								.setHspGaps(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_gaps").getTextContent()))
-								.setHspAlignLen(new Integer(XMLHelper.selectSingleElement(hspElement, "Hsp_align-len").getTextContent()))
+								.setHspQueryFrom(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_query-from").getTextContent()))
+								.setHspQueryTo(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_query-to").getTextContent()))
+								.setHspHitFrom(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_hit-from").getTextContent()))
+								.setHspHitTo(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_hit-to").getTextContent()))
+								.setHspQueryFrame(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_query-frame").getTextContent()))
+								.setHspHitFrame(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_hit-frame").getTextContent()))
+								.setHspIdentity(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_identity").getTextContent()))
+								.setHspPositive(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_positive").getTextContent()))
+								.setHspGaps(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_gaps").getTextContent()))
+								.setHspAlignLen(Integer.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_align-len").getTextContent()))
 								.setHspQseq(XMLHelper.selectSingleElement(hspElement, "Hsp_qseq").getTextContent())
 								.setHspHseq(XMLHelper.selectSingleElement(hspElement, "Hsp_hseq").getTextContent())
 								.setHspIdentityString(XMLHelper.selectSingleElement(hspElement, "Hsp_midline").getTextContent());

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/ABITrace.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/ABITrace.java
@@ -434,7 +434,7 @@ public class ABITrace {
 		for (int x = 0; x <= seqLength - 1; ++x) {
 			tempseq[x] = (char) traceData[PBAS2 + x];
 		}
-		sequence = new String(tempseq);
+		sequence = String.valueOf(tempseq);
 	}
 
 	/**

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GeneIDGFF2Reader.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GeneIDGFF2Reader.java
@@ -147,9 +147,9 @@ public class GeneIDGFF2Reader {
 		end = s.indexOf('#', start);
 		String attributes = null;
 		if (end < 0) {
-			attributes = new String(s.substring(start));
+			attributes = s.substring(start);
 		} else {
-			attributes = new String(s.substring(start, end));
+			attributes = s.substring(start, end);
 		}
 		//need to add in attribute assignment for geneid where it just provides a gene name and will make it gtf like
 		attributes = "gene_id " + '"' + attributes + '"' + ";";

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GeneMarkGTFReader.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GeneMarkGTFReader.java
@@ -147,9 +147,9 @@ public class GeneMarkGTFReader {
 		end = s.indexOf('#', start);
 		String attributes = null;
 		if (end < 0) {
-			attributes = new String(s.substring(start));
+			attributes = s.substring(start);
 		} else {
-			attributes = new String(s.substring(start, end));
+			attributes = s.substring(start, end);
 		}
 
 		return new Feature(seqname, source, type, location, score, frame, attributes);

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/Location.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/Location.java
@@ -843,7 +843,7 @@ public class Location implements Iterable<Location>
 	@Override
 	public String toString()
 	{
-		return new String( "[L=" + (mEnd - mStart) + "; S=" + mStart + "; E=" + mEnd +"]" );
+		return "[L=" + (mEnd - mStart) + "; S=" + mStart + "; E=" + mEnd +"]";
 	}
 
 	/* (non-Javadoc)

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/twobit/TwoBitParser.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/twobit/TwoBitParser.java
@@ -91,7 +91,7 @@ public class TwoBitParser extends InputStream {
 			int name_len = raf.read();
 			char[] chars = new char[name_len];
 			for(int j=0;j<name_len;j++) chars[j] = (char)raf.read();
-			seq_names[i] = new String(chars);
+			seq_names[i] = String.valueOf(chars);
 			long pos = readFourBytes();
 			seq2pos.put(seq_names[i],pos);
 			logger.debug("2bit: Sequence name=[{}], pos={}", seq_names[i], pos);

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/IntegerOntology.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/IntegerOntology.java
@@ -190,7 +190,7 @@ implements Ontology {
 	}
 
 	public IntTerm resolveInt(int val) {
-		Integer i = new Integer(val);
+		Integer i = val;
 		IntTerm term = (IntTerm) termCache.get(i);
 
 		if(term == null) {

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/obo/OboFileParser.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/obo/OboFileParser.java
@@ -67,21 +67,21 @@ public class OboFileParser {
 		new HashMap<Character, Character>();
 
 	static {
-		escapeChars.put(new Character('n'), new Character('\n'));
-		escapeChars.put(new Character('W'), new Character(' '));
-		escapeChars.put(new Character('t'), new Character('\t'));
-		escapeChars.put(new Character(':'), new Character(':'));
-		escapeChars.put(new Character(','), new Character(','));
-		escapeChars.put(new Character('"'), new Character('"'));
-		escapeChars.put(new Character('\''), new Character('\''));
-		escapeChars.put(new Character('\\'), new Character('\\'));
-		escapeChars.put(new Character('{'), new Character('{'));
-		escapeChars.put(new Character('}'), new Character('}'));
-		escapeChars.put(new Character('('), new Character('('));
-		escapeChars.put(new Character(')'), new Character(')'));
-		escapeChars.put(new Character('['), new Character('['));
-		escapeChars.put(new Character(']'), new Character(']'));
-		escapeChars.put(new Character('!'), new Character('!'));
+		escapeChars.put('n', '\n');
+		escapeChars.put('W', ' ');
+		escapeChars.put('t', '\t');
+		escapeChars.put(':', ':');
+		escapeChars.put(',', ',');
+		escapeChars.put('"', '"');
+		escapeChars.put('\'', '\'');
+		escapeChars.put('\\', '\\');
+		escapeChars.put('{', '{');
+		escapeChars.put('}', '}');
+		escapeChars.put('(', '(');
+		escapeChars.put(')', ')');
+		escapeChars.put('[', '[');
+		escapeChars.put(']', ']');
+		escapeChars.put('!', '!');
 		Iterator <Character> it = escapeChars.keySet().iterator();
 		while (it.hasNext()) {
 			Character key = it.next();
@@ -417,7 +417,7 @@ public class OboFileParser {
 		StringBuffer out = new StringBuffer();
 		for (int i = 0; i < str.length(); i++) {
 			char c = str.charAt(i);
-			Object o = unescapeChars.get(new Character(c));
+			Object o = unescapeChars.get(c);
 			if (o == null)
 				out.append(c);
 			else {
@@ -449,7 +449,7 @@ public class OboFileParser {
 				i++;
 				c = str.charAt(i);
 				Character mapchar = escapeChars
-				.get(new Character(c));
+				.get(c);
 				if (mapchar == null)
 					throw new IOException("Unrecognized escape"
 							+ " character " + c + " found.");

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/StructureAlignmentJmol.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/StructureAlignmentJmol.java
@@ -257,12 +257,12 @@ public class StructureAlignmentJmol extends AbstractAlignmentJmol implements Cha
 		zoomSlider.setPaintTicks(true);
 
 		Hashtable<Integer, JLabel> labelTable = new Hashtable<Integer, JLabel>();
-		labelTable.put(new Integer(0),new JLabel("0%"));
-		labelTable.put(new Integer(100),new JLabel("100%"));
-		labelTable.put(new Integer(200),new JLabel("200%"));
-		labelTable.put(new Integer(300),new JLabel("300%"));
-		labelTable.put(new Integer(400),new JLabel("400%"));
-		labelTable.put(new Integer(500),new JLabel("500%"));
+		labelTable.put(0,new JLabel("0%"));
+		labelTable.put(100,new JLabel("100%"));
+		labelTable.put(200,new JLabel("200%"));
+		labelTable.put(300,new JLabel("300%"));
+		labelTable.put(400,new JLabel("400%"));
+		labelTable.put(500,new JLabel("500%"));
 
 		zoomSlider.setLabelTable(labelTable);
 		zoomSlider.setPaintLabels(true);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/AlternativeAlignmentFrame.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/AlternativeAlignmentFrame.java
@@ -126,12 +126,12 @@ extends JFrame{
 		for ( int i=0;i< aligs.length;i++){
 			AlternativeAlignment alig = aligs[i];
 
-			data[i][0] = new Integer(i+1);
-			data[i][1] = new Integer(alig.getEqr());
-			data[i][2] = new Double(alig.getScore());
-			data[i][3] = new Double(alig.getRmsd());
-			data[i][4] = new Integer(alig.getGaps());
-			data[i][5] = new Integer(alig.getCluster());
+			data[i][0] = Integer.valueOf(i+1);
+			data[i][1] = Integer.valueOf(alig.getEqr());
+			data[i][2] = Double.valueOf(alig.getScore());
+			data[i][3] = Double.valueOf(alig.getRmsd());
+			data[i][4] = Integer.valueOf(alig.getGaps());
+			data[i][5] = Integer.valueOf(alig.getCluster());
 			JButton maxb = new JButton("Distance Matrix");
 			maxb.addMouseListener(new MatrixMouseListener(this,i));
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/StrucAligParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/StrucAligParameters.java
@@ -125,16 +125,16 @@ public class StrucAligParameters {
 		StringBuffer buf = new StringBuffer();
 		String t = " ";
 
-		Object[] params = new Object[]{new Integer(initialK) ,new Integer(seedFragmentLength),
-				new Float(seedRmsdCutoff),
-				new Integer(fragmentLength),
-				new Integer(diagonalDistance), new Integer(diagonalDistance2), new Float(fragmentMiniDistance),
-				new Integer(angleDiff),
-				new Float(fragCompat), new Integer(maxrefine),
-				new Boolean(reduceInitialFragments), new Double(joinRMSCutoff), new Boolean(joinPlo),
-				new Boolean(doAngleCheck), new Boolean(doDistanceCheck), new Boolean(doRMSCheck),
-				new Boolean(doDensityCheck), new Float(densityCutoff), new Float(create_co), new Integer(maxIter),
-				new Float(gapOpen), new Float(gapExtension), new Integer(permutationSize), new Float(evalCutoff)};
+		Object[] params = new Object[]{Integer.valueOf(initialK) ,Integer.valueOf(seedFragmentLength),
+				Float.valueOf(seedRmsdCutoff),
+				Integer.valueOf(fragmentLength),
+				Integer.valueOf(diagonalDistance), Integer.valueOf(diagonalDistance2), Float.valueOf(fragmentMiniDistance),
+				Integer.valueOf(angleDiff),
+				Float.valueOf(fragCompat), Integer.valueOf(maxrefine),
+				Boolean.valueOf(reduceInitialFragments), Double.valueOf(joinRMSCutoff), Boolean.valueOf(joinPlo),
+				Boolean.valueOf(doAngleCheck), Boolean.valueOf(doDistanceCheck), Boolean.valueOf(doRMSCheck),
+				Boolean.valueOf(doDensityCheck), Float.valueOf(densityCutoff), Float.valueOf(create_co), Integer.valueOf(maxIter),
+				Float.valueOf(gapOpen), Float.valueOf(gapExtension), Integer.valueOf(permutationSize), Float.valueOf(evalCutoff)};
 
 		for (int i=0 ; i< params.length ; i++){
 			buf.append(params[i]);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AFPChain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AFPChain.java
@@ -447,8 +447,8 @@ public class AFPChain implements Serializable, Cloneable {
 		afpChainTwiNum = 0;
 		alignScore = 0;
 		alignScoreUpdate = 0;
-		conn = new Double(0);
-		dvar = new Double(0);
+		conn = Double.valueOf(0);
+		dvar = Double.valueOf(0);
 		calculationTime = 0;
 
 		similarity = -1;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AfpChainWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AfpChainWriter.java
@@ -263,9 +263,9 @@ public class AfpChainWriter
 
 
 			//System.err.println("t,len:"+t+":"+len);
-			String lseq1 = new String(alnseq1).substring(t,t+len);
-			String lseq2 = new String(alnseq2).substring(t,t+len);
-			String lsymb = new String(alnsymb).substring(t,t+len);
+			String lseq1 = String.valueOf(alnseq1).substring(t,t+len);
+			String lseq2 = String.valueOf(alnseq2).substring(t,t+len);
+			String lsymb = String.valueOf(alnsymb).substring(t,t+len);
 
 			//System.err.println("B:" + b);
 
@@ -1197,8 +1197,8 @@ public class AfpChainWriter
 
 
 			//System.err.println("t,len:"+t+":"+len);
-			a = new String(alnseq1).substring(t,t+len);
-			b = new String(alnseq2).substring(t,t+len);
+			a = String.valueOf(alnseq1).substring(t,t+len);
+			b = String.valueOf(alnseq2).substring(t,t+len);
 
 			//System.err.println("B:" + b);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/CliTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/CliTools.java
@@ -153,13 +153,13 @@ public class CliTools {
 
 					if (propType == Integer.TYPE) {
 						try {
-							propVal = new Integer(args[++i]);
+							propVal = Integer.valueOf(args[++i]);
 						} catch (Exception ex) {
 							throw new ConfigurationException("Option " + arg + " requires an integer parameter");
 						}
 					} else if (propType == Double.TYPE || propType == Double.class ) {
 						try {
-							propVal = new Double(args[++i]);
+							propVal = Double.valueOf(args[++i]);
 						} catch (Exception ex) {
 							throw new ConfigurationException("Option " + arg + " requires a numerical parameter");
 						}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/MultipleAlignmentXMLParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/MultipleAlignmentXMLParser.java
@@ -202,7 +202,7 @@ public class MultipleAlignmentXMLParser {
 					if (residue.equals("null")){
 						alignRes.get(str-1).add(null);
 					} else {
-						alignRes.get(str-1).add(new Integer(residue));
+						alignRes.get(str-1).add(Integer.valueOf(residue));
 					}
 
 					str++;
@@ -225,7 +225,7 @@ public class MultipleAlignmentXMLParser {
 			for (int y=0; y<4; y++){
 				String key = "mat"+(x+1)+(y+1);
 				String value = atts.getNamedItem(key).getTextContent();
-				m.setElement(x, y, new Double(value));
+				m.setElement(x, y, Double.valueOf(value));
 			}
 		}
 		return m;
@@ -241,7 +241,7 @@ public class MultipleAlignmentXMLParser {
 			NamedNodeMap atts = child.getAttributes();
 			if (atts != null) {
 				Node score = atts.getNamedItem("value");
-				Double value = new Double(score.getTextContent());
+				Double value = Double.valueOf(score.getTextContent());
 				cache.putScore(child.getNodeName(), value);
 			}
 		}
@@ -264,12 +264,12 @@ public class MultipleAlignmentXMLParser {
 
 		String ioTime = atts.getNamedItem("IOTime").getTextContent();
 		if (!ioTime.equals("null")){
-			ensemble.setIoTime(new Long(ioTime));
+			ensemble.setIoTime(Long.valueOf(ioTime));
 		}
 
 		String time = atts.getNamedItem("CalculationTime").getTextContent();
 		if (!time.equals("null")){
-			ensemble.setCalculationTime(new Long(time));
+			ensemble.setCalculationTime(Long.valueOf(time));
 		}
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/ClusterDomains.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/ClusterDomains.java
@@ -77,8 +77,8 @@ public class ClusterDomains {
 					if(minDomSize>150&&maxDomSize>1.5*minDomSize) maxDomSize=1.5*minDomSize;
 					else if(maxDomSize>2*minDomSize) maxDomSize=2*minDomSize;
 
-					long size1= new Double(Math.min(PDPParameters.MAXSIZE,minDomSize)).longValue();
-					long size2= new Double(Math.min(PDPParameters.MAXSIZE,maxDomSize)).longValue();
+					long size1= Double.valueOf(Math.min(PDPParameters.MAXSIZE,minDomSize)).longValue();
+					long size2= Double.valueOf(Math.min(PDPParameters.MAXSIZE,maxDomSize)).longValue();
 					minDomSize=Math.min(Math.pow(minDomSize,1.6/3)+PDPParameters.RG1,Math.pow(minDomSize,1.4/3)+Math.pow(PDPParameters.TD1,1.6/3)+PDPParameters.RG1);
 					maxDomSize=Math.min(Math.pow(maxDomSize,1.6/3)+PDPParameters.RG1,Math.pow(maxDomSize,1.4/3)+Math.pow(PDPParameters.TD1,1.6/3)+PDPParameters.RG1);
 
@@ -90,8 +90,8 @@ public class ClusterDomains {
 					/*
 				total_max_contacts = min(x*y,MAXCONT);
 					 */
-					total_max_contacts=new Double(minDomSize*maxDomSize*10).longValue();
-					if(size1>130) total_max_contacts=new Double(minDomSize*maxDomSize*9).longValue();
+					total_max_contacts=Double.valueOf(minDomSize*maxDomSize*10).longValue();
+					if(size1>130) total_max_contacts=Double.valueOf(minDomSize*maxDomSize*9).longValue();
 					/*
 	avd=(domains.get(i).avd+domains.get(j).avd)/2;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -2034,7 +2034,7 @@ public class PDBFileParser  {
 
 		if ( ! sbond.equals("")) {
 			bond = Integer.parseInt(sbond);
-			b = new Integer(bond);
+			b = bond;
 		}
 
 		return b ;
@@ -2091,7 +2091,7 @@ public class PDBFileParser  {
 			//System.out.println(atomserial+ " "+ bond1 +" "+bond2+ " " +bond3+" "+bond4+" "+
 			//		   hyd1+" "+hyd2 +" "+salt1+" "+hyd3+" "+hyd4+" "+salt2);
 			HashMap<String, Integer> cons = new HashMap<String, Integer>();
-			cons.put("atomserial",new Integer(atomserial));
+			cons.put("atomserial",atomserial);
 
 			if ( bond1 != null) cons.put("bond1",bond1);
 			if ( bond2 != null) cons.put("bond2",bond2);
@@ -3164,7 +3164,7 @@ public class PDBFileParser  {
 			if (c[0]=='A') {
 				c[1] = getNextChar(c[1]);
 			}
-			return new String(c);
+			return String.valueOf(c);
 		} else if (asymId.length()==3) {
 			char[] c = new char[3];
 			asymId.getChars(0, 3, c, 0);
@@ -3175,7 +3175,7 @@ public class PDBFileParser  {
 					c[2] = getNextChar(c[2]);
 				}
 			}
-			return new String(c);
+			return String.valueOf(c);
 		}
 		return null;
 	}


### PR DESCRIPTION
…'BigInteger', 'BigDecimal' and primitive-wrapper classes (Issue #1066)

This PR fixe all or part of the sonar violation S2129 whose sonar recommendation is to consider simplifying when possible for more efficient and cleaner code.