### PR TITLE
Fix sonar issue 2629 Logging arguments should not require evaluation

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FileDownloadUtils.java
@@ -212,7 +212,7 @@ public class FileDownloadUtils {
 		if(size == -1) {
 			logger.warn("could not find expected file size for resource {}.", resourceUrlConnection.getURL());
 		} else {
-			logger.debug("Content-Length: " + size);
+			logger.debug("Content-Length: {}", size);
 			File sizeFile = new File(localDestination.getParentFile(), localDestination.getName() + SIZE_EXT);
 			try (PrintStream sizePrintStream = new PrintStream(sizeFile)) {
 				sizePrintStream.print(size);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
@@ -135,7 +135,7 @@ public class SingleLinkageClusterer {
 		dendrogram = new LinkedPair[numItems-1];
 
 
-		logger.debug("Initial matrix: \n"+matrixToString());
+		logger.debug("Initial matrix: \n{}", matrixToString());
 
 
 		for (int m=0;m<numItems-1;m++) {
@@ -309,11 +309,11 @@ public class SingleLinkageClusterer {
 					}
 				}
 
-				logger.debug("Within cutoff:     "+dendrogram[i]);
+				logger.debug("Within cutoff:     {}", dendrogram[i]);
 
 			} else {
 
-				logger.debug("Not within cutoff: "+dendrogram[i]);
+				logger.debug("Not within cutoff: {}", dendrogram[i]);
 
 			}
 		}
@@ -344,7 +344,7 @@ public class SingleLinkageClusterer {
 
 		}
 
-		logger.debug("Clusters: \n"+clustersToString(finalClusters));
+		logger.debug("Clusters: \n{}", clustersToString(finalClusters));
 
 		return finalClusters;
 	}

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/util/ChromosomeMappingTools.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/util/ChromosomeMappingTools.java
@@ -231,12 +231,12 @@ public class ChromosomeMappingTools {
 	 */
 	public static ChromPos getChromosomePosForCDScoordinate(int cdsNucleotidePosition, GeneChromosomePosition chromPos) {
 
-		logger.debug(" ? Checking chromosome position for CDS position " + cdsNucleotidePosition);
+		logger.debug(" ? Checking chromosome position for CDS position {}", cdsNucleotidePosition);
 
 		List<Integer> exonStarts = chromPos.getExonStarts();
 		List<Integer> exonEnds = chromPos.getExonEnds();
 
-		logger.debug(" Exons:" + exonStarts.size());
+		logger.debug(" Exons:{}", exonStarts.size());
 
 		int cdsStart = chromPos.getCdsStart();
 		int cdsEnd = chromPos.getCdsEnd();
@@ -378,7 +378,7 @@ public class ChromosomeMappingTools {
 
 					if ( tmp > (end - start ) ) {
 						tmp = (end - start );
-						logger.debug("changing tmp to " + tmp);
+						logger.debug("changing tmp to {}", tmp);
 					}
 					logger.debug("     " + cdsPos + " " + codingLength + " | " + (cdsPos - codingLength) + " | " + (end -start) + " | " + tmp);
 					logger.debug("     Exon        : " + format(start+1) + " - " + format(end) + " | " + format(end - start) + " | " + codingLength + " | " + (codingLength % 3));
@@ -397,7 +397,7 @@ public class ChromosomeMappingTools {
 			logger.debug("     coding length: " + codingLength + "(phase:" + (codingLength % 3) + ") CDS POS trying to map:" + cdsPos);
 		}
 
-		logger.debug("length exons: " + lengthExons);
+		logger.debug("length exons: {}", lengthExons);
 		// could not map, or map over the full length??
 		return new ChromPos(-1,-1);
 
@@ -811,11 +811,11 @@ public class ChromosomeMappingTools {
 
 		// the genetic coordinate is not in a coding region
 		if ( (chromPos < (cdsStart+base) ) || ( chromPos > (cdsEnd+base) ) ) {
-			logger.debug("The "+format(chromPos)+" position is not in a coding region");
+			logger.debug("The {} position is not in a coding region", format(chromPos));
 			return -1;
 		}
 
-		logger.debug("looking for CDS position for " +format(chromPos));
+		logger.debug("looking for CDS position for {}", format(chromPos));
 
 		// map the genetic coordinates of coding region on a stretch of a reverse strand
 		List<Range<Integer>> cdsRegions = getCDSRegions(exonStarts, exonEnds, cdsStart, cdsEnd);
@@ -858,11 +858,11 @@ public class ChromosomeMappingTools {
 
 		// the genetic coordinate is not in a coding region
 		if ( (chromPos < (cdsStart+base)) || ( chromPos > (cdsEnd+base) ) ) {
-			logger.debug("The "+format(chromPos)+" position is not in a coding region");
+			logger.debug("The {} position is not in a coding region", format(chromPos));
 			return -1;
 		}
 
-		logger.debug("looking for CDS position for " +format(chromPos));
+		logger.debug("looking for CDS position for {}", format(chromPos));
 
 		// map the genetic coordinate on a stretch of a reverse strand
 		List<Range<Integer>> cdsRegions = getCDSRegions(exonStarts, exonEnds, cdsStart, cdsEnd);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ChainImpl.java
@@ -597,14 +597,7 @@ public class ChainImpl implements Chain {
 				max = GroupType.HETATM;
 			}
 		}
-		logger.debug(
-				"Ratio of residues to total for chain with asym_id {} is below {}. Assuming it is a {} chain. "
-						+ "Counts: # aa residues: {}, # nuc residues: {}, # non-water het residues: {}, # waters: {}, "
-						+ "ratio aa/total: {}, ratio nuc/total: {}",
-				getId(), ratioResiduesToTotal, max, sizeAminos,
-				sizeNucleotides, sizeHetatomsWithoutWater, sizeWaters,
-				(double) sizeAminos / (double) fullSize,
-				(double) sizeNucleotides / (double) fullSize);
+		logger.debug("Ratio of residues to total for chain with asym_id {} is below {}. Assuming it is a {} chain. Counts: # aa residues: {}, # nuc residues: {}, # non-water het residues: {}, # waters: {}, ratio aa/total: {}, ratio nuc/total: {}{}{}{}{}", getId(), ratioResiduesToTotal, max, sizeAminos, sizeNucleotides, sizeHetatomsWithoutWater, sizeWaters, (double) sizeAminos, (double) fullSize, (double) sizeNucleotides, (double) fullSize);
 
 		return max;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -834,10 +834,7 @@ public class StructureTools {
 			for (String atomName : atomNames) {
 				Atom a = g.getAtom(atomName);
 				if (a == null) {
-					logger.debug("Group " + g.getResidueNumber() + " ("
-							+ g.getPDBName()
-							+ ") does not have the required atom '" + atomName
-							+ "'");
+					logger.debug("Group {} ({}) does not have the required atom '{}'", g.getResidueNumber(), g.getPDBName(), atomName);
 					// this group does not have a required atom, skip it...
 					thisGroupAllAtoms = false;
 					break;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/StructurePairAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/StructurePairAligner.java
@@ -407,8 +407,8 @@ public class StructurePairAligner {
 
 		// step 1 get all Diagonals of length X that are similar between both
 		// structures
-		logger.debug(" length atoms1:" + ca1.length);
-		logger.debug(" length atoms2:" + ca2.length);
+		logger.debug(" length atoms1:{}", ca1.length);
+		logger.debug(" length atoms2:{}", ca2.length);
 
 		logger.debug("step 1 - get fragments with similar intramolecular distances ");
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/FragmentJoiner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/FragmentJoiner.java
@@ -375,10 +375,10 @@ public class FragmentJoiner {
 		List<JointFragments> fll = new ArrayList<JointFragments>();
 
 		double adiff = angleDiff * Math.PI / 180d;
-		logger.debug("addiff" + adiff);
+		logger.debug("addiff{}", adiff);
 		//distance between two unit vectors with angle adiff
 		double ddiff = Math.sqrt(2.0-2.0*Math.cos(adiff));
-		logger.debug("ddiff" + ddiff);
+		logger.debug("ddiff{}", ddiff);
 
 		// the fpairs in the flist have to be sorted with respect to their positions
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3Daligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3Daligner.java
@@ -140,7 +140,7 @@ public class SmithWaterman3Daligner extends AbstractStructureAlignment implement
 			throw new StructureException("Empty alignment for sequences "+s1+" and "+s2);
 		}
 
-		logger.debug("Smith-Waterman alignment is: "+pair.toString(100));
+		logger.debug("Smith-Waterman alignment is: {}", pair.toString(100));
 
 		// convert to a 3D alignment...
 		afpChain = convert(ca1,ca2,pair, smithWaterman);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
@@ -82,7 +82,7 @@ public class SubunitExtractor {
 		// Calculate the minimum length of a Subunit
 		int adjustedMinLen = calcAdjustedMinimumSequenceLength(subunits,
 				absMinLen, fraction, minLen);
-		logger.debug("Adjusted minimum sequence length: " + adjustedMinLen);
+		logger.debug("Adjusted minimum sequence length: {}", adjustedMinLen);
 
 		// Filter out short Subunits
 		for (int s = subunits.size() - 1; s >= 0; s--) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterfaceList.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterfaceList.java
@@ -468,13 +468,13 @@ public class StructureInterfaceList implements Serializable, Iterable<StructureI
 	public static StructureInterfaceList calculateInterfaces(Structure struc) {
 		CrystalBuilder builder = new CrystalBuilder(struc);
 		StructureInterfaceList interfaces = builder.getUniqueInterfaces();
-		logger.debug("Calculating ASA for "+interfaces.size()+" potential interfaces");
+		logger.debug("Calculating ASA for {} potential interfaces", interfaces.size());
 		interfaces.calcAsas(StructureInterfaceList.DEFAULT_ASA_SPHERE_POINTS, //fewer for performance
 				Runtime.getRuntime().availableProcessors(),
 				StructureInterfaceList.DEFAULT_MIN_COFACTOR_SIZE);
 		interfaces.removeInterfacesBelowArea();
 		interfaces.getClusters();
-		logger.debug("Found "+interfaces.size()+" interfaces");
+		logger.debug("Found {} interfaces", interfaces.size());
 		return interfaces;
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/SerializableCache.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/SerializableCache.java
@@ -127,7 +127,7 @@ public class SerializableCache <K,V>{
 
 		try{
 
-			logger.debug("Reloading from cache " + f.getAbsolutePath());
+			logger.debug("Reloading from cache {}", f.getAbsolutePath());
 
 			FileInputStream fis = new FileInputStream(f);
 			ObjectInputStream ois = new ObjectInputStream(fis);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/geometry/SuperPositionQCP.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/geometry/SuperPositionQCP.java
@@ -261,13 +261,13 @@ public final class SuperPositionQCP extends SuperPositionAbstract {
 			// translate to origin
 			xref = CalcPoint.clonePoint3dArray(x);
 			xtrans = CalcPoint.centroid(xref);
-			logger.debug("x centroid: " + xtrans);
+			logger.debug("x centroid: {}", xtrans);
 			xtrans.negate();
 			CalcPoint.translate(new Vector3d(xtrans), xref);
 
 			yref = CalcPoint.clonePoint3dArray(y);
 			ytrans = CalcPoint.centroid(yref);
-			logger.debug("y centroid: " + ytrans);
+			logger.debug("y centroid: {}", ytrans);
 			ytrans.negate();
 			CalcPoint.translate(new Vector3d(ytrans), yref);
 			innerProduct(yref, xref);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/EntityFinder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/EntityFinder.java
@@ -297,7 +297,7 @@ public class EntityFinder {
 
 					logger.debug("Alignment for chain pair {},{}: identity: {}, gap coverage 1: {}, gap coverage 2: {}",
 							c1.getId(), c2.getId(), String.format("%4.2f",identity), String.format("%4.2f",gapCov1), String.format("%4.2f",gapCov2));
-					logger.debug("\n"+pair.toString(100));
+					logger.debug("\n{}", pair.toString(100));
 
 					if (identity > IDENTITY_THRESHOLD && gapCov1<GAP_COVERAGE_THRESHOLD && gapCov2<GAP_COVERAGE_THRESHOLD) {
 						if (	!chainIds2entities.containsKey(c1.getId()) &&

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
@@ -436,7 +436,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 				// delete file
 				boolean success = existing.delete();
 				if(success) {
-					logger.debug("Deleting "+existing.getAbsolutePath());
+					logger.debug("Deleting {}", existing.getAbsolutePath());
 				}
 				deleted = deleted || success;
 
@@ -445,7 +445,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 				if(parent != null) {
 					success = parent.delete();
 					if(success) {
-						logger.debug("Deleting "+parent.getAbsolutePath());
+						logger.debug("Deleting {}", parent.getAbsolutePath());
 					}
 				}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -369,7 +369,7 @@ public class PDBFileParser  {
 			pdbCode         = line.substring (62, min(len,66)).trim() ;
 			pdbId = pdbCode;
 
-			logger.debug("Parsing entry " + pdbId);
+			logger.debug("Parsing entry {}", pdbId);
 
 			PdbId pdbIdToSet;
 			if(pdbCode.isBlank()) {
@@ -917,14 +917,10 @@ public class PDBFileParser  {
 	 */
 	private void pdb_COMPND_Handler(String line) {
 
-		logger.debug("previousContinuationField  is "
-					+ previousContinuationField);
-		logger.debug("current continuationField  is "
-					+ continuationField);
-		logger.debug("current continuationString is "
-					+ continuationString);
-		logger.debug("current compound           is "
-					+ current_compound);
+		logger.debug("previousContinuationField  is {}", previousContinuationField);
+		logger.debug("current continuationField  is {}", continuationField);
+		logger.debug("current continuationString is {}", continuationString);
+		logger.debug("current compound           is {}", current_compound);
 
 
 		// In legacy PDB files the line ends with the PDB code and a serial number, chop those off!
@@ -979,13 +975,12 @@ public class PDBFileParser  {
 			if (previousContinuationField.equals(continuationField)
 					&& compndFieldValues.contains(continuationField)) {
 
-				logger.debug("Still in field " + continuationField);
-				logger.debug("token = " + token);
+				logger.debug("Still in field {}", continuationField);
+				logger.debug("token = {}", token);
 
 				continuationString = continuationString.concat(token + " ");
 
-				logger.debug("continuationString = "
-							+ continuationString);
+				logger.debug("continuationString = {}", continuationString);
 
 			}
 			if (!continuationField.equals(previousContinuationField)) {
@@ -1148,16 +1143,11 @@ public class PDBFileParser  {
 
 
 
-		logger.debug("current continuationNo     is "
-				+ continuationNr);
-		logger.debug("previousContinuationField  is "
-				+ previousContinuationField);
-		logger.debug("current continuationField  is "
-				+ continuationField);
-		logger.debug("current continuationString is "
-				+ continuationString);
-		logger.debug("current compound           is "
-				+ current_compound);
+		logger.debug("current continuationNo     is {}", continuationNr);
+		logger.debug("previousContinuationField  is {}", previousContinuationField);
+		logger.debug("current continuationField  is {}", continuationField);
+		logger.debug("current continuationString is {}", continuationString);
+		logger.debug("current compound           is {}", current_compound);
 
 
 		// following the docs, the last valid character should be 79, chop off the rest
@@ -1167,7 +1157,7 @@ public class PDBFileParser  {
 
 		line = line.substring(10, line.length());
 
-		logger.debug("LINE: >" + line + "<");
+		logger.debug("LINE: >{}<", line);
 
 		String[] fieldList = line.split("\\s+");
 
@@ -1216,12 +1206,11 @@ public class PDBFileParser  {
 			if (previousContinuationField.equals(continuationField)
 					&& sourceFieldValues.contains(continuationField)) {
 
-				logger.debug("Still in field " + continuationField);
+				logger.debug("Still in field {}", continuationField);
 
 				continuationString = continuationString.concat(token + " ");
 
-				logger.debug("continuationString = "
-							+ continuationString);
+				logger.debug("continuationString = {}", continuationString);
 			}
 			if (!continuationField.equals(previousContinuationField)) {
 
@@ -2174,7 +2163,7 @@ public class PDBFileParser  {
 	 */
 	private void pdb_DBREF_Handler(String line){
 
-		logger.debug("Parsing DBREF " + line);
+		logger.debug("Parsing DBREF {}", line);
 
 		DBRef dbref = new DBRef();
 		String idCode      = line.substring(7,11);
@@ -2385,7 +2374,7 @@ public class PDBFileParser  {
 
 		//  make a map of: SiteId to List<ResidueNumber>
 
-		logger.debug("Site Line:"+line);
+		logger.debug("Site Line:{}", line);
 
 
 		String siteID = line.substring(11, 14);
@@ -2398,7 +2387,7 @@ public class PDBFileParser  {
 			siteToResidueMap.put(siteID.trim(), siteResidues);
 
 			logger.debug(String.format("New Site made: %s %s", siteID,  siteResidues));
-			logger.debug("Now made " + siteMap.size() + " sites");
+			logger.debug("Now made {} sites", siteMap.size());
 
 		}
 
@@ -2414,7 +2403,7 @@ public class PDBFileParser  {
 		while (!"          ".equals((groupString = line.substring(0, 10)))) {
 			//groupstring: 'ARG H 221A'
 
-			logger.debug("groupString: '" + groupString + "'");
+			logger.debug("groupString: '{}'", groupString);
 
 			//set the residue name
 			//residueName = 'ARG'
@@ -2444,7 +2433,7 @@ public class PDBFileParser  {
 			ResidueNumber residueNumber = new ResidueNumber();
 
 
-			logger.debug("pdbCode: '" + resNum + insCode + "'");
+			logger.debug("pdbCode: '{}{}'", resNum, insCode);
 
 			residueNumber.setChainName(chainId);
 			residueNumber.setSeqNum(resNum);
@@ -2457,7 +2446,7 @@ public class PDBFileParser  {
 			line = line.substring(11);
 		}
 
-		logger.debug("Current SiteMap (contains "+ siteToResidueMap.keySet().size() + " sites):");
+		logger.debug("Current SiteMap (contains {} sites):", siteToResidueMap.keySet().size());
 		for (String key : siteToResidueMap.keySet()) {
 			logger.debug(key + " : " + siteToResidueMap.get(key));
 		}
@@ -2481,7 +2470,7 @@ public class PDBFileParser  {
 				//                    remark800Counter++;
 				String siteID = fields[1].trim();
 
-				logger.debug("siteID: '" + siteID +"'");
+				logger.debug("siteID: '{}'", siteID);
 
 				//fetch the siteResidues from the map
 				site = siteMap.get(siteID);
@@ -2491,8 +2480,8 @@ public class PDBFileParser  {
 					site = new Site(siteID, new ArrayList<Group>());
 					siteMap.put(site.getSiteID(), site);
 
-					logger.debug("New Site made: " + site);
-					logger.debug("Now made " + siteMap.size() + " sites");
+					logger.debug("New Site made: {}", site);
+					logger.debug("Now made {} sites", siteMap.size());
 
 				}
 			}
@@ -2500,7 +2489,7 @@ public class PDBFileParser  {
 				//                    remark800Counter++;
 				String evCode = fields[1].trim();
 
-				logger.debug("evCode: '" + evCode +"'");
+				logger.debug("evCode: '{}'", evCode);
 
 				//fetch the siteResidues from the map
 				site.setEvCode(evCode);
@@ -2509,12 +2498,12 @@ public class PDBFileParser  {
 				//                    remark800Counter++;
 				String desc = fields[1].trim();
 
-				logger.debug("desc: '" + desc +"'");
+				logger.debug("desc: '{}'", desc);
 
 				//fetch the siteResidues from the map
 				site.setDescription(desc);
 
-				logger.debug("Finished making REMARK 800 for site " + site.getSiteID());
+				logger.debug("Finished making REMARK 800 for site {}", site.getSiteID());
 				logger.debug(site.remark800toPDB());
 
 			}
@@ -3417,7 +3406,7 @@ public class PDBFileParser  {
 			if ("AUTH".equals(subField)) {
 				auth.append(line.substring(19, line.length()).trim());
 
-				logger.debug("AUTH '" + auth.toString() + "'");
+				logger.debug("AUTH '{}'", auth.toString());
 
 			}
 			if ("TITL".equals(subField)) {
@@ -3425,26 +3414,26 @@ public class PDBFileParser  {
 				//words on the join won't be concatenated
 				titl.append(line.substring(19, line.length()).trim()).append(" ");
 
-				logger.debug("TITL '" + titl.toString() + "'");
+				logger.debug("TITL '{}'", titl.toString());
 
 			}
 			if ("EDIT".equals(subField)) {
 				edit.append(line.substring(19, line.length()).trim());
 
-				logger.debug("EDIT '" + edit.toString() + "'");
+				logger.debug("EDIT '{}'", edit.toString());
 
 			}
 			//        JRNL        REF    NAT.IMMUNOL.                  V.   8   430 2007
 			if ("REF ".equals(subField)) {
 				ref.append(line.substring(19, line.length()).trim()).append(" ");
 
-				logger.debug("REF '" + ref.toString() + "'");
+				logger.debug("REF '{}'", ref.toString());
 
 			}
 			if ("PUBL".equals(subField)) {
 				publ.append(line.substring(19, line.length()).trim()).append(" ");
 
-				logger.debug("PUBL '" + publ.toString() + "'");
+				logger.debug("PUBL '{}'", publ.toString());
 
 			}
 			//        JRNL        REFN                   ISSN 1529-2908
@@ -3455,21 +3444,21 @@ public class PDBFileParser  {
 				}
 				refn.append(line.substring(35, line.length()).trim());
 
-				logger.debug("REFN '" + refn.toString() + "'");
+				logger.debug("REFN '{}'", refn.toString());
 
 			}
 			//        JRNL        PMID   17351618
 			if ("PMID".equals(subField)) {
 				pmid.append(line.substring(19, line.length()).trim());
 
-				logger.debug("PMID '" + pmid.toString() + "'");
+				logger.debug("PMID '{}'", pmid.toString());
 
 			}
 			//        JRNL        DOI    10.1038/NI1450
 			if ("DOI ".equals(subField)) {
 				doi.append(line.substring(19, line.length()).trim());
 
-				logger.debug("DOI '" + doi.toString() + "'");
+				logger.debug("DOI '{}'", doi.toString());
 
 			}
 		}
@@ -3509,7 +3498,7 @@ public class PDBFileParser  {
 
 		public JournalParser(String ref) {
 
-			logger.debug("JournalParser init '" + ref + "'");
+			logger.debug("JournalParser init '{}'", ref);
 
 
 			if ("TO BE PUBLISHED ".equals(ref)) {
@@ -3599,7 +3588,7 @@ public class PDBFileParser  {
 			if (!"    ".equals(journalString)) {
 				journalName = journalString;
 
-				logger.debug("JournalParser set journalName " + journalName);
+				logger.debug("JournalParser set journalName {}", journalName);
 
 			}
 		}
@@ -3649,14 +3638,14 @@ public class PDBFileParser  {
 			Author author = new Author();
 			author.setSurname(authors[0]);
 
-			logger.debug("Set consortium author name " + author.getSurname());
+			logger.debug("Set consortium author name {}", author.getSurname());
 
 			authorList.add(author);
 		} else {
 			for (int i = 0; i < authors.length; i++) {
 				String authorFullName = authors[i];
 
-				logger.debug("Building author " + authorFullName);
+				logger.debug("Building author {}", authorFullName);
 
 				Author author = new Author();
 				String regex = "\\.";
@@ -3679,7 +3668,7 @@ public class PDBFileParser  {
 				else if (authorNames.length == 1) {
 					author.setSurname(authorNames[0]);
 
-					logger.debug("Set consortium author name in multiple author block " + author.getSurname
+					logger.debug("Set consortium author name in multiple author block {}", author.getSurname
 								());
 
 				} else {
@@ -3693,14 +3682,14 @@ public class PDBFileParser  {
 						initials += initial + ".";
 					}
 
-					logger.debug("built initials '" + initials + "'");
+					logger.debug("built initials '{}'", initials);
 
 					author.setInitials(initials);
 					//surname is always last
 					int lastName = authorNames.length - 1;
 					String surname = authorNames[lastName];
 
-					logger.debug("built author surname " + surname);
+					logger.debug("built author surname {}", surname);
 
 					author.setSurname(surname);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/SeqRes2AtomAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/SeqRes2AtomAligner.java
@@ -312,7 +312,7 @@ public class SeqRes2AtomAligner {
 			//			}
 
 			if ( seqResPos >= seqResGroups.size()){
-				logger.debug("seqres groups don't match atom indices " + seqResPos);
+				logger.debug("seqres groups don't match atom indices {}", seqResPos);
 				if ( atomResGroup instanceof AminoAcid )
 					return null;
 				else
@@ -521,7 +521,7 @@ public class SeqRes2AtomAligner {
 
 
 
-		logger.debug("Alignment:\n"+pair.toString(100));
+		logger.debug("Alignment:\n{}", pair.toString(100));
 
 
 		boolean noMatchFound = mapDNAChains(seqRes,atomRes,pair,seqresIndexPosition, atomIndexPosition );
@@ -617,7 +617,7 @@ public class SeqRes2AtomAligner {
 		}
 
 
-		logger.debug("Alignment:\n"+pair.toString(100));
+		logger.debug("Alignment:\n{}", pair.toString(100));
 
 
 		boolean noMatchFound = mapChains(seqRes,atomRes,pair,seqresIndexPosition, atomIndexPosition );

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
@@ -560,8 +560,7 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
                 // If the entry describes a structure determined by a technique other than X-ray crystallography,
                 // cell is (sometimes!) a = b = c = 1.0, alpha = beta = gamma = 90 degrees
                 // if so we don't add and CrystalCell will be null
-                logger.debug("The crystal cell read from file does not have reasonable dimensions (at least one " +
-                        "dimension is below {}), discarding it.", CrystalCell.MIN_VALID_CELL_SIZE);
+                logger.debug("The crystal cell read from file does not have reasonable dimensions (at least one dimension is below {}), discarding it.", CrystalCell.MIN_VALID_CELL_SIZE);
                 return;
             }
 
@@ -617,7 +616,7 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
 
     @Override
     public void consumeDatabasePDBRev(DatabasePDBRev databasePDBrev) {
-        logger.debug("got a database revision:" + databasePDBrev);
+        logger.debug("got a database revision:{}", databasePDBrev);
 
         Date modDate = null;
         for (int rowIndex = 0; rowIndex < databasePDBrev.getRowCount(); rowIndex++) {
@@ -715,8 +714,7 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
                     // the group is actually a nucleotide group...
                     g = new NucleotideImpl();
                 } else {
-                    logger.debug("Residue {} {} is not a standard aminoacid or nucleotide, will create a het group " +
-                            "for it", entityPolySeq.getNum().get(rowIndex), entityPolySeq.getMonId().get(rowIndex));
+                    logger.debug("Residue {} {} is not a standard aminoacid or nucleotide, will create a het group for it", entityPolySeq.getNum().get(rowIndex), entityPolySeq.getMonId().get(rowIndex));
                     g = new HetatomImpl();
                 }
             }
@@ -1595,8 +1593,7 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
             if (lastResNum == null || !lastResNum.equals(currentResNum)) {
                 trimmedChain.addGroup(g);
             } else {
-                logger.debug("Removing seqres group because it seems to be repeated in entity_poly_seq, most likely " +
-                        "has hetero='y': {}", g);
+                logger.debug("Removing seqres group because it seems to be repeated in entity_poly_seq, most likely has hetero='y': {}", g);
             }
             lastResNum = currentResNum;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsMappingProvider.java
@@ -81,7 +81,7 @@ public class SiftsMappingProvider {
 		}
 		File dest = new File( hashDir, pdbId + ".sifts.xml.gz");
 
-		logger.debug("testing SIFTS file " + dest.getAbsolutePath());
+		logger.debug("testing SIFTS file {}", dest.getAbsolutePath());
 
 
 		if ( ! dest.exists()){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsXMLParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsXMLParser.java
@@ -131,13 +131,13 @@ public class SiftsXMLParser {
 
 					SiftsSegment s = getSiftsSegment(el);
 
-					logger.debug("new segment: " + s);
+					logger.debug("new segment: {}", s);
 					entity.addSegment(s);
 
 				}
 			}
 
-			logger.debug("new SIFTS entity: " + entity);
+			logger.debug("new SIFTS entity: {}", entity);
 			return entity;
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/Astral.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/Astral.java
@@ -222,7 +222,7 @@ public class Astral {
 						String scopId = line.split("\\s")[0].substring(1);
 						names.add(scopId);
 						if (i % 1000 == 0) {
-							logger.debug("Reading ASTRAL line for " + scopId);
+							logger.debug("Reading ASTRAL line for {}", scopId);
 						}
 						i++;
 					} catch (RuntimeException e) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixSolver.java
@@ -87,7 +87,7 @@ public class HelixSolver {
 
 		for (Entry<Integer[], Integer> entry : interactionMap.entrySet()) {
 			Integer[] pair = entry.getKey();
-			logger.debug("HelixSolver: pair: " + Arrays.toString(pair));
+			logger.debug("HelixSolver: pair: {}", Arrays.toString(pair));
 
 			int contacts = entry.getValue();
 			Point3d[] h1 = CalcPoint.clonePoint3dArray(repeatUnits.get(pair[0]));
@@ -125,7 +125,7 @@ public class HelixSolver {
 				continue;
 			}
 			permutations.add(permutation);
-			logger.debug("Permutation: " + permutation);
+			logger.debug("Permutation: {}", permutation);
 
 
 			// keep track of which subunits are permuted
@@ -238,10 +238,10 @@ public class HelixSolver {
 					repeatUnitCenters.get(pair[1]));
 			angle = getAngle(transformation);
 
-			logger.debug("Trace rmsd: " + traceRmsd);
-			logger.debug("Trace rise: " + rise);
-			logger.debug("Trace angle: " + Math.toDegrees(angle));
-			logger.debug("Permutation: " + permutation);
+			logger.debug("Trace rmsd: {}", traceRmsd);
+			logger.debug("Trace rise: {}", rise);
+			logger.debug("Trace angle: {}", Math.toDegrees(angle));
+			logger.debug("Permutation: {}", permutation);
 
 			if (traceRmsd > parameters.getRmsdThreshold()) {
 				continue;
@@ -280,7 +280,7 @@ public class HelixSolver {
 			helix.setFold(fold);
 			helix.setContacts(contacts);
 			helix.setRepeatUnits(unit.getRepeatUnitIndices());
-			logger.debug("Layerlines: " + helix.getLayerLines());
+			logger.debug("Layerlines: {}", helix.getLayerLines());
 
 			for (List<Integer> line : helix.getLayerLines()) {
 				maxLayerLineLength = Math.max(maxLayerLineLength, line.size());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymm.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymm.java
@@ -431,7 +431,7 @@ public class CeSymm {
 					msa = optimizer.optimize();
 					result.setMultipleAlignment(msa);
 				} catch (RefinerFailedException e) {
-					logger.debug("Optimization failed:" + e.getMessage());
+					logger.debug("Optimization failed:{}", e.getMessage());
 				}
 			}
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymmIterative.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymmIterative.java
@@ -128,8 +128,7 @@ public class CeSymmIterative {
 		if ((atoms.length <= params.getWinSize()
 				|| atoms.length <= params.getMinCoreLength())
 				&& !levels.isEmpty()) {
-			logger.debug("Aborting iteration due to insufficient Atom "
-					+ "array length: %d", atoms.length);
+			logger.debug("Aborting iteration due to insufficient Atom array length: %d", atoms.length);
 			return;
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalBuilder.java
@@ -280,12 +280,12 @@ public class CrystalBuilder {
 			int neighbors = (2*numCells+1)*(2*numCells+1)*(2*numCells+1)-1;
 			int auTrials = (numPolyChainsAu*(numPolyChainsAu-1))/2;
 			int trials = numPolyChainsAu*numOperatorsSg*numPolyChainsAu*neighbors;
-			logger.debug("Chain clash trials within original AU: "+auTrials);
+			logger.debug("Chain clash trials within original AU: {}", auTrials);
 			logger.debug(
 					"Chain clash trials between the original AU and the neighbouring "+neighbors+
 					" whole unit cells ("+numCells+" neighbours)" +
 					"(2x"+numPolyChainsAu+"chains x "+numOperatorsSg+"AUs x "+neighbors+"cells) : "+trials);
-			logger.debug("Total trials: "+(auTrials+trials));
+			logger.debug("Total trials: {}", (auTrials+trials));
 		}
 
 		List<Chain> polyChains = structure.getPolyChains();
@@ -404,12 +404,12 @@ public class CrystalBuilder {
 		}
 
 		end = System.currentTimeMillis();
-		logger.debug("\n"+trialCount+" chain-chain clash trials done. Time "+(end-start)/1000+"s");
-		logger.debug("  skipped (not overlapping AUs)       : "+skippedAUsNoOverlap);
-		logger.debug("  skipped (not overlapping chains)    : "+skippedChainsNoOverlap);
-		logger.debug("  skipped (sym redundant op pairs)    : "+skippedRedundant);
-		logger.debug("  skipped (sym redundant self op)     : "+skippedSelfEquivalent);
-		logger.debug("Found "+set.size()+" interfaces.");
+		logger.debug("\n{} chain-chain clash trials done. Time {}{}s", trialCount, (end-start), 1000);
+		logger.debug("  skipped (not overlapping AUs)       : {}", skippedAUsNoOverlap);
+		logger.debug("  skipped (not overlapping chains)    : {}", skippedChainsNoOverlap);
+		logger.debug("  skipped (sym redundant op pairs)    : {}", skippedRedundant);
+		logger.debug("  skipped (sym redundant self op)     : {}", skippedSelfEquivalent);
+		logger.debug("Found {} interfaces.", set.size());
 	}
 
 


### PR DESCRIPTION
Some method calls can effectively be "no-ops", meaning that the invoked method does nothing, based on the application’s configuration (eg: debug logs in production). However, even if the method effectively does nothing, its arguments may still need to evaluated before the method is called. This fix improves performance, especially in cases where concatenation is used at low logging levels.