### PR TITLE
Changed the SCOP Installation URLs

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
@@ -85,8 +85,8 @@ public class ScopInstallation implements LocalScopDatabase {
 	public static final String comFileName = "dir.com.scop.txt_";
 
 	// Download locations
-	public static final String SCOP_DOWNLOAD = "http://scop.berkeley.edu/downloads/parse/";
-	public static final String SCOP_DOWNLOAD_ALTERNATE = "http://scop.berkeley.edu/downloads/parse/";
+	public static final String SCOP_DOWNLOAD = "https://scop.berkeley.edu/downloads/parse/";
+	public static final String SCOP_DOWNLOAD_ALTERNATE = "https://scop.berkeley.edu/downloads/parse/";
 
 	//public static final String NEWLINE = System.getProperty("line.separator");
 	public static final String FILESPLIT = System.getProperty("file.separator");
@@ -913,10 +913,19 @@ public class ScopInstallation implements LocalScopDatabase {
 		// first, try default scop
 		ScopMirror primary = new ScopMirror();
 		// If unreachable, try alternate Berkeley location
-		ScopMirror alt = new ScopMirror(
-				SCOP_DOWNLOAD_ALTERNATE,
-				"dir.cla.scop.%s.txt","dir.des.scop.%s.txt",
-				"dir.hie.scop.%s.txt","dir.com.scop.%s.txt");
+		ScopMirror alt;
+		if (scopVersion.startsWith("2.")) {
+			alt = new ScopMirror(
+					SCOP_DOWNLOAD_ALTERNATE,
+					"dir.cla.scope.%s.txt","dir.des.scope.%s.txt",
+					"dir.hie.scope.%s.txt","dir.com.scope.%s.txt");
+		}
+		else {
+			alt = new ScopMirror(
+					SCOP_DOWNLOAD_ALTERNATE,
+					"dir.cla.scop.%s.txt","dir.des.scop.%s.txt",
+					"dir.hie.scop.%s.txt","dir.com.scop.%s.txt");
+		}
 		mirrors.add(primary);
 		mirrors.add(alt);
 	}


### PR DESCRIPTION
I was going through the tutorial and was displaying a jmol panel.  When I selected Show SCOP Domains for the color on the selection, I received a `FileNotFoundException`.   A review of the Berkeley site shows that they changed from http to https for the scheme.   They also appear to have changed the path portion of the URL in version 2 from 'scop' to 'scope.'

All of the unit tests worked before and after this change.  I tried to create a unit test to show the failure, fix it, and run the unit test to show that it was fixed, but I couldn't quite follow the path to get to the ScopInstallation code from the Swing application.

To recreate my original error, the following code can be used (derived from the tutorial).

```
         Structure structure = StructureIO.getStructure("4FRW");
         System.out.println(StructureTools.getNrAtoms(structure));
         StructureAlignmentJmol jmolPanel = new StructureAlignmentJmol();

         jmolPanel.setStructure(structure);

         // send some commands to Jmol
         jmolPanel.evalString("select * ; color chain;");
         jmolPanel.evalString("select *; spacefill off; wireframe off; cartoon on;  ");
         jmolPanel.evalString("select ligands; cartoon off; wireframe 0.3; spacefill 0.5; color cpk;");
```