### PR TITLE
Fix container inefficiency in GenericFastaHeaderParser.java

### DIFF
--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericFastaHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericFastaHeaderParser.java
@@ -93,9 +93,9 @@ public class GenericFastaHeaderParser<S extends AbstractSequence<C>, C extends C
 					sb.append(header.charAt(i));
 				}
 
-				data = new String[values.size()];
-				values.toArray(data);
 			}
+			data = new String[values.size()];
+			values.toArray(data);
 		} else {
 			data = header.split(" ");
 		}


### PR DESCRIPTION
Hi,

We find that there exist container inefficiency in GenericFastaHeaderParser.java.

In particular, at lines 96 and 97 in GenericFastaHeaderParser.java, the for loop keep allocating the `data` array and transform container object `values` to array, which incurs redundant memory allocation and container operations.

We discovered the above containers inefficiencies by our tool cinst. The patch is submitted. Could you please check and accept it? We have tested the patch on our PC. The patched program works well.