### PR TITLE
Fix sonar issue S2293 Replace the type specification in this constructor call with the diamond operator ('<>')

### DIFF
--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/CommandPrompt.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/CommandPrompt.java
@@ -95,8 +95,8 @@ public class CommandPrompt {
 		/*
 		 * Parse input arguments
 		 */
-		List<Character> propertyList = new ArrayList<Character>();
-		List<Character> specificList = new ArrayList<Character>();
+		List<Character> propertyList = new ArrayList<>();
+		List<Character> specificList = new ArrayList<>();
 		String inputLocation = null;
 		String outputLocation = null;
 		String aminoAcidCompositionLocation = null;
@@ -179,14 +179,14 @@ public class CommandPrompt {
 		}
 		LinkedHashMap<String, ProteinSequence> ret;
 		if ( inputLocation.toLowerCase().contains(".gb")) {
-			GenbankReader<ProteinSequence, AminoAcidCompound> genbankReader = new GenbankReader<ProteinSequence, AminoAcidCompound>(
+			GenbankReader<ProteinSequence, AminoAcidCompound> genbankReader = new GenbankReader<>(
 					inStream, new GenericGenbankHeaderParser<ProteinSequence, AminoAcidCompound>(),
 					new ProteinSequenceCreator(set));
 			ret = genbankReader.process();
 
 
 		} else {
-			FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<ProteinSequence, AminoAcidCompound>(
+			FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<>(
 					inStream, new GenericFastaHeaderParser<ProteinSequence, AminoAcidCompound>(),
 					new ProteinSequenceCreator(set));
 			ret = fastaReader.process();
@@ -214,7 +214,7 @@ public class CommandPrompt {
 		 * 9 Composition of the 20 standard amino acid
 		 * 0 Composition of the specific amino acid
 		 */
-		List<String> sList = new ArrayList<String>();
+		List<String> sList = new ArrayList<>();
 		sList.add("SequenceName");
 		for(Character c:propertyList){
 			switch(c){
@@ -277,7 +277,7 @@ public class CommandPrompt {
 		IPeptideProperties pp = new PeptidePropertiesImpl();
 
 		int specificCount = 0;
-		List<Double> dList = new ArrayList<Double>();
+		List<Double> dList = new ArrayList<>();
 		for(Character c:propertyList){
 			switch(c){
 			case '1':

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/Constraints.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/Constraints.java
@@ -64,14 +64,14 @@ public class Constraints {
 	public static AminoAcidCompound Y = aaSet.getCompoundForString("Y");
 	public static AminoAcidCompound V = aaSet.getCompoundForString("V");
 
-	public static Map<AminoAcidCompound, Double> aa2ExtinctionCoefficient = new HashMap<AminoAcidCompound, Double>();
-	public static Map<AminoAcidCompound, Double> aa2MolecularWeight = new HashMap<AminoAcidCompound, Double>();
-	public static Map<AminoAcidCompound, Double> aa2Hydrophathicity = new HashMap<AminoAcidCompound, Double>();
-	public static Map<AminoAcidCompound, Double> aa2PKa = new HashMap<AminoAcidCompound, Double>();
-	public static Map<String, Double> diAA2Instability = new HashMap<String, Double>();
+	public static Map<AminoAcidCompound, Double> aa2ExtinctionCoefficient = new HashMap<>();
+	public static Map<AminoAcidCompound, Double> aa2MolecularWeight = new HashMap<>();
+	public static Map<AminoAcidCompound, Double> aa2Hydrophathicity = new HashMap<>();
+	public static Map<AminoAcidCompound, Double> aa2PKa = new HashMap<>();
+	public static Map<String, Double> diAA2Instability = new HashMap<>();
 
-	public static Map<AminoAcidCompound, Double> aa2NTerminalPka = new HashMap<AminoAcidCompound, Double>();
-	public static Map<AminoAcidCompound, Double> aa2CTerminalPka = new HashMap<AminoAcidCompound, Double>();
+	public static Map<AminoAcidCompound, Double> aa2NTerminalPka = new HashMap<>();
+	public static Map<AminoAcidCompound, Double> aa2CTerminalPka = new HashMap<>();
 
 	static{
 		initMolecularWeight();

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptideProperties.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptideProperties.java
@@ -532,7 +532,7 @@ public class PeptideProperties {
 	 */
 	public static final Map<String, Double> getAACompositionString(String sequence){
 		Map<AminoAcidCompound, Double> aa2Composition = getAAComposition(sequence);
-		Map<String, Double> aaString2Composition = new HashMap<String, Double>();
+		Map<String, Double> aaString2Composition = new HashMap<>();
 		aaString2Composition = aa2Composition.keySet().stream() .collect(Collectors.toMap(aaCompound -> aaCompound.getShortName(),aaCompound ->aa2Composition.get(aaCompound)));
 		return aaString2Composition;
 	}
@@ -550,7 +550,7 @@ public class PeptideProperties {
 	 */
 	public static final Map<Character, Double> getAACompositionChar(String sequence){
 		Map<AminoAcidCompound, Double> aa2Composition = getAAComposition(sequence);
-		Map<Character, Double> aaChar2Composition = new HashMap<Character, Double>();
+		Map<Character, Double> aaChar2Composition = new HashMap<>();
 		for(AminoAcidCompound aaCompound:aa2Composition.keySet()){
 			aaChar2Composition.put(aaCompound.getShortName().charAt(0), aa2Composition.get(aaCompound));
 		}

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptidePropertiesImpl.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/PeptidePropertiesImpl.java
@@ -210,7 +210,7 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 			}
 		}
 		AminoAcidCompoundSet aaSet = new AminoAcidCompoundSet();
-		Map<AminoAcidCompound, Integer> extinctAA2Count = new HashMap<AminoAcidCompound, Integer>();
+		Map<AminoAcidCompound, Integer> extinctAA2Count = new HashMap<>();
 		//Ignore Case is always true
 		extinctAA2Count.put(aaSet.getCompoundForString("W"), numW + smallW);
 		extinctAA2Count.put(aaSet.getCompoundForString("C"), (int) (numC + smallC));
@@ -532,7 +532,7 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 			}
 		}
 		AminoAcidCompoundSet aaSet = new AminoAcidCompoundSet();
-		Map<AminoAcidCompound, Integer> chargedAA2Count = new HashMap<AminoAcidCompound, Integer>();
+		Map<AminoAcidCompound, Integer> chargedAA2Count = new HashMap<>();
 		chargedAA2Count.put(aaSet.getCompoundForString("K"), numK);
 		chargedAA2Count.put(aaSet.getCompoundForString("R"), numR);
 		chargedAA2Count.put(aaSet.getCompoundForString("H"), numH);
@@ -558,7 +558,7 @@ public class PeptidePropertiesImpl implements IPeptideProperties{
 	@Override
 	public Map<AminoAcidCompound, Double> getAAComposition(ProteinSequence sequence) {
 		int validLength = 0;
-		Map<AminoAcidCompound, Double> aa2Composition = new HashMap<AminoAcidCompound, Double>();
+		Map<AminoAcidCompound, Double> aa2Composition = new HashMap<>();
 		AminoAcidCompoundSet aaSet = new AminoAcidCompoundSet();
 		for(AminoAcidCompound aa:aaSet.getAllCompounds()){
 			aa2Composition.put(aa, 0.0);

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/Utils.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/Utils.java
@@ -106,7 +106,7 @@ public class Utils {
 	 * 		a new sequence with all invalid characters being replaced by '-'.
 	 */
 	public final static String cleanSequence(String sequence, Set<Character> cSet){
-		Set<Character> invalidCharSet = new HashSet<Character>();
+		Set<Character> invalidCharSet = new HashSet<>();
 		StringBuilder cleanSeq = new StringBuilder();
 		if(cSet == null) cSet = PeptideProperties.standardAASet;
 		for(char c:sequence.toCharArray()){

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/profeat/ProfeatPropertiesImpl.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/profeat/ProfeatPropertiesImpl.java
@@ -125,35 +125,35 @@ public class ProfeatPropertiesImpl implements IProfeatProperties{
 
 	@Override
 	public Map<GROUPING, Double> getComposition(ProteinSequence sequence, ATTRIBUTE attribute) throws Exception {
-		Map<GROUPING, Double> grouping2Composition = new HashMap<GROUPING, Double>();
+		Map<GROUPING, Double> grouping2Composition = new HashMap<>();
 		for(GROUPING group:GROUPING.values()) grouping2Composition.put(group, getComposition(sequence, attribute, group));
 		return grouping2Composition;
 	}
 
 	@Override
 	public Map<ATTRIBUTE, Map<GROUPING, Double>> getComposition(ProteinSequence sequence) throws Exception {
-		Map<ATTRIBUTE, Map<GROUPING, Double>> attribute2Grouping2Composition = new HashMap<ATTRIBUTE, Map<GROUPING, Double>>();
+		Map<ATTRIBUTE, Map<GROUPING, Double>> attribute2Grouping2Composition = new HashMap<>();
 		for(ATTRIBUTE attribute:ATTRIBUTE.values()) attribute2Grouping2Composition.put(attribute, getComposition(sequence, attribute));
 		return attribute2Grouping2Composition;
 	}
 
 	@Override
 	public Map<TRANSITION, Double> getTransition(ProteinSequence sequence, ATTRIBUTE attribute) throws Exception {
-		Map<TRANSITION, Double> transition2Double = new HashMap<TRANSITION, Double>();
+		Map<TRANSITION, Double> transition2Double = new HashMap<>();
 		for(TRANSITION transition:TRANSITION.values()) transition2Double.put(transition, getTransition(sequence, attribute, transition));
 		return transition2Double;
 	}
 
 	@Override
 	public Map<ATTRIBUTE, Map<TRANSITION, Double>> getTransition(ProteinSequence sequence) throws Exception {
-		Map<ATTRIBUTE, Map<TRANSITION, Double>> attribute2Transition2Double = new HashMap<ATTRIBUTE, Map<TRANSITION, Double>>();
+		Map<ATTRIBUTE, Map<TRANSITION, Double>> attribute2Transition2Double = new HashMap<>();
 		for(ATTRIBUTE attribute:ATTRIBUTE.values()) attribute2Transition2Double.put(attribute, getTransition(sequence, attribute));
 		return attribute2Transition2Double;
 	}
 
 	@Override
 	public Map<DISTRIBUTION, Double> getDistributionPosition(ProteinSequence sequence, ATTRIBUTE attribute, GROUPING group) throws Exception {
-		Map<DISTRIBUTION, Double> distribution2Double = new HashMap<DISTRIBUTION, Double>();
+		Map<DISTRIBUTION, Double> distribution2Double = new HashMap<>();
 		for(DISTRIBUTION distribution:DISTRIBUTION.values())
 			distribution2Double.put(distribution, getDistributionPosition(sequence, attribute, group, distribution));
 		return distribution2Double;
@@ -161,7 +161,7 @@ public class ProfeatPropertiesImpl implements IProfeatProperties{
 
 	@Override
 	public Map<GROUPING, Map<DISTRIBUTION, Double>> getDistributionPosition(ProteinSequence sequence, ATTRIBUTE attribute) throws Exception {
-		Map<GROUPING, Map<DISTRIBUTION, Double>> grouping2Distribution2Double = new HashMap<GROUPING, Map<DISTRIBUTION, Double>>();
+		Map<GROUPING, Map<DISTRIBUTION, Double>> grouping2Distribution2Double = new HashMap<>();
 		for(GROUPING group:GROUPING.values())
 			grouping2Distribution2Double.put(group, getDistributionPosition(sequence, attribute, group));
 		return grouping2Distribution2Double;
@@ -170,7 +170,7 @@ public class ProfeatPropertiesImpl implements IProfeatProperties{
 	@Override
 	public Map<ATTRIBUTE, Map<GROUPING, Map<DISTRIBUTION, Double>>> getDistributionPosition(ProteinSequence sequence) throws Exception {
 		Map<ATTRIBUTE, Map<GROUPING, Map<DISTRIBUTION, Double>>> attribute2Grouping2Distribution2Double =
-			new HashMap<ATTRIBUTE, Map<GROUPING, Map<DISTRIBUTION, Double>>>();
+			new HashMap<>();
 		for(ATTRIBUTE attribute:ATTRIBUTE.values())
 			attribute2Grouping2Distribution2Double.put(attribute, getDistributionPosition(sequence, attribute));
 		return attribute2Grouping2Distribution2Double;

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/AminoAcidCompositionTable.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/AminoAcidCompositionTable.java
@@ -83,7 +83,7 @@ public class AminoAcidCompositionTable {
 	 * 		Stores the mass of elements and isotopes
 	 */
 	public void computeMolecularWeight(ElementTable eTable){
-		this.aaSymbol2MolecularWeight = new HashMap<Character, Double>();
+		this.aaSymbol2MolecularWeight = new HashMap<>();
 		for(AminoAcidComposition a:aminoacid){
 			//Check to ensure that the symbol is of single character
 			if(a.getSymbol().length() != 1){

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/CaseFreeAminoAcidCompoundSet.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/CaseFreeAminoAcidCompoundSet.java
@@ -39,9 +39,9 @@ import java.util.*;
  */
 public class CaseFreeAminoAcidCompoundSet implements CompoundSet<AminoAcidCompound> {
 
-	private final Map<String, AminoAcidCompound> aminoAcidCompoundCache = new HashMap<String, AminoAcidCompound>();
+	private final Map<String, AminoAcidCompound> aminoAcidCompoundCache = new HashMap<>();
 	private final Map<AminoAcidCompound, Set<AminoAcidCompound>> equivalentsCache =
-			new HashMap<AminoAcidCompound, Set<AminoAcidCompound>>();
+			new HashMap<>();
 
 	public CaseFreeAminoAcidCompoundSet() {
 		aminoAcidCompoundCache.put("A", new AminoAcidCompound(null, "A", "Ala", "Alanine", 71.0788f));
@@ -83,7 +83,7 @@ public class CaseFreeAminoAcidCompoundSet implements CompoundSet<AminoAcidCompou
 		//which then does the actual conversion to Pyl.
 		aminoAcidCompoundCache.put("O", new AminoAcidCompound(null, "O", "Pyl", "Pyrrolysine", 255.3172f));
 
-		Map<String, AminoAcidCompound> lowerCaseSet = new HashMap<String, AminoAcidCompound>();
+		Map<String, AminoAcidCompound> lowerCaseSet = new HashMap<>();
 		for(String s:this.aminoAcidCompoundCache.keySet()){
 			lowerCaseSet.put(s.toLowerCase(), this.aminoAcidCompoundCache.get(s));
 		}
@@ -144,7 +144,7 @@ public class CaseFreeAminoAcidCompoundSet implements CompoundSet<AminoAcidCompou
 			addAmbiguousEquivalents("I", "L", "J");
 			// ambiguous gaps
 			AminoAcidCompound gap1, gap2, gap3;
-			Set<AminoAcidCompound> gaps = new HashSet<AminoAcidCompound>();
+			Set<AminoAcidCompound> gaps = new HashSet<>();
 			gaps.add(gap1 = aminoAcidCompoundCache.get("-"));
 			gaps.add(gap2 = aminoAcidCompoundCache.get("."));
 			gaps.add(gap3 = aminoAcidCompoundCache.get("_"));
@@ -162,18 +162,18 @@ public class CaseFreeAminoAcidCompoundSet implements CompoundSet<AminoAcidCompou
 		Set<AminoAcidCompound> equivalents;
 		AminoAcidCompound cOne, cTwo, cEither;
 
-		equivalents = new HashSet<AminoAcidCompound>();
+		equivalents = new HashSet<>();
 		equivalents.add(cOne = aminoAcidCompoundCache.get(one));
 		equivalents.add(cTwo = aminoAcidCompoundCache.get(two));
 		equivalents.add(cEither = aminoAcidCompoundCache.get(either));
 		equivalentsCache.put(cEither, equivalents);
 
-		equivalents = new HashSet<AminoAcidCompound>();
+		equivalents = new HashSet<>();
 		equivalents.add(cOne);
 		equivalents.add(cEither);
 		equivalentsCache.put(cOne, equivalents);
 
-		equivalents = new HashSet<AminoAcidCompound>();
+		equivalents = new HashSet<>();
 		equivalents.add(cTwo);
 		equivalents.add(cEither);
 		equivalentsCache.put(cTwo, equivalents);
@@ -186,7 +186,7 @@ public class CaseFreeAminoAcidCompoundSet implements CompoundSet<AminoAcidCompou
 
 	@Override
 	public List<AminoAcidCompound> getAllCompounds() {
-		return new ArrayList<AminoAcidCompound>(aminoAcidCompoundCache.values());
+		return new ArrayList<>(aminoAcidCompoundCache.values());
 	}
 
 

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/Element.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/Element.java
@@ -120,7 +120,7 @@ public class Element {
 
 	public void setIsotopes(List<Isotope> isotopes) {
 		this.isotope = isotopes;
-		this.name2Isotope = new HashMap<String, Isotope>();
+		this.name2Isotope = new HashMap<>();
 		if(isotopes != null){
 			for(Isotope i:isotopes){
 				name2Isotope.put(i.getName(), i);

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/ElementTable.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/ElementTable.java
@@ -58,8 +58,8 @@ public class ElementTable {
 	 * Populate the Maps for quick retrieval
 	 */
 	public void populateMaps(){
-		this.elementName2Element = new HashMap<String, Element>();
-		this.isotopeName2Isotope = new HashMap<String, Isotope>();
+		this.elementName2Element = new HashMap<>();
+		this.isotopeName2Isotope = new HashMap<>();
 		if(this.element != null){
 			for(Element e:this.element){
 				this.elementName2Element.put(e.getName(), e);

--- a/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/ModifiedAminoAcidCompoundSet.java
+++ b/biojava-aa-prop/src/main/java/org/biojava/nbio/aaproperties/xml/ModifiedAminoAcidCompoundSet.java
@@ -28,7 +28,7 @@ import java.util.*;
 
 public class ModifiedAminoAcidCompoundSet implements CompoundSet<AminoAcidCompound> {
 
-	private final Map<String, AminoAcidCompound> aminoAcidCompoundCache = new HashMap<String, AminoAcidCompound>();
+	private final Map<String, AminoAcidCompound> aminoAcidCompoundCache = new HashMap<>();
 
 	public ModifiedAminoAcidCompoundSet(List<AminoAcidComposition> aaList, Map<Character, Double> aaSymbol2MolecularWeight) {
 		this.aminoAcidCompoundCache.put("-", new AminoAcidCompound(null, "-", "", "", 0.0f));
@@ -84,7 +84,7 @@ public class ModifiedAminoAcidCompoundSet implements CompoundSet<AminoAcidCompou
 
 	@Override
 	public List<AminoAcidCompound> getAllCompounds() {
-		return new ArrayList<AminoAcidCompound>(aminoAcidCompoundCache.values());
+		return new ArrayList<>(aminoAcidCompoundCache.values());
 	}
 
 	@Override

--- a/biojava-alignment/src/main/java/demo/CookbookMSA.java
+++ b/biojava-alignment/src/main/java/demo/CookbookMSA.java
@@ -43,7 +43,7 @@ public class CookbookMSA {
 	}
 
 	private static void multipleSequenceAlignment(String[] ids) throws Exception {
-		List<ProteinSequence> lst = new ArrayList<ProteinSequence>();
+		List<ProteinSequence> lst = new ArrayList<>();
 		for (String id : ids) {
 			lst.add(getSequenceForId(id));
 		}

--- a/biojava-alignment/src/main/java/demo/DemoDistanceTree.java
+++ b/biojava-alignment/src/main/java/demo/DemoDistanceTree.java
@@ -58,7 +58,7 @@ public class DemoDistanceTree {
 				.getResourceAsStream("/PF00104_small.fasta");
 
 		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader =
-				new FastaReader<ProteinSequence, AminoAcidCompound>(
+				new FastaReader<>(
 				inStream,
 				new GenericFastaHeaderParser<ProteinSequence, AminoAcidCompound>(),
 				new ProteinSequenceCreator(AminoAcidCompoundSet
@@ -70,7 +70,7 @@ public class DemoDistanceTree {
 		inStream.close();
 
 		MultipleSequenceAlignment<ProteinSequence, AminoAcidCompound> msa =
-				new MultipleSequenceAlignment<ProteinSequence, AminoAcidCompound>();
+				new MultipleSequenceAlignment<>();
 
 		for (ProteinSequence proteinSequence : proteinSequences.values()) {
 			msa.addAlignedSequence(proteinSequence);

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/Alignments.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/Alignments.java
@@ -189,7 +189,7 @@ public class Alignments {
 		runPairwiseScorers(scorers);
 
 		// stage 2: hierarchical clustering into a guide tree
-		GuideTree<S, C> tree = new GuideTree<S, C>(sequences, scorers);
+		GuideTree<S, C> tree = new GuideTree<>(sequences, scorers);
 		scorers = null;
 
 		// stage 3: progressive alignment
@@ -233,7 +233,7 @@ public class Alignments {
 	static <S extends Sequence<C>, C extends Compound> List<PairwiseSequenceAligner<S, C>> getAllPairsAligners(
 			List<S> sequences, PairwiseSequenceAlignerType type, GapPenalty gapPenalty,
 			SubstitutionMatrix<C> subMatrix) {
-		List<PairwiseSequenceAligner<S, C>> allPairs = new ArrayList<PairwiseSequenceAligner<S, C>>();
+		List<PairwiseSequenceAligner<S, C>> allPairs = new ArrayList<>();
 		for (int i = 0; i < sequences.size(); i++) {
 			for (int j = i+1; j < sequences.size(); j++) {
 				allPairs.add(getPairwiseAligner(sequences.get(i), sequences.get(j), type, gapPenalty, subMatrix));
@@ -256,7 +256,7 @@ public class Alignments {
 	public static <S extends Sequence<C>, C extends Compound> List<PairwiseSequenceScorer<S, C>> getAllPairsScorers(
 			List<S> sequences, PairwiseSequenceScorerType type, GapPenalty gapPenalty,
 			SubstitutionMatrix<C> subMatrix) {
-		List<PairwiseSequenceScorer<S, C>> allPairs = new ArrayList<PairwiseSequenceScorer<S, C>>();
+		List<PairwiseSequenceScorer<S, C>> allPairs = new ArrayList<>();
 		for (int i = 0; i < sequences.size(); i++) {
 			for (int j = i+1; j < sequences.size(); j++) {
 				allPairs.add(getPairwiseScorer(sequences.get(i), sequences.get(j), type, gapPenalty, subMatrix));
@@ -291,7 +291,7 @@ public class Alignments {
 	 * @return calculated elements
 	 */
 	static <E> List<E> getListFromFutures(List<Future<E>> futures) {
-		List<E> list = new ArrayList<E>();
+		List<E> list = new ArrayList<>();
 		for (Future<E> f : futures) {
 			// TODO when added to ConcurrencyTools, log completions and exceptions instead of printing stack traces
 			try {
@@ -326,9 +326,9 @@ public class Alignments {
 		switch (type) {
 		default:
 		case GLOBAL:
-			return new NeedlemanWunsch<S, C>(query, target, gapPenalty, subMatrix);
+			return new NeedlemanWunsch<>(query, target, gapPenalty, subMatrix);
 		case LOCAL:
-			return new SmithWaterman<S, C>(query, target, gapPenalty, subMatrix);
+			return new SmithWaterman<>(query, target, gapPenalty, subMatrix);
 		case GLOBAL_LINEAR_SPACE:
 		case LOCAL_LINEAR_SPACE:
 			// TODO other alignment options (Myers-Miller, Thompson)
@@ -374,18 +374,18 @@ public class Alignments {
 		case GLOBAL:
 			return getPairwiseAligner(query, target, PairwiseSequenceAlignerType.GLOBAL, gapPenalty, subMatrix);
 		case GLOBAL_IDENTITIES:
-			return new FractionalIdentityScorer<S, C>(getPairwiseAligner(query, target,
+			return new FractionalIdentityScorer<>(getPairwiseAligner(query, target,
 					PairwiseSequenceAlignerType.GLOBAL, gapPenalty, subMatrix));
 		case GLOBAL_SIMILARITIES:
-			return new FractionalSimilarityScorer<S, C>(getPairwiseAligner(query, target,
+			return new FractionalSimilarityScorer<>(getPairwiseAligner(query, target,
 					PairwiseSequenceAlignerType.GLOBAL, gapPenalty, subMatrix));
 		case LOCAL:
 			return getPairwiseAligner(query, target, PairwiseSequenceAlignerType.LOCAL, gapPenalty, subMatrix);
 		case LOCAL_IDENTITIES:
-			return new FractionalIdentityScorer<S, C>(getPairwiseAligner(query, target,
+			return new FractionalIdentityScorer<>(getPairwiseAligner(query, target,
 					PairwiseSequenceAlignerType.LOCAL, gapPenalty, subMatrix));
 		case LOCAL_SIMILARITIES:
-			return new FractionalSimilarityScorer<S, C>(getPairwiseAligner(query, target,
+			return new FractionalSimilarityScorer<>(getPairwiseAligner(query, target,
 					PairwiseSequenceAlignerType.LOCAL, gapPenalty, subMatrix));
 		case KMERS:
 		case WU_MANBER:
@@ -413,7 +413,7 @@ public class Alignments {
 		switch (type) {
 		default:
 		case GLOBAL:
-			return new SimpleProfileProfileAligner<S, C>(profile1, profile2, gapPenalty, subMatrix);
+			return new SimpleProfileProfileAligner<>(profile1, profile2, gapPenalty, subMatrix);
 		case GLOBAL_LINEAR_SPACE:
 		case GLOBAL_CONSENSUS:
 		case LOCAL:
@@ -443,7 +443,7 @@ public class Alignments {
 		switch (type) {
 		default:
 		case GLOBAL:
-			return new SimpleProfileProfileAligner<S, C>(profile1, profile2, gapPenalty, subMatrix);
+			return new SimpleProfileProfileAligner<>(profile1, profile2, gapPenalty, subMatrix);
 		case GLOBAL_LINEAR_SPACE:
 		case GLOBAL_CONSENSUS:
 		case LOCAL:
@@ -473,7 +473,7 @@ public class Alignments {
 		switch (type) {
 		default:
 		case GLOBAL:
-			return new SimpleProfileProfileAligner<S, C>(profile1, profile2, gapPenalty, subMatrix);
+			return new SimpleProfileProfileAligner<>(profile1, profile2, gapPenalty, subMatrix);
 		case GLOBAL_LINEAR_SPACE:
 		case GLOBAL_CONSENSUS:
 		case LOCAL:
@@ -503,7 +503,7 @@ public class Alignments {
 		switch (type) {
 		default:
 		case GLOBAL:
-			return new SimpleProfileProfileAligner<S, C>(profile1, profile2, gapPenalty, subMatrix);
+			return new SimpleProfileProfileAligner<>(profile1, profile2, gapPenalty, subMatrix);
 		case GLOBAL_LINEAR_SPACE:
 		case GLOBAL_CONSENSUS:
 		case LOCAL:
@@ -550,7 +550,7 @@ public class Alignments {
 			ProfileProfileAlignerType type, GapPenalty gapPenalty, SubstitutionMatrix<C> subMatrix) {
 
 		// find inner nodes in post-order traversal of tree (each leaf node has a single sequence profile)
-		List<GuideTreeNode<S, C>> innerNodes = new ArrayList<GuideTreeNode<S, C>>();
+		List<GuideTreeNode<S, C>> innerNodes = new ArrayList<>();
 		for (GuideTreeNode<S, C> n : tree) {
 			if (n.getProfile() == null) {
 				innerNodes.add(n);
@@ -599,7 +599,7 @@ public class Alignments {
 	static <S extends Sequence<C>, C extends Compound> List<SequencePair<S, C>>
 			runPairwiseAligners(List<PairwiseSequenceAligner<S, C>> aligners) {
 		int n = 1, all = aligners.size();
-		List<Future<SequencePair<S, C>>> futures = new ArrayList<Future<SequencePair<S, C>>>();
+		List<Future<SequencePair<S, C>>> futures = new ArrayList<>();
 		for (PairwiseSequenceAligner<S, C> aligner : aligners) {
 			futures.add(ConcurrencyTools.submit(new CallablePairwiseSequenceAligner<S, C>(aligner),
 					String.format("Aligning pair %d of %d", n++, all)));
@@ -619,7 +619,7 @@ public class Alignments {
 	public static <S extends Sequence<C>, C extends Compound> double[] runPairwiseScorers(
 			List<PairwiseSequenceScorer<S, C>> scorers) {
 		int n = 1, all = scorers.size();
-		List<Future<Double>> futures = new ArrayList<Future<Double>>();
+		List<Future<Double>> futures = new ArrayList<>();
 		for (PairwiseSequenceScorer<S, C> scorer : scorers) {
 			futures.add(ConcurrencyTools.submit(new CallablePairwiseSequenceScorer<S, C>(scorer),
 					String.format("Scoring pair %d of %d", n++, all)));
@@ -644,7 +644,7 @@ public class Alignments {
 	static <S extends Sequence<C>, C extends Compound> List<ProfilePair<S, C>>
 			runProfileAligners(List<ProfileProfileAligner<S, C>> aligners) {
 		int n = 1, all = aligners.size();
-		List<Future<ProfilePair<S, C>>> futures = new ArrayList<Future<ProfilePair<S, C>>>();
+		List<Future<ProfilePair<S, C>>> futures = new ArrayList<>();
 		for (ProfileProfileAligner<S, C> aligner : aligners) {
 			futures.add(ConcurrencyTools.submit(new CallableProfileProfileAligner<S, C>(aligner),
 					String.format("Aligning pair %d of %d", n++, all)));

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/GuideTree.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/GuideTree.java
@@ -182,7 +182,7 @@ public class GuideTree<S extends Sequence<C>, C extends Compound> implements Ite
 			distance = node.getDistanceToParent();
 			name = node.getName();
 			if(isLeaf = node.isExternal()) {
-				profile = new SimpleProfile<S, C>(sequences.get(distances.getIndex(name)));
+				profile = new SimpleProfile<>(sequences.get(distances.getIndex(name)));
 			} else {
 				child1 = new Node(node.getChildNode1(), this);
 				child2 = new Node(node.getChildNode2(), this);
@@ -237,7 +237,7 @@ public class GuideTree<S extends Sequence<C>, C extends Compound> implements Ite
 
 		@Override
 		public Enumeration<GuideTreeNode<S, C>> children() {
-			Vector<GuideTreeNode<S, C>> children = new Vector<GuideTreeNode<S, C>>();
+			Vector<GuideTreeNode<S, C>> children = new Vector<>();
 			children.add(getChild1());
 			children.add(getChild2());
 			return children.elements();
@@ -305,7 +305,7 @@ public class GuideTree<S extends Sequence<C>, C extends Compound> implements Ite
 
 		private PostOrderIterator() {
 			getRoot().clearVisited();
-			nodes = new Stack<Node>();
+			nodes = new Stack<>();
 			nodes.push(getRoot());
 		}
 

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/SimpleProfileProfileAligner.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/SimpleProfileProfileAligner.java
@@ -110,7 +110,7 @@ public class SimpleProfileProfileAligner<S extends Sequence<C>, C extends Compou
 
 	@Override
 	protected void setProfile(List<Step> sx, List<Step> sy) {
-		profile = pair = new SimpleProfilePair<S, C>(getQuery(), getTarget(), sx, sy);
+		profile = pair = new SimpleProfilePair<>(getQuery(), getTarget(), sx, sy);
 	}
 
 }

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/SmithWaterman.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/SmithWaterman.java
@@ -69,7 +69,7 @@ public class SmithWaterman<S extends Sequence<C>, C extends Compound> extends Ab
 
 	@Override
 	protected void setProfile(List<Step> sx, List<Step> sy) {
-		profile = pair = new SimpleSequencePair<S, C>(getQuery(), getTarget(), sx, xyStart[0],
+		profile = pair = new SimpleSequencePair<>(getQuery(), getTarget(), sx, xyStart[0],
 				getQuery().getLength() - xyMax[0], sy, xyStart[1], getTarget().getLength() - xyMax[1]);
 	}
 

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmFileAnnotation.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmFileAnnotation.java
@@ -125,7 +125,7 @@ public class StockholmFileAnnotation {
 	private Set<DatabaseReference> dbReferences;
 	private StringBuffer refComment;
 	/**TODO When implementing toString(), the function should loop on the vector */
-	private Vector<StockholmFileAnnotationReference> references = new Vector<StockholmFileAnnotation.StockholmFileAnnotationReference>();
+	private Vector<StockholmFileAnnotationReference> references = new Vector<>();
 	private StringBuffer keywords;
 	private CharSequence comment;
 	private StringBuffer pfamAccession;
@@ -137,7 +137,7 @@ public class StockholmFileAnnotation {
 	private float falseDiscoveryRate;
 
 	public StockholmFileAnnotation() {
-		embTrees = new HashMap<String, List<String>>();
+		embTrees = new HashMap<>();
 	}
 
 	public StringBuffer getDbComment() {
@@ -164,7 +164,7 @@ public class StockholmFileAnnotation {
 	 */
 	public void addDBReference(String dbReferenceRepresentingString) {
 		if (this.dbReferences == null) {
-			this.dbReferences = new HashSet<DatabaseReference>();
+			this.dbReferences = new HashSet<>();
 		}
 		dbReferences.add(new DatabaseReference(dbReferenceRepresentingString));
 	}
@@ -492,7 +492,7 @@ public class StockholmFileAnnotation {
 	public void addGFNewHampshire(String newHampshire) {
 		List<String> hampshireTree = embTrees.get(TREE_DEFAULT_ID);
 		if (hampshireTree == null) {
-			hampshireTree = new ArrayList<String>();
+			hampshireTree = new ArrayList<>();
 		}
 		hampshireTree.add(newHampshire);
 		embTrees.put(TREE_DEFAULT_ID, hampshireTree);

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmFileParser.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmFileParser.java
@@ -356,7 +356,7 @@ public class StockholmFileParser {
 		if (internalScanner == null) {
 			internalScanner = new Scanner(inStream);
 		}
-		ArrayList<StockholmStructure> structures = new ArrayList<StockholmStructure>();
+		ArrayList<StockholmStructure> structures = new ArrayList<>();
 		while (max != INFINITY && max-- > 0) {
 			StockholmStructure structure = parse(internalScanner);
 			if (structure != null) {

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmSequenceAnnotation.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmSequenceAnnotation.java
@@ -74,7 +74,7 @@ class StockholmSequenceAnnotation {
 	 */
 	public void addDBReference(String dbReferenceRepresentingString) {
 		if (this.dbReferences == null) {
-			this.dbReferences = new HashSet<DatabaseReference>();
+			this.dbReferences = new HashSet<>();
 		}
 		dbReferences.add(new DatabaseReference(dbReferenceRepresentingString));
 	}

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmStructure.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/io/StockholmStructure.java
@@ -94,9 +94,9 @@ public class StockholmStructure {
 	public StockholmStructure() {
 		fileAnnotation = new StockholmFileAnnotation();
 		consAnnotation = new StockholmConsensusAnnotation();
-		sequences = new HashMap<String, StringBuffer>();
-		seqsAnnotation = new HashMap<String, StockholmSequenceAnnotation>();
-		resAnnotation = new HashMap<String, StockholmResidueAnnotation>();
+		sequences = new HashMap<>();
+		seqsAnnotation = new HashMap<>();
+		resAnnotation = new HashMap<>();
 	}
 
 	public StockholmFileAnnotation getFileAnnotation() {
@@ -235,7 +235,7 @@ public class StockholmStructure {
 		if (forcedSequenceType != null && !(forcedSequenceType.equals(PFAM) || forcedSequenceType.equals(RFAM))) {
 			throw new IllegalArgumentException("Illegal Argument " + forcedSequenceType);
 		}
-		List<AbstractSequence<? extends AbstractCompound>> seqs = new ArrayList<AbstractSequence<? extends AbstractCompound>>();
+		List<AbstractSequence<? extends AbstractCompound>> seqs = new ArrayList<>();
 		for (String sequencename : sequences.keySet()) {
 			AbstractSequence<? extends AbstractCompound> seq = null;
 			String sequence = sequences.get(sequencename).toString();

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/routines/AlignerHelper.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/routines/AlignerHelper.java
@@ -268,7 +268,7 @@ public class AlignerHelper {
 		 */
 		public static List<Subproblem> getSubproblems(List<Anchor> anchors, int querySequenceLength, int targetSequenceLength) {
 			Collections.sort(anchors, new Anchor.QueryIndexComparator());
-			List<Subproblem> list = new ArrayList<Subproblem>();
+			List<Subproblem> list = new ArrayList<>();
 			Anchor last = new Anchor(-1, -1); // sentinal anchor
 			boolean isAnchored = false;
 			for (int i = 0; i < anchors.size(); i++) {

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/routines/AnchoredPairwiseSequenceAligner.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/routines/AnchoredPairwiseSequenceAligner.java
@@ -111,7 +111,7 @@ public class AnchoredPairwiseSequenceAligner<S extends Sequence<C>, C extends Co
 	 * @param anchors list of points that are tied to the given indices in the target
 	 */
 	public void setAnchors(int[] anchors) {
-		super.anchors = new ArrayList<Anchor>();
+		super.anchors = new ArrayList<>();
 		if (anchors != null) {
 			for (int i = 0; i < anchors.length; i++) {
 				if (anchors[i] >= 0) {
@@ -133,7 +133,7 @@ public class AnchoredPairwiseSequenceAligner<S extends Sequence<C>, C extends Co
 
 	@Override
 	protected void setProfile(List<Step> sx, List<Step> sy) {
-		profile = pair = new SimpleSequencePair<S, C>(getQuery(), getTarget(), sx, sy);
+		profile = pair = new SimpleSequencePair<>(getQuery(), getTarget(), sx, sy);
 	}
 
 }

--- a/biojava-alignment/src/main/java/org/biojava/nbio/alignment/template/AbstractMatrixAligner.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/alignment/template/AbstractMatrixAligner.java
@@ -55,7 +55,7 @@ public abstract class AbstractMatrixAligner<S extends Sequence<C>, C extends Com
 	protected GapPenalty gapPenalty;
 	private SubstitutionMatrix<C> subMatrix;
 	private boolean local, storingScoreMatrix;
-	protected List<Anchor> anchors = new ArrayList<Anchor>();
+	protected List<Anchor> anchors = new ArrayList<>();
 	protected int cutsPerSection;
 
 	// output fields
@@ -312,7 +312,7 @@ public abstract class AbstractMatrixAligner<S extends Sequence<C>, C extends Com
 		}
 		boolean linear = (gapPenalty.getType() == GapPenalty.Type.LINEAR);
 		Last[][][] traceback = new Last[dim[0]][][];
-		List<Step> sx = new ArrayList<Step>(), sy = new ArrayList<Step>();
+		List<Step> sx = new ArrayList<>(), sy = new ArrayList<>();
 
 		if (!local) {
 			xyMax = new int[] { dim[0] - 1, dim[1] - 1 };

--- a/biojava-alignment/src/main/java/org/biojava/nbio/phylo/ForesterWrapper.java
+++ b/biojava-alignment/src/main/java/org/biojava/nbio/phylo/ForesterWrapper.java
@@ -64,7 +64,7 @@ public class ForesterWrapper {
 
 		// Convert the biojava MSA to a FASTA String
 		OutputStream os = new ByteArrayOutputStream();
-		FastaWriter<C, D> fastaW = new FastaWriter<C, D>(os,
+		FastaWriter<C, D> fastaW = new FastaWriter<>(os,
 				msa.getAlignedSequences(),
 				new FastaHeaderFormatInterface<C, D>() {
 					@Override

--- a/biojava-core/src/main/java/demo/DemoSixFrameTranslation.java
+++ b/biojava-core/src/main/java/demo/DemoSixFrameTranslation.java
@@ -106,7 +106,7 @@ public class DemoSixFrameTranslation {
 			CompoundSet<NucleotideCompound> nucleotideCompoundSet = AmbiguityRNACompoundSet.getRNACompoundSet();
 
 			FastaReader<DNASequence, NucleotideCompound> proxy =
-					new FastaReader<DNASequence, NucleotideCompound>(
+					new FastaReader<>(
 							stream,
 							new GenericFastaHeaderParser<DNASequence, NucleotideCompound>(),
 							new DNASequenceCreator(ambiguityDNACompoundSet));

--- a/biojava-core/src/main/java/demo/ParseFastaFileDemo.java
+++ b/biojava-core/src/main/java/demo/ParseFastaFileDemo.java
@@ -94,7 +94,7 @@ public class ParseFastaFileDemo {
 		InputStream inStream = isp.getInputStream(f);
 
 
-		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<ProteinSequence, AminoAcidCompound>(
+		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<>(
 				inStream,
 				new GenericFastaHeaderParser<ProteinSequence, AminoAcidCompound>(),
 				new ProteinSequenceCreator(AminoAcidCompoundSet.getAminoAcidCompoundSet()));

--- a/biojava-core/src/main/java/org/biojava/nbio/core/alignment/SimpleAlignedSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/alignment/SimpleAlignedSequence.java
@@ -285,7 +285,7 @@ public class SimpleAlignedSequence<S extends Sequence<C>, C extends Compound> im
 
 	@Override
 	public List<C> getAsList() {
-		List<C> compounds = new ArrayList<C>();
+		List<C> compounds = new ArrayList<>();
 		for (int i = 1; i <= length; i++) {
 			compounds.add(getCompoundAt(i));
 		}
@@ -382,7 +382,7 @@ public class SimpleAlignedSequence<S extends Sequence<C>, C extends Compound> im
 
 	// helper method to initialize the location
 	private void setLocation(List<Step> steps) {
-		List<Location> sublocations = new ArrayList<Location>();
+		List<Location> sublocations = new ArrayList<>();
 		int start = 0, step = 0, oStep = numBefore+numAfter, oMax = this.original.getLength(), pStep = 0, pMax =
 				(prev == null) ? 0 : prev.getLength();
 		boolean inGap = true;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/alignment/SimpleProfile.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/alignment/SimpleProfile.java
@@ -70,11 +70,11 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 		if (query.getLength() != target.getLength()) {
 			throw new IllegalArgumentException("Aligned sequences differ in size");
 		}
-		list = new ArrayList<AlignedSequence<S, C>>();
+		list = new ArrayList<>();
 		list.add(query);
 		list.add(target);
 		list = Collections.unmodifiableList(list);
-		originals = new ArrayList<S>();
+		originals = new ArrayList<>();
 		originals.add(query.getOriginalSequence());
 		originals.add(target.getOriginalSequence());
 		originals = Collections.unmodifiableList(originals);
@@ -87,14 +87,14 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 	 * @param sequence sequence to seed profile
 	 */
 	public SimpleProfile(S sequence) {
-		List<Step> s = new ArrayList<Step>();
+		List<Step> s = new ArrayList<>();
 		for (int i = 0; i < sequence.getLength(); i++) {
 			s.add(Step.COMPOUND);
 		}
-		list = new ArrayList<AlignedSequence<S, C>>();
+		list = new ArrayList<>();
 		list.add(new SimpleAlignedSequence<S, C>(sequence, s));
 		list = Collections.unmodifiableList(list);
-		originals = new ArrayList<S>();
+		originals = new ArrayList<>();
 		originals.add(sequence);
 		originals = Collections.unmodifiableList(originals);
 		length = sequence.getLength();
@@ -117,11 +117,11 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 		if (sx.size() != sy.size()) {
 			throw new IllegalArgumentException("Alignments differ in size");
 		}
-		list = new ArrayList<AlignedSequence<S, C>>();
+		list = new ArrayList<>();
 		list.add(new SimpleAlignedSequence<S, C>(query, sx, xb, xa));
 		list.add(new SimpleAlignedSequence<S, C>(target, sy, yb, ya));
 		list = Collections.unmodifiableList(list);
-		originals = new ArrayList<S>();
+		originals = new ArrayList<>();
 		originals.add(query);
 		originals.add(target);
 		originals = Collections.unmodifiableList(originals);
@@ -141,7 +141,7 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 		if (sx.size() != sy.size()) {
 			throw new IllegalArgumentException("Alignments differ in size");
 		}
-		list = new ArrayList<AlignedSequence<S, C>>();
+		list = new ArrayList<>();
 		for (AlignedSequence<S, C> s : query) {
 			list.add(new SimpleAlignedSequence<S, C>(s, sx));
 		}
@@ -149,7 +149,7 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 			list.add(new SimpleAlignedSequence<S, C>(s, sy));
 		}
 		list = Collections.unmodifiableList(list);
-		originals = new ArrayList<S>();
+		originals = new ArrayList<>();
 		originals.addAll(query.getOriginalSequences());
 		originals.addAll(target.getOriginalSequences());
 		originals = Collections.unmodifiableList(originals);
@@ -163,8 +163,8 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 	 * collection is empty.
 	 */
 	public SimpleProfile(Collection<AlignedSequence<S,C>> alignedSequences) {
-		list = new ArrayList<AlignedSequence<S,C>>();
-		originals = new ArrayList<S>();
+		list = new ArrayList<>();
+		originals = new ArrayList<>();
 
 		Iterator<AlignedSequence<S,C>> itr = alignedSequences.iterator();
 		if(!itr.hasNext()) {
@@ -213,7 +213,7 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 
 	@Override
 	public List<AlignedSequence<S, C>> getAlignedSequences(int... listIndices) {
-		List<AlignedSequence<S, C>> tempList = new ArrayList<AlignedSequence<S, C>>();
+		List<AlignedSequence<S, C>> tempList = new ArrayList<>();
 		for (int i : listIndices) {
 			tempList.add(getAlignedSequence(i));
 		}
@@ -222,7 +222,7 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 
 	@Override
 	public List<AlignedSequence<S, C>> getAlignedSequences(S... sequences) {
-		List<AlignedSequence<S, C>> tempList = new ArrayList<AlignedSequence<S, C>>();
+		List<AlignedSequence<S, C>> tempList = new ArrayList<>();
 		for (S s : sequences) {
 			tempList.add(getAlignedSequence(s));
 		}
@@ -262,7 +262,7 @@ public class SimpleProfile<S extends Sequence<C>, C extends Compound> implements
 	@Override
 	public List<C> getCompoundsAt(int alignmentIndex) {
 		// TODO handle circular alignments
-		List<C> column = new ArrayList<C>();
+		List<C> column = new ArrayList<>();
 		for (AlignedSequence<S, C> s : list) {
 			column.add(s.getCompoundAt(alignmentIndex));
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/AAIndexFileParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/AAIndexFileParser.java
@@ -52,7 +52,7 @@ public class AAIndexFileParser {
 	boolean symmetricMatrix ;
 
 	public AAIndexFileParser(){
-		matrices  = new HashMap<String, SubstitutionMatrix<AminoAcidCompound>>();
+		matrices  = new HashMap<>();
 	}
 
 	/** Parse an inputStream that points to an AAINDEX database file
@@ -154,8 +154,8 @@ public class AAIndexFileParser {
 
 		matrix = new short[nrRows][nrCols];
 
-		rows = new ArrayList<AminoAcidCompound>();
-		cols = new ArrayList<AminoAcidCompound>();
+		rows = new ArrayList<>();
+		cols = new ArrayList<>();
 
 		//System.out.println(">" + currentRows+"<");
 		AminoAcidCompoundSet compoundSet = AminoAcidCompoundSet.getAminoAcidCompoundSet();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/ScaledSubstitutionMatrix.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/ScaledSubstitutionMatrix.java
@@ -216,7 +216,7 @@ public class ScaledSubstitutionMatrix implements
 	@Override
 	public Map<AminoAcidCompound, Short> getRow(AminoAcidCompound row) {
 		int rowIndex = rows.indexOf(row);
-		Map<AminoAcidCompound, Short> map = new HashMap<AminoAcidCompound, Short>();
+		Map<AminoAcidCompound, Short> map = new HashMap<>();
 		for (int colIndex = 0; colIndex < matrix[rowIndex].length; colIndex++) {
 			map.put(cols.get(colIndex), matrix[rowIndex][colIndex]);
 		}
@@ -226,7 +226,7 @@ public class ScaledSubstitutionMatrix implements
 	@Override
 	public Map<AminoAcidCompound, Short> getColumn(AminoAcidCompound column) {
 		int colIndex = cols.indexOf(column);
-		Map<AminoAcidCompound, Short> map = new HashMap<AminoAcidCompound, Short>();
+		Map<AminoAcidCompound, Short> map = new HashMap<>();
 		for (int i = 0; i < matrix.length; i++) {
 			map.put(rows.get(i), matrix[i][colIndex]);
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/SimpleSubstitutionMatrix.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/SimpleSubstitutionMatrix.java
@@ -57,7 +57,7 @@ public class SimpleSubstitutionMatrix<C extends Compound> implements Substitutio
 	private List<C> rows, cols;
 
 	public static SubstitutionMatrix<AminoAcidCompound> getBlosum62() {
-		return new SimpleSubstitutionMatrix<AminoAcidCompound>(AminoAcidCompoundSet.getAminoAcidCompoundSet(), new InputStreamReader(
+		return new SimpleSubstitutionMatrix<>(AminoAcidCompoundSet.getAminoAcidCompoundSet(), new InputStreamReader(
 				SimpleSubstitutionMatrix.class.getResourceAsStream("/matrices/blosum62.txt")), "blosum62");
 	}
 
@@ -126,10 +126,10 @@ public class SimpleSubstitutionMatrix<C extends Compound> implements Substitutio
 		this.name = name;
 		max = Short.MIN_VALUE;
 		min = Short.MAX_VALUE;
-		rows = new ArrayList<C>();
-		cols = new ArrayList<C>();
+		rows = new ArrayList<>();
+		cols = new ArrayList<>();
 		StringBuilder descriptionIn = new StringBuilder();
-		List<short[]> matrixIn = new ArrayList<short[]>();
+		List<short[]> matrixIn = new ArrayList<>();
 		while(input.hasNextLine()) {
 			String line = input.nextLine();
 			if (line.startsWith(comment)) {
@@ -288,7 +288,7 @@ public class SimpleSubstitutionMatrix<C extends Compound> implements Substitutio
 	@Override
 	public Map<C, Short> getRow(C row) {
 		int rowIndex = rows.indexOf(row);
-		Map<C, Short> map = new HashMap<C, Short>();
+		Map<C, Short> map = new HashMap<>();
 		for (int colIndex = 0; colIndex < matrix[rowIndex].length; colIndex++) {
 			map.put(cols.get(colIndex), matrix[rowIndex][colIndex]);
 		}
@@ -298,7 +298,7 @@ public class SimpleSubstitutionMatrix<C extends Compound> implements Substitutio
 	@Override
 	public Map<C, Short> getColumn(C column) {
 		int colIndex = cols.indexOf(column);
-		Map<C, Short> map = new HashMap<C, Short>();
+		Map<C, Short> map = new HashMap<>();
 		for (int i = 0; i < matrix.length; i++) {
 			map.put(rows.get(i), matrix[i][colIndex]);
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/SubstitutionMatrixHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/alignment/matrices/SubstitutionMatrixHelper.java
@@ -50,9 +50,9 @@ public class SubstitutionMatrixHelper implements Serializable {
 	private static final long serialVersionUID = 148491724604653225L;
 
 	private static Map<String, SubstitutionMatrix<AminoAcidCompound>> aminoAcidMatrices =
-			new HashMap<String, SubstitutionMatrix<AminoAcidCompound>>();
+			new HashMap<>();
 	private static Map<String, SubstitutionMatrix<NucleotideCompound>> nucleotideMatrices =
-			new HashMap<String, SubstitutionMatrix<NucleotideCompound>>();
+			new HashMap<>();
 
 	// prevents instantiation
 	private SubstitutionMatrixHelper() { }

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Hsp.java
@@ -120,7 +120,7 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
 		alignedQuery = new SimpleAlignedSequence(getSequence(hspQseq), getAlignmentsSteps(hspQseq));
 		alignedHit = new SimpleAlignedSequence(getSequence(hspHseq), getAlignmentsSteps(hspHseq));
 
-		returnAln = new SimpleSequencePair<S, C>(alignedQuery, alignedHit);
+		returnAln = new SimpleSequencePair<>(alignedQuery, alignedHit);
 
 		return returnAln;
 	}
@@ -145,7 +145,7 @@ public abstract class Hsp <S extends Sequence<C>, C extends Compound> {
 	}
 
 	private List<Step> getAlignmentsSteps(String gappedSequenceString){
-		List<Step> returnList = new ArrayList<Step>();
+		List<Step> returnList = new ArrayList<>();
 
 		for (char c: gappedSequenceString.toCharArray()){
 			if (c=='-') returnList.add(Step.GAP); else returnList.add(Step.COMPOUND);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/SearchIO.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/SearchIO.java
@@ -140,7 +140,7 @@ public class SearchIO implements Iterable<Result>{
 	 */
 	private ResultFactory guessFactory(File f){
 		if (extensionFactoryAssociation == null){
-			extensionFactoryAssociation = new HashMap<String, ResultFactory>();
+			extensionFactoryAssociation = new HashMap<>();
 			ServiceLoader<ResultFactory> impl = ServiceLoader.load(ResultFactory.class);
 			for (ResultFactory loadedImpl : impl) {
 				List<String> fileExtensions = loadedImpl.getFileExtensions();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastTabularParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastTabularParser.java
@@ -71,7 +71,7 @@ public class BlastTabularParser implements ResultFactory {
 
 	// data imported private:
 	int queryIdNumber = 0;
-	HashMap<String,String> queryIdMapping = new HashMap<String,String>();
+	HashMap<String,String> queryIdMapping = new HashMap<>();
 	String programName=null, queryName = null, databaseFile = null;
 	private String queryId      ;
 	private String subjectId    ;
@@ -89,7 +89,7 @@ public class BlastTabularParser implements ResultFactory {
 
 	@Override
 	public List<String> getFileExtensions() {
-		List<String> l = new ArrayList<String>();
+		List<String> l = new ArrayList<>();
 		l.add("blasttabular");
 		l.add("blasttxt");
 		return l;
@@ -102,7 +102,7 @@ public class BlastTabularParser implements ResultFactory {
 
 	@Override
 	public List<Result> createObjects(double maxEScore) throws IOException, ParseException {
-		List<Result> results = new ArrayList<Result>();
+		List<Result> results = new ArrayList<>();
 
 		log.info("Query for hits");
 		LineNumberReader  lnr = new LineNumberReader(new FileReader(targetFile));
@@ -126,13 +126,13 @@ public class BlastTabularParser implements ResultFactory {
 						.setQueryDef(queryName)
 						.setReference(blastReference);
 
-				List<Hit> hits = new ArrayList<Hit>();
+				List<Hit> hits = new ArrayList<>();
 
 				String currentQueryId = queryId;
 				while (currentQueryId.equals(queryId) && lineNumber < fileLinesCount){
 					BlastHitBuilder hitBuilder = new BlastHitBuilder();
 
-					List<Hsp> hsps = new ArrayList<Hsp>();
+					List<Hsp> hsps = new ArrayList<>();
 
 					String currentSubjectId=subjectId;
 					while (currentSubjectId.equals(subjectId) && lineNumber < fileLinesCount){

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastXMLParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastXMLParser.java
@@ -105,7 +105,7 @@ public class BlastXMLParser implements ResultFactory {
 			ArrayList<Element> IterationsList = XMLHelper.selectElements(blastDoc.getDocumentElement(), "BlastOutput_iterations/Iteration[Iteration_hits]");
 			logger.info(IterationsList.size() + " results");
 
-			resultsCollection = new ArrayList<Result>();
+			resultsCollection = new ArrayList<>();
 			for (Element element : IterationsList) {
 				BlastResultBuilder resultBuilder = new BlastResultBuilder();
 				// will add BlastOutput* key sections in the result object
@@ -131,7 +131,7 @@ public class BlastXMLParser implements ResultFactory {
 				Element iterationHitsElement = XMLHelper.selectSingleElement(element, "Iteration_hits");
 				ArrayList<Element> hitList = XMLHelper.selectElements(iterationHitsElement, "Hit");
 
-				hitsCollection = new ArrayList<Hit>();
+				hitsCollection = new ArrayList<>();
 				for (Element hitElement : hitList) {
 					BlastHitBuilder blastHitBuilder = new BlastHitBuilder();
 					blastHitBuilder
@@ -148,7 +148,7 @@ public class BlastXMLParser implements ResultFactory {
 					Element hithspsElement = XMLHelper.selectSingleElement(hitElement, "Hit_hsps");
 					ArrayList<Element> hspList = XMLHelper.selectElements(hithspsElement, "Hsp");
 
-					hspsCollection = new ArrayList<Hsp>();
+					hspsCollection = new ArrayList<>();
 					for (Element hspElement : hspList) {
 						Double evalue = Double.valueOf(XMLHelper.selectSingleElement(hspElement, "Hsp_evalue").getTextContent());
 
@@ -195,7 +195,7 @@ public class BlastXMLParser implements ResultFactory {
 
 	@Override
 	public List<String> getFileExtensions(){
-		ArrayList<String> extensions = new ArrayList<String>(1);
+		ArrayList<String> extensions = new ArrayList<>(1);
 		extensions.add("blastxml");
 		return extensions;
 	}
@@ -215,7 +215,7 @@ public class BlastXMLParser implements ResultFactory {
 	 */
 	private void mapIds() {
 		if (queryReferences != null) {
-			queryReferencesMap = new HashMap<String,Sequence>(queryReferences.size());
+			queryReferencesMap = new HashMap<>(queryReferences.size());
 			for (int counter=0; counter < queryReferences.size() ; counter ++){
 				String id = "Query_"+(counter+1);
 				queryReferencesMap.put(id, queryReferences.get(counter));
@@ -223,7 +223,7 @@ public class BlastXMLParser implements ResultFactory {
 		}
 
 		if (databaseReferences != null) {
-			databaseReferencesMap = new HashMap<String,Sequence>(databaseReferences.size());
+			databaseReferencesMap = new HashMap<>(databaseReferences.size());
 			for (int counter=0; counter < databaseReferences.size() ; counter ++){
 				// this is strange: while Query_id are 1 based, Hit (database) id are 0 based
 				String id = "gnl|BL_ORD_ID|"+(counter);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ChromosomeSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ChromosomeSequence.java
@@ -37,7 +37,7 @@ import java.util.LinkedHashMap;
 public class ChromosomeSequence extends DNASequence {
 
 	private int chromosomeNumber;
-	private LinkedHashMap<String, GeneSequence> geneSequenceHashMap = new LinkedHashMap<String, GeneSequence>();
+	private LinkedHashMap<String, GeneSequence> geneSequenceHashMap = new LinkedHashMap<>();
 
 	/**
 	 * Empty constructor used by tools that need a proper Bean that allows the actual

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/DNASequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/DNASequence.java
@@ -136,14 +136,14 @@ public class DNASequence extends AbstractSequence<NucleotideCompound> {
 	 * Returns a Sequence which runs in the current reverse order
 	 */
 	public SequenceView<NucleotideCompound> getReverse() {
-		return new ReversedSequenceView<NucleotideCompound>(this);
+		return new ReversedSequenceView<>(this);
 	}
 
 	/**
 	 * Returns a Sequence which will complement every base
 	 */
 	public SequenceView<NucleotideCompound> getComplement() {
-		return new ComplementSequenceView<NucleotideCompound>(this);
+		return new ComplementSequenceView<>(this);
 	}
 
 	/**

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/GeneSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/GeneSequence.java
@@ -41,11 +41,11 @@ public class GeneSequence extends DNASequence {
 
 	private final static Logger logger = LoggerFactory.getLogger(GeneSequence.class);
 
-	private final LinkedHashMap<String, TranscriptSequence> transcriptSequenceHashMap = new LinkedHashMap<String, TranscriptSequence>();
-	private final LinkedHashMap<String, IntronSequence> intronSequenceHashMap = new LinkedHashMap<String, IntronSequence>();
-	private final LinkedHashMap<String, ExonSequence> exonSequenceHashMap = new LinkedHashMap<String, ExonSequence>();
-	private final ArrayList<IntronSequence> intronSequenceList = new ArrayList<IntronSequence>();
-	private final ArrayList<ExonSequence> exonSequenceList = new ArrayList<ExonSequence>();
+	private final LinkedHashMap<String, TranscriptSequence> transcriptSequenceHashMap = new LinkedHashMap<>();
+	private final LinkedHashMap<String, IntronSequence> intronSequenceHashMap = new LinkedHashMap<>();
+	private final LinkedHashMap<String, ExonSequence> exonSequenceHashMap = new LinkedHashMap<>();
+	private final ArrayList<IntronSequence> intronSequenceList = new ArrayList<>();
+	private final ArrayList<ExonSequence> exonSequenceList = new ArrayList<>();
 	boolean intronAdded = false; // need to deal with the problem that typically introns are not added when validating the list and adding in introns as the regions not included in exons
 	private Strand strand = Strand.UNDEFINED;
 	private ChromosomeSequence chromosomeSequence;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/MultipleSequenceAlignment.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/MultipleSequenceAlignment.java
@@ -42,7 +42,7 @@ import java.util.List;
  */
 public class MultipleSequenceAlignment<S extends Sequence<C>, C extends Compound> implements LightweightProfile<S, C> {
 
-	private List<S> sequences = new ArrayList<S>();
+	private List<S> sequences = new ArrayList<>();
 	private Integer length = null;
 
 	/**
@@ -98,7 +98,7 @@ public class MultipleSequenceAlignment<S extends Sequence<C>, C extends Compound
 	 */
 	@Override
 	public List<C> getCompoundsAt(int alignmentIndex) {
-		List<C> column = new ArrayList<C>();
+		List<C> column = new ArrayList<>();
 		for (S s : sequences) {
 			column.add(s.getCompoundAt(alignmentIndex));
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ProteinSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ProteinSequence.java
@@ -160,7 +160,7 @@ public class ProteinSequence extends AbstractSequence<AminoAcidCompound> {
 		InputStream is = url.openConnection().getInputStream();
 
 		FastaReader<DNASequence, NucleotideCompound> parentReader
-				= new FastaReader<DNASequence, NucleotideCompound>(is,
+				= new FastaReader<>(is,
 						new PlainFastaHeaderParser<DNASequence, NucleotideCompound>(),
 						new DNASequenceCreator(AmbiguityDNACompoundSet.getDNACompoundSet()));
 		LinkedHashMap<String, DNASequence> seq = parentReader.process();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/TranscriptSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/TranscriptSequence.java
@@ -41,8 +41,8 @@ public class TranscriptSequence extends DNASequence {
 
 	private final static Logger logger = LoggerFactory.getLogger(TranscriptSequence.class);
 
-	private final ArrayList<CDSSequence> cdsSequenceList = new ArrayList<CDSSequence>();
-	private final LinkedHashMap<String, CDSSequence> cdsSequenceHashMap = new LinkedHashMap<String, CDSSequence>();
+	private final ArrayList<CDSSequence> cdsSequenceList = new ArrayList<>();
+	private final LinkedHashMap<String, CDSSequence> cdsSequenceHashMap = new LinkedHashMap<>();
 	private StartCodonSequence startCodonSequence = null;
 	private StopCodonSequence stopCodonSequence = null;
 	private GeneSequence parentGeneSequence = null;
@@ -153,7 +153,7 @@ public class TranscriptSequence extends DNASequence {
 	 * @return
 	 */
 	public ArrayList<ProteinSequence> getProteinCDSSequences() {
-		ArrayList<ProteinSequence> proteinSequenceList = new ArrayList<ProteinSequence>();
+		ArrayList<ProteinSequence> proteinSequenceList = new ArrayList<>();
 		for (int i = 0; i < cdsSequenceList.size(); i++) {
 			CDSSequence cdsSequence = cdsSequenceList.get(i);
 			String codingSequence = cdsSequence.getCodingSequence();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/compound/AminoAcidCompoundSet.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/compound/AminoAcidCompoundSet.java
@@ -44,11 +44,11 @@ public class AminoAcidCompoundSet implements CompoundSet<AminoAcidCompound>, Ser
 	 *
 	 */
 	private static final long serialVersionUID = 4000344194364133456L;
-	private final Map<String, AminoAcidCompound> aminoAcidCompoundCache = new HashMap<String, AminoAcidCompound>();
-	private final Map<String, AminoAcidCompound> aminoAcidCompoundCache3Letter = new HashMap<String, AminoAcidCompound>();
+	private final Map<String, AminoAcidCompound> aminoAcidCompoundCache = new HashMap<>();
+	private final Map<String, AminoAcidCompound> aminoAcidCompoundCache3Letter = new HashMap<>();
 
 	private final Map<AminoAcidCompound, Set<AminoAcidCompound>> equivalentsCache =
-			new HashMap<AminoAcidCompound, Set<AminoAcidCompound>>();
+			new HashMap<>();
 
 	public AminoAcidCompoundSet() {
 		aminoAcidCompoundCache.put("A", new AminoAcidCompound(this, "A", "Ala", "Alanine", 71.0788f));
@@ -154,7 +154,7 @@ public class AminoAcidCompoundSet implements CompoundSet<AminoAcidCompound>, Ser
 			addAmbiguousEquivalents("I", "L", "J");
 			// ambiguous gaps
 			AminoAcidCompound gap1, gap2, gap3;
-			Set<AminoAcidCompound> gaps = new HashSet<AminoAcidCompound>();
+			Set<AminoAcidCompound> gaps = new HashSet<>();
 			gaps.add(gap1 = aminoAcidCompoundCache.get("-"));
 			gaps.add(gap2 = aminoAcidCompoundCache.get("."));
 			gaps.add(gap3 = aminoAcidCompoundCache.get("_"));
@@ -172,18 +172,18 @@ public class AminoAcidCompoundSet implements CompoundSet<AminoAcidCompound>, Ser
 		Set<AminoAcidCompound> equivalents;
 		AminoAcidCompound cOne, cTwo, cEither;
 
-		equivalents = new HashSet<AminoAcidCompound>();
+		equivalents = new HashSet<>();
 		equivalents.add(cOne = aminoAcidCompoundCache.get(one));
 		equivalents.add(cTwo = aminoAcidCompoundCache.get(two));
 		equivalents.add(cEither = aminoAcidCompoundCache.get(either));
 		equivalentsCache.put(cEither, equivalents);
 
-		equivalents = new HashSet<AminoAcidCompound>();
+		equivalents = new HashSet<>();
 		equivalents.add(cOne);
 		equivalents.add(cEither);
 		equivalentsCache.put(cOne, equivalents);
 
-		equivalents = new HashSet<AminoAcidCompound>();
+		equivalents = new HashSet<>();
 		equivalents.add(cTwo);
 		equivalents.add(cEither);
 		equivalentsCache.put(cTwo, equivalents);
@@ -206,7 +206,7 @@ public class AminoAcidCompoundSet implements CompoundSet<AminoAcidCompound>, Ser
 
 	@Override
 	public List<AminoAcidCompound> getAllCompounds() {
-		return new ArrayList<AminoAcidCompound>(aminoAcidCompoundCache.values());
+		return new ArrayList<>(aminoAcidCompoundCache.values());
 	}
 
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/edits/Edit.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/edits/Edit.java
@@ -78,13 +78,13 @@ public interface Edit<C extends Compound> {
 		@Override
 		public Sequence<C> edit(Sequence<C> editingSequence) {
 			Sequence<C> targetSequence = getTargetSequence(editingSequence);
-			List<Sequence<C>> sequences = new ArrayList<Sequence<C>>();
+			List<Sequence<C>> sequences = new ArrayList<>();
 
 			sequences.add(getFivePrime(editingSequence));
 			sequences.add(targetSequence);
 			sequences.add(getThreePrime(editingSequence));
 
-			return new JoiningSequenceReader<C>(sequences);
+			return new JoiningSequenceReader<>(sequences);
 		}
 		private int start = -1;
 		private int end = -1;
@@ -119,7 +119,7 @@ public interface Edit<C extends Compound> {
 		public Sequence<C> getTargetSequence(Sequence<C> editingSequence) {
 			if (sequence == null && stringSequence != null) {
 				try {
-					sequence = new BasicSequence<C>(
+					sequence = new BasicSequence<>(
 								stringSequence, editingSequence.getCompoundSet());
 				} catch (CompoundNotFoundException e) {
 					// TODO is there a better way to handle this exception?
@@ -136,7 +136,7 @@ public interface Edit<C extends Compound> {
 		protected Sequence<C> getEmptySequence(Sequence<C> editingSequence) {
 			Sequence<C> s = null;
 			try {
-				s = new BasicSequence<C>("", editingSequence.getCompoundSet());
+				s = new BasicSequence<>("", editingSequence.getCompoundSet());
 			} catch (CompoundNotFoundException e) {
 				// should not happen
 				logger.error("Could not construct empty sequence. {}. This is most likely a bug.", e.getMessage());

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/AbstractFeature.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/AbstractFeature.java
@@ -40,7 +40,7 @@ import java.util.Map;
  */
 public abstract class AbstractFeature<S extends AbstractSequence<C>, C extends Compound>
 		implements FeatureInterface<S, C> {
-	List<FeatureInterface<S, C>> childrenFeatures = new ArrayList<FeatureInterface<S, C>>();
+	List<FeatureInterface<S, C>> childrenFeatures = new ArrayList<>();
 	FeatureInterface<S, C> parentFeature;
 	AbstractLocation sequenceLocation;
 	String type = "";
@@ -48,7 +48,7 @@ public abstract class AbstractFeature<S extends AbstractSequence<C>, C extends C
 	private String description = "";
 	private String shortDescription = "";
 	private Object userObject = null;
-	private Map<String, List<Qualifier>> Qualifiers = new HashMap<String, List<Qualifier>>();
+	private Map<String, List<Qualifier>> Qualifiers = new HashMap<>();
 
 	/**
 	 * A feature has a type and a source
@@ -292,7 +292,7 @@ public abstract class AbstractFeature<S extends AbstractSequence<C>, C extends C
 			vals.add(qualifier);
 			Qualifiers.put(key, vals);
 		} else {
-			List<Qualifier> vals = new ArrayList<Qualifier>();
+			List<Qualifier> vals = new ArrayList<>();
 			vals.add(qualifier);
 			Qualifiers.put(key, vals);
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/DBReferenceInfo.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/DBReferenceInfo.java
@@ -37,7 +37,7 @@ import java.util.LinkedHashMap;
  * @author Paolo Pavan
  */
 public class DBReferenceInfo extends Qualifier {
-	private LinkedHashMap<String, String> properties = new LinkedHashMap<String, String>();
+	private LinkedHashMap<String, String> properties = new LinkedHashMap<>();
 	private String database = "";
 	private String id = "";
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/FeatureDbReferenceInfo.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/FeatureDbReferenceInfo.java
@@ -46,11 +46,11 @@ public class FeatureDbReferenceInfo<S extends AbstractSequence<C>, C extends Com
 
 	private AbstractLocation location;
 	private FeatureInterface<S,C> parentFeature;
-	private List<FeatureInterface<S, C>> childrenFeatures = new ArrayList<FeatureInterface<S, C>>();
+	private List<FeatureInterface<S, C>> childrenFeatures = new ArrayList<>();
 	private String description = "";
 	private String shortDescription = "";
 	private Object userObject;
-	private Map<String, List<Qualifier>> qualifiers = new HashMap<String,List<Qualifier>>();
+	private Map<String, List<Qualifier>> qualifiers = new HashMap<>();
 
 
 	public FeatureDbReferenceInfo(String database, String id) {
@@ -150,7 +150,7 @@ public class FeatureDbReferenceInfo<S extends AbstractSequence<C>, C extends Com
 	@Override
 	public void addQualifier(String key, Qualifier qualifier) {
 		if (qualifiers == null) {
-			qualifiers = new HashMap<String, List<Qualifier>>();
+			qualifiers = new HashMap<>();
 		}
 		// Check for key. Update list of values
 		if (qualifiers.containsKey(key)){
@@ -158,7 +158,7 @@ public class FeatureDbReferenceInfo<S extends AbstractSequence<C>, C extends Com
 			vals.add(qualifier);
 			qualifiers.put(key, vals);
 		} else {
-			List<Qualifier> vals = new ArrayList<Qualifier>();
+			List<Qualifier> vals = new ArrayList<>();
 			vals.add(qualifier);
 			qualifiers.put(key, vals);
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/QualityFeature.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/QualityFeature.java
@@ -37,7 +37,7 @@ import java.util.List;
  */
 public class QualityFeature<S extends AbstractSequence<C>, C extends Compound> extends AbstractFeature<S, C> {
 
-	private List<Number> qualities = new ArrayList<Number>();
+	private List<Number> qualities = new ArrayList<>();
 
 	/**
 	 * @param type

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/QuantityFeature.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/QuantityFeature.java
@@ -35,7 +35,7 @@ import java.util.List;
  */
 public class QuantityFeature<S extends AbstractSequence<C>, C extends Compound> extends AbstractFeature<S, C> {
 
-	private List<Number> quantities = new ArrayList<Number>();
+	private List<Number> quantities = new ArrayList<>();
 
 	/**
 	 *

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/CasePreservingProteinSequenceCreator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/CasePreservingProteinSequenceCreator.java
@@ -90,7 +90,7 @@ public class CasePreservingProteinSequenceCreator extends ProteinSequenceCreator
 	public AbstractSequence<AminoAcidCompound> getSequence(
 			List<AminoAcidCompound> list) {
 		AbstractSequence<AminoAcidCompound> seq =super.getSequence(list);
-		Collection<Object> strCase = new ArrayList<Object>(seq.getLength());
+		Collection<Object> strCase = new ArrayList<>(seq.getLength());
 		for(int i=0;i<seq.getLength();i++) {
 			strCase.add(true);
 		}
@@ -107,7 +107,7 @@ public class CasePreservingProteinSequenceCreator extends ProteinSequenceCreator
 	 * This list contains only Booleans.
 	 */
 	private static List<Object> getStringCase(String str) {
-		List<Object> types = new ArrayList<Object>(str.length());
+		List<Object> types = new ArrayList<>(str.length());
 		for(int i=0;i<str.length();i++) {
 			types.add(Character.isUpperCase(str.charAt(i)));
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/DNASequenceCreator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/DNASequenceCreator.java
@@ -83,7 +83,7 @@ public AbstractSequence<NucleotideCompound> getSequence(
 	@Override
 public AbstractSequence<NucleotideCompound> getSequence(
 			List<NucleotideCompound> list) {
-		ArrayListProxySequenceReader<NucleotideCompound> store = new ArrayListProxySequenceReader<NucleotideCompound>();
+		ArrayListProxySequenceReader<NucleotideCompound> store = new ArrayListProxySequenceReader<>();
 		store.setCompoundSet(compoundSet);
 		store.setContents(list);
 		return new DNASequence(store);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaReader.java
@@ -148,7 +148,7 @@ public class FastaReader<S extends Sequence<?>, C extends Compound> {
 		boolean keepGoing = true;
 
 
-		LinkedHashMap<String,S> sequences = new LinkedHashMap<String,S>();
+		LinkedHashMap<String,S> sequences = new LinkedHashMap<>();
 
 		do {
 			line = line.trim(); // nice to have but probably not needed

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaReaderHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaReaderHelper.java
@@ -57,7 +57,7 @@ public class FastaReaderHelper {
 		}
 
 		FastaReader<DNASequence, NucleotideCompound> fastaProxyReader =
-				new FastaReader<DNASequence, NucleotideCompound>(
+				new FastaReader<>(
 						file,
 						new GenericFastaHeaderParser<DNASequence, NucleotideCompound>(),
 						new FileProxyDNASequenceCreator(
@@ -85,7 +85,7 @@ public class FastaReaderHelper {
 		}
 
 		FastaReader<RNASequence, NucleotideCompound> fastaProxyReader =
-				new FastaReader<RNASequence, NucleotideCompound>(
+				new FastaReader<>(
 						file,
 						new GenericFastaHeaderParser<RNASequence, NucleotideCompound>(),
 						new FileProxyRNASequenceCreator(
@@ -124,7 +124,7 @@ public class FastaReaderHelper {
 	 */
 	public static LinkedHashMap<String, ProteinSequence> readFastaProteinSequence(
 			InputStream inStream) throws IOException {
-		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<ProteinSequence, AminoAcidCompound>(
+		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<>(
 				inStream,
 				new GenericFastaHeaderParser<ProteinSequence, AminoAcidCompound>(),
 				new ProteinSequenceCreator(AminoAcidCompoundSet.getAminoAcidCompoundSet()));
@@ -139,7 +139,7 @@ public class FastaReaderHelper {
 	 */
 	public static LinkedHashMap<String, DNASequence> readFastaDNASequence(
 			InputStream inStream) throws IOException {
-		FastaReader<DNASequence, NucleotideCompound> fastaReader = new FastaReader<DNASequence, NucleotideCompound>(
+		FastaReader<DNASequence, NucleotideCompound> fastaReader = new FastaReader<>(
 				inStream,
 				new GenericFastaHeaderParser<DNASequence, NucleotideCompound>(),
 				new DNASequenceCreator(DNACompoundSet.getDNACompoundSet()));
@@ -168,7 +168,7 @@ public class FastaReaderHelper {
 	 */
 	public static LinkedHashMap<String, RNASequence> readFastaRNASequence(
 			InputStream inStream) throws IOException {
-		FastaReader<RNASequence, NucleotideCompound> fastaReader = new FastaReader<RNASequence, NucleotideCompound>(
+		FastaReader<RNASequence, NucleotideCompound> fastaReader = new FastaReader<>(
 				inStream,
 				new GenericFastaHeaderParser<RNASequence, NucleotideCompound>(),
 				new RNASequenceCreator(RNACompoundSet.getRNACompoundSet()));

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaWriterHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaWriterHelper.java
@@ -71,7 +71,7 @@ public class FastaWriterHelper {
 	public static void writeProteinSequence(OutputStream outputStream,
 			Collection<ProteinSequence> proteinSequences) throws Exception {
 
-		FastaWriter<ProteinSequence, AminoAcidCompound> fastaWriter = new FastaWriter<ProteinSequence, AminoAcidCompound>(
+		FastaWriter<ProteinSequence, AminoAcidCompound> fastaWriter = new FastaWriter<>(
 				outputStream, proteinSequences,
 				new GenericFastaHeaderFormat<ProteinSequence, AminoAcidCompound>());
 		fastaWriter.process();
@@ -132,7 +132,7 @@ public class FastaWriterHelper {
 	 */
 
 	public static void writeNucleotideSequence(OutputStream outputStream, Collection<DNASequence> dnaSequences) throws Exception {
-		FastaWriter<DNASequence, NucleotideCompound> fastaWriter = new FastaWriter<DNASequence, NucleotideCompound>(
+		FastaWriter<DNASequence, NucleotideCompound> fastaWriter = new FastaWriter<>(
 				outputStream, dnaSequences,
 				new GenericFastaHeaderFormat<DNASequence, NucleotideCompound>());
 		fastaWriter.process();
@@ -170,7 +170,7 @@ public class FastaWriterHelper {
 	 */
 
 	private static Collection<Sequence<?>> singleSeqToCollection(Sequence<?> sequence) {
-		Collection<Sequence<?>> sequences = new ArrayList<Sequence<?>>();
+		Collection<Sequence<?>> sequences = new ArrayList<>();
 		sequences.add(sequence);
 		return sequences;
 	}
@@ -199,7 +199,7 @@ public class FastaWriterHelper {
 				};
 
 		FastaWriter<Sequence<?>, Compound> fastaWriter =
-				new FastaWriter<Sequence<?>, Compound>(outputStream,
+				new FastaWriter<>(outputStream,
 				sequences, fhfi);
 
 		fastaWriter.process();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FileProxyDNASequenceCreator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FileProxyDNASequenceCreator.java
@@ -78,7 +78,7 @@ public class FileProxyDNASequenceCreator implements
 	 */
 	@Override
 	public AbstractSequence<NucleotideCompound> getSequence(String sequence, long index ) throws CompoundNotFoundException, IOException {
-		SequenceFileProxyLoader<NucleotideCompound> sequenceFileProxyLoader = new SequenceFileProxyLoader<NucleotideCompound>(
+		SequenceFileProxyLoader<NucleotideCompound> sequenceFileProxyLoader = new SequenceFileProxyLoader<>(
 				file,
 				sequenceParser,
 				index,

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FileProxyProteinSequenceCreator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FileProxyProteinSequenceCreator.java
@@ -76,7 +76,7 @@ public class FileProxyProteinSequenceCreator implements SequenceCreatorInterface
 	@Override
 	public AbstractSequence<AminoAcidCompound> getSequence(String sequence, long index) throws CompoundNotFoundException, IOException {
 		SequenceFileProxyLoader<AminoAcidCompound> sequenceFileProxyLoader =
-				new SequenceFileProxyLoader<AminoAcidCompound>(
+				new SequenceFileProxyLoader<>(
 						file,
 						sequenceParser,
 						index,

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FileProxyRNASequenceCreator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FileProxyRNASequenceCreator.java
@@ -78,7 +78,7 @@ public class FileProxyRNASequenceCreator implements
 	 */
 	@Override
 	public AbstractSequence<NucleotideCompound> getSequence(String sequence, long index ) throws CompoundNotFoundException, IOException {
-		SequenceFileProxyLoader<NucleotideCompound> sequenceFileProxyLoader = new SequenceFileProxyLoader<NucleotideCompound>(
+		SequenceFileProxyLoader<NucleotideCompound> sequenceFileProxyLoader = new SequenceFileProxyLoader<>(
 				file,
 				sequenceParser,
 				index,

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReaderHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReaderHelper.java
@@ -61,7 +61,7 @@ public class GenbankReaderHelper {
 		}
 
 		GenbankReader<DNASequence, NucleotideCompound> GenbankProxyReader =
-				new GenbankReader<DNASequence, NucleotideCompound>(
+				new GenbankReader<>(
 						file,
 						new GenericGenbankHeaderParser<DNASequence, NucleotideCompound>(),
 						new FileProxyDNASequenceCreator(
@@ -89,7 +89,7 @@ public class GenbankReaderHelper {
 		}
 
 		GenbankReader<ProteinSequence, AminoAcidCompound> GenbankProxyReader =
-				new GenbankReader<ProteinSequence, AminoAcidCompound>(
+				new GenbankReader<>(
 						file,
 						new GenericGenbankHeaderParser<ProteinSequence, AminoAcidCompound>(),
 						new FileProxyProteinSequenceCreator(
@@ -117,7 +117,7 @@ public class GenbankReaderHelper {
 		}
 
 		GenbankReader<RNASequence, NucleotideCompound> GenbankProxyReader =
-				new GenbankReader<RNASequence, NucleotideCompound>(
+				new GenbankReader<>(
 						file,
 						new GenericGenbankHeaderParser<RNASequence, NucleotideCompound>(),
 						new FileProxyRNASequenceCreator(
@@ -156,7 +156,7 @@ public class GenbankReaderHelper {
 	 */
 	public static LinkedHashMap<String, ProteinSequence> readGenbankProteinSequence(
 			InputStream inStream) throws Exception {
-		GenbankReader<ProteinSequence, AminoAcidCompound> GenbankReader = new GenbankReader<ProteinSequence, AminoAcidCompound>(
+		GenbankReader<ProteinSequence, AminoAcidCompound> GenbankReader = new GenbankReader<>(
 				inStream,
 				new GenericGenbankHeaderParser<ProteinSequence, AminoAcidCompound>(),
 				new ProteinSequenceCreator(AminoAcidCompoundSet.getAminoAcidCompoundSet()));
@@ -171,7 +171,7 @@ public class GenbankReaderHelper {
 	 */
 	public static LinkedHashMap<String, DNASequence> readGenbankDNASequence(
 			InputStream inStream) throws Exception {
-		GenbankReader<DNASequence, NucleotideCompound> GenbankReader = new GenbankReader<DNASequence, NucleotideCompound>(
+		GenbankReader<DNASequence, NucleotideCompound> GenbankReader = new GenbankReader<>(
 				inStream,
 				new GenericGenbankHeaderParser<DNASequence, NucleotideCompound>(),
 				new DNASequenceCreator(DNACompoundSet.getDNACompoundSet()));
@@ -199,7 +199,7 @@ public class GenbankReaderHelper {
 	 */
 	public static LinkedHashMap<String, RNASequence> readGenbankRNASequence(
 			InputStream inStream) throws Exception {
-		GenbankReader<RNASequence, NucleotideCompound> GenbankReader = new GenbankReader<RNASequence, NucleotideCompound>(
+		GenbankReader<RNASequence, NucleotideCompound> GenbankReader = new GenbankReader<>(
 				inStream,
 				new GenericGenbankHeaderParser<RNASequence, NucleotideCompound>(),
 				new RNASequenceCreator(RNACompoundSet.getRNACompoundSet()));

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankWriterHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankWriterHelper.java
@@ -76,7 +76,7 @@ public class GenbankWriterHelper {
 	public static void writeProteinSequence(OutputStream outputStream,
 			Collection<ProteinSequence> proteinSequences) throws Exception {
 
-		GenbankWriter<ProteinSequence, AminoAcidCompound> genbankWriter = new GenbankWriter<ProteinSequence, AminoAcidCompound>(
+		GenbankWriter<ProteinSequence, AminoAcidCompound> genbankWriter = new GenbankWriter<>(
 				outputStream,
 				proteinSequences,
 				new GenericGenbankHeaderFormat<ProteinSequence, AminoAcidCompound>());
@@ -126,10 +126,10 @@ public class GenbankWriterHelper {
 	public static void writeNucleotideSequence(OutputStream outputStream,
 			Collection<DNASequence> dnaSequences, String seqType)
 			throws Exception {
-		GenericGenbankHeaderFormat<DNASequence, NucleotideCompound> genericGenbankHeaderFormat = new GenericGenbankHeaderFormat<DNASequence, NucleotideCompound>(
+		GenericGenbankHeaderFormat<DNASequence, NucleotideCompound> genericGenbankHeaderFormat = new GenericGenbankHeaderFormat<>(
 				seqType);
 		// genericGenbankHeaderFormat.setLineSeparator(lineSep);
-		GenbankWriter<DNASequence, NucleotideCompound> genbankWriter = new GenbankWriter<DNASequence, NucleotideCompound>(
+		GenbankWriter<DNASequence, NucleotideCompound> genbankWriter = new GenbankWriter<>(
 				outputStream, dnaSequences, genericGenbankHeaderFormat);
 		// genbankWriter.setLineSeparator(lineSep);
 		genbankWriter.process();
@@ -146,9 +146,9 @@ public class GenbankWriterHelper {
 
 	public static void writeNucleotideSequenceOriginal(OutputStream outputStream, Collection<DNASequence> dnaSequences)
 			throws Exception {
-		GenericGenbankHeaderFormat<DNASequence, NucleotideCompound> genericGenbankHeaderFormat = new GenericGenbankHeaderFormat<DNASequence, NucleotideCompound>(
+		GenericGenbankHeaderFormat<DNASequence, NucleotideCompound> genericGenbankHeaderFormat = new GenericGenbankHeaderFormat<>(
 				true);
-		GenbankWriter<DNASequence, NucleotideCompound> genbankWriter = new GenbankWriter<DNASequence, NucleotideCompound>(
+		GenbankWriter<DNASequence, NucleotideCompound> genbankWriter = new GenbankWriter<>(
 				outputStream, dnaSequences, genericGenbankHeaderFormat);
 		genbankWriter.process();
 	}
@@ -189,7 +189,7 @@ public class GenbankWriterHelper {
 
 	private static Collection<Sequence<?>> singleSeqToCollection(
 			Sequence<?> sequence) {
-		Collection<Sequence<?>> sequences = new ArrayList<Sequence<?>>();
+		Collection<Sequence<?>> sequences = new ArrayList<>();
 		sequences.add(sequence);
 		return sequences;
 	}
@@ -219,7 +219,7 @@ public class GenbankWriterHelper {
 			;
 		};
 
-		GenbankWriter<Sequence<?>, Compound> genbankWriter = new GenbankWriter<Sequence<?>, Compound>(
+		GenbankWriter<Sequence<?>, Compound> genbankWriter = new GenbankWriter<>(
 				outputStream, sequences, fhfi);
 
 		genbankWriter.process();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericFastaHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericFastaHeaderParser.java
@@ -71,7 +71,7 @@ public class GenericFastaHeaderParser<S extends AbstractSequence<C>, C extends C
 	 */
 	private String[] getHeaderValues(String header) {
 		String[] data = new String[0];
-		ArrayList<String> values = new ArrayList<String>();
+		ArrayList<String> values = new ArrayList<>();
 		StringBuffer sb = new StringBuffer();
 		//commented out 1/11/2012 to resolve an issue where headers do contain a length= at the end that are not recognized
 		//if(header.indexOf("length=") != -1){

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -208,7 +208,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 				
 				StringBuilder sb = new StringBuilder();
 				Formatter formatter = new Formatter(sb, Locale.US);
-				ArrayList<String> locations = new ArrayList<String>();
+				ArrayList<String> locations = new ArrayList<>();
 				for(Location l  : feature.getLocations().getSubLocations()) {	
 					locations.add(_insdc_location_string_ignoring_strand_and_subfeatures((AbstractLocation) l, record_length));					
 				}
@@ -223,7 +223,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 				//This covers typical forward strand features, and also an evil mixed strand:
 				StringBuilder sb = new StringBuilder();
 				Formatter formatter = new Formatter(sb,Locale.US);
-				ArrayList<String> locations = new ArrayList<String>();
+				ArrayList<String> locations = new ArrayList<>();
 				for(Location l  : feature.getLocations().getSubLocations()) {	
 					locations.add(_insdc_location_string_ignoring_strand_and_subfeatures((AbstractLocation) l, record_length));					
 				}
@@ -248,7 +248,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 			}
 			StringBuilder sb = new StringBuilder();
 			Formatter formatter = new Formatter(sb,Locale.US);
-			ArrayList<String> locations = new ArrayList<String>();
+			ArrayList<String> locations = new ArrayList<>();
 			for(FeatureInterface<AbstractSequence<C>, C> f  : feature.getChildrenFeatures()) {
 				locations.add(_insdc_location_string_ignoring_strand_and_subfeatures(f.getLocations(), record_length));
 			}
@@ -261,7 +261,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 		//This covers typical forward strand features, and also an evil mixed strand:
 		StringBuilder sb = new StringBuilder();
 		Formatter formatter = new Formatter(sb,Locale.US);
-		ArrayList<String> locations = new ArrayList<String>();
+		ArrayList<String> locations = new ArrayList<>();
 		for(FeatureInterface<AbstractSequence<C>, C> f  : feature.getChildrenFeatures()) {
 			locations.add(_insdc_location_string_ignoring_strand_and_subfeatures(f.getLocations(), record_length));
 		}
@@ -406,14 +406,14 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 	 */
 	protected ArrayList<String> _split_multi_line(String text, int max_len) {
 		// TODO Auto-generated method stub
-		ArrayList<String> output = new ArrayList<String>();
+		ArrayList<String> output = new ArrayList<>();
 		text = text.trim();
 		if(text.length() <= max_len) {
 			output.add(text);
 			return output;
 		}
 
-		ArrayList<String> words = new ArrayList<String>();
+		ArrayList<String> words = new ArrayList<>();
 		Collections.addAll(words, text.split("\\s+"));
 		while(!words.isEmpty()) {
 			text = words.remove(0);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/IUPACParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/IUPACParser.java
@@ -134,8 +134,8 @@ public class IUPACParser {
 
 	private void populateLookups() {
 		if(nameLookup == null) {
-			nameLookup = new HashMap<String, IUPACTable>();
-			idLookup = new HashMap<Integer, IUPACTable>();
+			nameLookup = new HashMap<>();
+			idLookup = new HashMap<>();
 			for(IUPACTable t: getTables()) {
 				nameLookup.put(t.getName(), t);
 				idLookup.put(t.getId(), t);
@@ -144,7 +144,7 @@ public class IUPACParser {
 	}
 
 	private List<IUPACTable> parseTables() {
-		List<IUPACTable> localTables = new ArrayList<IUPACTable>();
+		List<IUPACTable> localTables = new ArrayList<>();
 		List<String> lines = IOUtils.getList(is);
 		Integer id = null;
 		String name, aa, starts, baseone, basetwo, basethree;
@@ -198,7 +198,7 @@ public class IUPACParser {
 		private final String       baseTwo;
 		private final String       baseThree;
 
-		private final List<Codon>  codons    = new ArrayList<Codon>();
+		private final List<Codon>  codons    = new ArrayList<>();
 		private CompoundSet<Codon> compounds = null;
 
 		public IUPACTable(String name, int id, String aminoAcidString,
@@ -328,7 +328,7 @@ public class IUPACParser {
 		}
 
 		private List<List<String>> codonStrings() {
-			List<List<String>> codons = new ArrayList<List<String>>();
+			List<List<String>> codons = new ArrayList<>();
 			for (int i = 0; i < baseOne.length(); i++) {
 				List<String> codon = Arrays.asList(Character
 						.toString(baseOne.charAt(i)),
@@ -348,7 +348,7 @@ public class IUPACParser {
 		}
 
 		private List<String> split(String string) {
-			List<String> split = new ArrayList<String>();
+			List<String> split = new ArrayList<>();
 			for (int i = 0; i < string.length(); i++) {
 				split.add(Character.toString(string.charAt(i)));
 			}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/ProteinSequenceCreator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/ProteinSequenceCreator.java
@@ -70,7 +70,7 @@ public AbstractSequence<AminoAcidCompound> getSequence(String sequence,
 	@Override
 public AbstractSequence<AminoAcidCompound> getSequence(
 			List<AminoAcidCompound> list) {
-		ArrayListProxySequenceReader<AminoAcidCompound> store = new ArrayListProxySequenceReader<AminoAcidCompound>();
+		ArrayListProxySequenceReader<AminoAcidCompound> store = new ArrayListProxySequenceReader<>();
 		store.setCompoundSet(compoundSet);
 		store.setContents(list);
 		return new ProteinSequence(store);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/RNASequenceCreator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/RNASequenceCreator.java
@@ -78,7 +78,7 @@ public AbstractSequence<NucleotideCompound> getSequence(
 	@Override
 public AbstractSequence<NucleotideCompound> getSequence(List<NucleotideCompound> list) {
 		ArrayListProxySequenceReader<NucleotideCompound> store =
-			new ArrayListProxySequenceReader<NucleotideCompound>();
+			new ArrayListProxySequenceReader<>();
 		store.setCompoundSet(compoundSet);
 		store.setContents(list);
 		return new RNASequence(store);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/util/IOUtils.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/util/IOUtils.java
@@ -110,7 +110,7 @@ public class IOUtils {
 	 * @throws ParserException Can throw this if we cannot parse the given reader
 	 */
 	public static List<String> getList(BufferedReader br) {
-		final List<String> list = new ArrayList<String>();
+		final List<String> list = new ArrayList<>();
 		processReader(br, new ReaderProcessor() {
 			@Override
 			public void process(String line) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/GenbankProxySequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/GenbankProxySequenceReader.java
@@ -74,7 +74,7 @@ public class GenbankProxySequenceReader<C extends Compound> extends StringProxyS
 		String db = compoundSet instanceof AminoAcidCompoundSet ? "protein" : "nuccore";
 
 		InputStream inStream = getBufferedInputStream(accessionID, db);
-		genbankParser = new GenbankSequenceParser<AbstractSequence<C>, C>();
+		genbankParser = new GenbankSequenceParser<>();
 
 		setContents(genbankParser.getSequence(new BufferedReader(new InputStreamReader(inStream)), 0));
 		headerParser = genbankParser.getSequenceHeaderParser();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/SequenceFileProxyLoader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/SequenceFileProxyLoader.java
@@ -57,7 +57,7 @@ public class SequenceFileProxyLoader<C extends Compound> implements ProxySequenc
 
 	SequenceParserInterface sequenceParser;
 	private CompoundSet<C> compoundSet;
-	private List<C> parsedCompounds = new ArrayList<C>();
+	private List<C> parsedCompounds = new ArrayList<>();
 	File file;
 	long sequenceStartIndex = -1;
 	int sequenceLength = -1;
@@ -204,7 +204,7 @@ public class SequenceFileProxyLoader<C extends Compound> implements ProxySequenc
 	 */
 	public String getSequenceAsString(Integer bioBegin, Integer bioEnd, Strand strand) {
 
-		SequenceAsStringHelper<C> sequenceAsStringHelper = new SequenceAsStringHelper<C>();
+		SequenceAsStringHelper<C> sequenceAsStringHelper = new SequenceAsStringHelper<>();
 		return sequenceAsStringHelper.getSequenceAsString(this.parsedCompounds, compoundSet, bioBegin, bioEnd, strand);
 	}
 
@@ -260,7 +260,7 @@ public class SequenceFileProxyLoader<C extends Compound> implements ProxySequenc
 	@Override
 	public SequenceView<C> getSubSequence(final Integer bioBegin, final Integer bioEnd) {
 
-		return new SequenceProxyView<C>(SequenceFileProxyLoader.this, bioBegin, bioEnd);
+		return new SequenceProxyView<>(SequenceFileProxyLoader.this, bioBegin, bioEnd);
 	}
 
 	/**

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/StringProxySequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/StringProxySequenceReader.java
@@ -46,7 +46,7 @@ public class StringProxySequenceReader<C extends Compound> implements ProxySeque
 
 	private String sequence;
 	private CompoundSet<C> compoundSet;
-	private List<C> parsedCompounds = new ArrayList<C>();
+	private List<C> parsedCompounds = new ArrayList<>();
 
 	public StringProxySequenceReader() {}
 
@@ -126,13 +126,13 @@ public class StringProxySequenceReader<C extends Compound> implements ProxySeque
 
 
 	public String getSequenceAsString(Integer bioBegin, Integer bioEnd,Strand strand) {
-		SequenceAsStringHelper<C> sequenceAsStringHelper = new SequenceAsStringHelper<C>();
+		SequenceAsStringHelper<C> sequenceAsStringHelper = new SequenceAsStringHelper<>();
 		return sequenceAsStringHelper.getSequenceAsString(this.parsedCompounds, compoundSet, bioBegin, bioEnd, strand);
 	}
 
 	@Override
 	public SequenceView<C> getSubSequence(final Integer bioBegin, final Integer bioEnd) {
-		return new SequenceProxyView<C>(StringProxySequenceReader.this,bioBegin,bioEnd);
+		return new SequenceProxyView<>(StringProxySequenceReader.this,bioBegin,bioEnd);
 	}
 
 	@Override

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/UniprotProxySequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/UniprotProxySequenceReader.java
@@ -79,7 +79,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	private static String uniprotDirectoryCache = null;
 	private String sequence;
 	private CompoundSet<C> compoundSet;
-	private List<C> parsedCompounds = new ArrayList<C>();
+	private List<C> parsedCompounds = new ArrayList<>();
 	Document uniprotDoc;
 
 	/**
@@ -125,7 +125,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	public static <C extends Compound> UniprotProxySequenceReader<C> parseUniprotXMLString(String xml, CompoundSet<C> compoundSet) {
 		try {
 			Document document = XMLHelper.inputStreamToDocument(new ByteArrayInputStream(xml.getBytes()));
-			return new UniprotProxySequenceReader<C>(document, compoundSet);
+			return new UniprotProxySequenceReader<>(document, compoundSet);
 		} catch (Exception e) {
 			logger.error("Exception on xml parse of: {}", xml);
 		}
@@ -281,7 +281,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @return
 	 */
 	public String getSequenceAsString(Integer bioBegin, Integer bioEnd, Strand strand) {
-		SequenceAsStringHelper<C> sequenceAsStringHelper = new SequenceAsStringHelper<C>();
+		SequenceAsStringHelper<C> sequenceAsStringHelper = new SequenceAsStringHelper<>();
 		return sequenceAsStringHelper.getSequenceAsString(this.parsedCompounds, compoundSet, bioBegin, bioEnd, strand);
 	}
 
@@ -293,7 +293,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 */
 	@Override
 	public SequenceView<C> getSubSequence(final Integer bioBegin, final Integer bioEnd) {
-		return new SequenceProxyView<C>(UniprotProxySequenceReader.this, bioBegin, bioEnd);
+		return new SequenceProxyView<>(UniprotProxySequenceReader.this, bioBegin, bioEnd);
 	}
 
 	/**
@@ -341,7 +341,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @throws XPathExpressionException
 	 */
 	public ArrayList<AccessionID> getAccessions() throws XPathExpressionException {
-		ArrayList<AccessionID> accessionList = new ArrayList<AccessionID>();
+		ArrayList<AccessionID> accessionList = new ArrayList<>();
 		if (uniprotDoc == null) {
 			return accessionList;
 		}
@@ -373,7 +373,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @throws XPathExpressionException
 	 */
 	public ArrayList<String> getProteinAliases() throws XPathExpressionException {
-		ArrayList<String> aliasList = new ArrayList<String>();
+		ArrayList<String> aliasList = new ArrayList<>();
 		if (uniprotDoc == null) {
 			return aliasList;
 		}
@@ -476,7 +476,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @throws XPathExpressionException
 	 */
 	public ArrayList<String> getGeneAliases() throws XPathExpressionException {
-		ArrayList<String> aliasList = new ArrayList<String>();
+		ArrayList<String> aliasList = new ArrayList<>();
 		if (uniprotDoc == null) {
 			return aliasList;
 		}
@@ -609,7 +609,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 		StringBuilder sb = new StringBuilder();
 		URL uniprot = new URL(uniprotURL);
 		int attempt = 5;
-		List<String> errorCodes = new ArrayList<String>();
+		List<String> errorCodes = new ArrayList<>();
 		while(attempt > 0) {
 			HttpURLConnection uniprotConnection = openURLConnection(uniprot);
 			int statusCode = uniprotConnection.getResponseCode();
@@ -775,7 +775,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 */
 	@Override
 	public ArrayList<String> getKeyWords() {
-		ArrayList<String> keyWordsList = new ArrayList<String>();
+		ArrayList<String> keyWordsList = new ArrayList<>();
 		if (uniprotDoc == null) {
 			return keyWordsList;
 		}
@@ -789,7 +789,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 			}
 		} catch (XPathExpressionException e) {
 			logger.error("Problems while parsing keywords in UniProt XML: {}. No keywords will be available.",e.getMessage());
-			return new ArrayList<String>();
+			return new ArrayList<>();
 		}
 
 		return keyWordsList;
@@ -815,7 +815,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 				String id = element.getAttribute("id");
 				List<DBReferenceInfo> idlist = databaseReferencesHashMap.get(type);
 				if (idlist == null) {
-					idlist = new ArrayList<DBReferenceInfo>();
+					idlist = new ArrayList<>();
 					databaseReferencesHashMap.put(type, idlist);
 				}
 				DBReferenceInfo dbreferenceInfo = new DBReferenceInfo(type, id);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/InsdcParser.java
@@ -153,7 +153,7 @@ public class InsdcParser {
 
 	private List<Location> parseLocationString(String string, int versus) {
 		Matcher m;
-		List<Location> boundedLocationsCollection = new ArrayList<Location>();
+		List<Location> boundedLocationsCollection = new ArrayList<>();
 
 		List<String> tokens = splitString(string);
 		for (String t : tokens) {
@@ -272,7 +272,7 @@ public class InsdcParser {
 
 
 	private List<String> splitString(String input) {
-		List<String> result = new ArrayList<String>();
+		List<String> result = new ArrayList<>();
 		int start = 0;
 		int openedParenthesis = 0;
 		for (int current = 0; current < input.length(); current++) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/LocationHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/LocationHelper.java
@@ -153,7 +153,7 @@ public class LocationHelper {
 			end = (length * (numberOfPasses + 1)) + modEnd;
 		}
 
-		List<Location> locations = new ArrayList<Location>();
+		List<Location> locations = new ArrayList<>();
 		locations.add(new SimpleLocation(modStart, length, strand));
 		for (int i = 0; i < numberOfPasses; i++) {
 			locations.add(new SimpleLocation(1, length, strand));
@@ -283,7 +283,7 @@ public class LocationHelper {
 	 * @return Returns a boolean indicating if this is consistently accessioned
 	 */
 	public static boolean consistentAccessions(List<Location> subLocations) {
-		Set<AccessionID> set = new HashSet<AccessionID>();
+		Set<AccessionID> set = new HashSet<>();
 		for(Location sub: subLocations) {
 			set.add(sub.getAccession());
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/template/AbstractLocation.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/template/AbstractLocation.java
@@ -224,7 +224,7 @@ public abstract class AbstractLocation implements Serializable, Location {
 			list = getSubLocations();
 		}
 		else {
-			list = new ArrayList<Location>();
+			list = new ArrayList<>();
 			list.add(this);
 		}
 		return list.iterator();
@@ -245,7 +245,7 @@ public abstract class AbstractLocation implements Serializable, Location {
 	 * Here to allow for recursion
 	 */
 	private List<Location> getAllSubLocations(Location location) {
-		List<Location> flatSubLocations = new ArrayList<Location>();
+		List<Location> flatSubLocations = new ArrayList<>();
 		for (Location l : location.getSubLocations()) {
 			if (l.isComplex()) {
 				flatSubLocations.addAll(getAllSubLocations(l));
@@ -312,11 +312,11 @@ public abstract class AbstractLocation implements Serializable, Location {
 	@Override
 	public <C extends Compound> Sequence<C> getSubSequence(Sequence<C> sequence) {
 		if(isCircular()) {
-			List<Sequence<C>> sequences = new ArrayList<Sequence<C>>();
+			List<Sequence<C>> sequences = new ArrayList<>();
 			for(Location l: this) {
 				sequences.add(l.getSubSequence(sequence));
 			}
-			return new JoiningSequenceReader<C>(sequence.getCompoundSet(), sequences);
+			return new JoiningSequenceReader<>(sequence.getCompoundSet(), sequences);
 		}
 		return reverseSequence(sequence.getSubSequence(
 				getStart().getPosition(), getEnd().getPosition()));
@@ -328,11 +328,11 @@ public abstract class AbstractLocation implements Serializable, Location {
 
 	@Override
 	public <C extends Compound> Sequence<C> getRelevantSubSequence(Sequence<C> sequence) {
-		List<Sequence<C>> sequences = new ArrayList<Sequence<C>>();
+		List<Sequence<C>> sequences = new ArrayList<>();
 		for(Location l: getRelevantSubLocations()) {
 			sequences.add(l.getSubSequence(sequence));
 		}
-		return new JoiningSequenceReader<C>(sequence.getCompoundSet(), sequences);
+		return new JoiningSequenceReader<>(sequence.getCompoundSet(), sequences);
 	}
 
 	/**
@@ -346,12 +346,12 @@ public abstract class AbstractLocation implements Serializable, Location {
 			return sequence;
 		}
 
-		Sequence<C> reversed = new ReversedSequenceView<C>(sequence);
+		Sequence<C> reversed = new ReversedSequenceView<>(sequence);
 		// "safe" operation as we have tried to check this
 		if(canComplement(sequence)) {
 			Sequence<ComplementCompound> casted = (Sequence<ComplementCompound>) reversed;
 			ComplementSequenceView<ComplementCompound> complement =
-					new ComplementSequenceView<ComplementCompound>(casted);
+					new ComplementSequenceView<>(casted);
 			return (Sequence<C>)complement;
 		}
 		return reversed;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/template/Location.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/location/template/Location.java
@@ -206,7 +206,7 @@ public interface Location extends Iterable<Location>, Accessioned {
 				end = (length * (numberOfPasses + 1)) + modEnd;
 			}
 
-			List<Location> locations = new ArrayList<Location>();
+			List<Location> locations = new ArrayList<>();
 			locations.add(new SimpleLocation(modStart, length, strand));
 			for (int i = 0; i < numberOfPasses; i++) {
 				locations.add(new SimpleLocation(1, length, strand));

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/ArrayListSequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/ArrayListSequenceReader.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class ArrayListSequenceReader<C extends Compound> implements SequenceReader<C> {
 
 	private CompoundSet<C> compoundSet;
-	private ArrayList<C> parsedCompounds = new ArrayList<C>();
+	private ArrayList<C> parsedCompounds = new ArrayList<>();
 
 	private volatile Integer hashcode = null;
 
@@ -95,7 +95,7 @@ public class ArrayListSequenceReader<C extends Compound> implements SequenceRead
 	 */
 	public String getSequenceAsString(Integer begin, Integer end, Strand strand) {
 		// TODO Optimise/cache.
-		SequenceAsStringHelper<C> sequenceAsStringHelper = new SequenceAsStringHelper<C>();
+		SequenceAsStringHelper<C> sequenceAsStringHelper = new SequenceAsStringHelper<>();
 		return sequenceAsStringHelper.getSequenceAsString(this.parsedCompounds, compoundSet, begin, end, strand);
 	}
 
@@ -232,7 +232,7 @@ public class ArrayListSequenceReader<C extends Compound> implements SequenceRead
 	 */
 	@Override
 	public SequenceView<C> getSubSequence(final Integer bioBegin, final Integer bioEnd) {
-		return new SequenceProxyView<C>(ArrayListSequenceReader.this, bioBegin, bioEnd);
+		return new SequenceProxyView<>(ArrayListSequenceReader.this, bioBegin, bioEnd);
 	}
 
 	/**

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/FourBitSequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/FourBitSequenceReader.java
@@ -114,7 +114,7 @@ public class FourBitSequenceReader<C extends Compound> extends BitSequenceReader
 		@Override
 		protected Map<C, Integer> generateCompoundsToIndex() {
 			final CompoundSet<C> cs = getCompoundSet();
-			Map<C, Integer> map = new HashMap<C, Integer>();
+			Map<C, Integer> map = new HashMap<>();
 			int index = 0;
 			for (C currentCompound : sortedCompounds(cs)) {
 				C upperCasedCompound = getOptionalUpperCasedCompound(currentCompound, cs);
@@ -143,7 +143,7 @@ public class FourBitSequenceReader<C extends Compound> extends BitSequenceReader
 		}
 
 		private List<C> sortedCompounds(final CompoundSet<C> cs) {
-			List<C> compounds = new ArrayList<C>(cs.getAllCompounds());
+			List<C> compounds = new ArrayList<>(cs.getAllCompounds());
 			Collections.sort(compounds, new Comparator<C>() {
 
 
@@ -165,7 +165,7 @@ public class FourBitSequenceReader<C extends Compound> extends BitSequenceReader
 		protected List<C> generateIndexToCompounds() {
 			CompoundSet<C> cs = getCompoundSet();
 			Map<C, Integer> lookup = getCompoundsToIndexLookup();
-			Map<Integer, C> tempMap = new HashMap<Integer, C>();
+			Map<Integer, C> tempMap = new HashMap<>();
 			//First get the reverse lookup working
 			for (C compound : lookup.keySet()) {
 				C upperCasedCompound = getOptionalUpperCasedCompound(compound, cs);
@@ -174,8 +174,8 @@ public class FourBitSequenceReader<C extends Compound> extends BitSequenceReader
 			}
 
 			//Then populate the results by going back through the sorted integer keys
-			List<C> compounds = new ArrayList<C>();
-			List<Integer> keys = new ArrayList<Integer>(tempMap.keySet());
+			List<C> compounds = new ArrayList<>();
+			List<Integer> keys = new ArrayList<>(tempMap.keySet());
 			Collections.sort(keys);
 			for (Integer key : keys) {
 				compounds.add(tempMap.get(key));

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/JoiningSequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/JoiningSequenceReader.java
@@ -86,7 +86,7 @@ public class JoiningSequenceReader<C extends Compound> implements ProxySequenceR
 	}
 
 	private List<Sequence<C>> grepSequences(List<Sequence<C>> sequences) {
-		List<Sequence<C>> seqs = new ArrayList<Sequence<C>>();
+		List<Sequence<C>> seqs = new ArrayList<>();
 		for (Sequence<C> s : sequences) {
 			if (s.getLength() != 0) {
 				seqs.add(s);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/SingleCompoundSequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/SingleCompoundSequenceReader.java
@@ -146,7 +146,7 @@ public class SingleCompoundSequenceReader<C extends Compound> implements ProxySe
 
 	@Override
 	public SequenceView<C> getSubSequence(Integer start, Integer end) {
-		return new SequenceProxyView<C>(this, start, end);
+		return new SequenceProxyView<>(this, start, end);
 	}
 
 	/**
@@ -182,7 +182,7 @@ public class SingleCompoundSequenceReader<C extends Compound> implements ProxySe
 
 	@Override
 	public Iterator<C> iterator() {
-		return new SequenceMixin.SequenceIterator<C>(this);
+		return new SequenceMixin.SequenceIterator<>(this);
 	}
 
 	@Override

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/TwoBitSequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/storage/TwoBitSequenceReader.java
@@ -133,7 +133,7 @@ public class TwoBitSequenceReader<C extends NucleotideCompound> extends BitSeque
 		@Override
 		protected List<C> generateIndexToCompounds() {
 			CompoundSet<C> cs = getCompoundSet();
-			List<C> result = new ArrayList<C>();
+			List<C> result = new ArrayList<>();
 			result.add( cs.getCompoundForString("T"));
 
 			result.add( cs.getCompoundForString("C"));

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractCompoundSet.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractCompoundSet.java
@@ -39,11 +39,11 @@ public abstract class AbstractCompoundSet<C extends Compound> implements Compoun
 
 	private final static Logger logger = LoggerFactory.getLogger(AbstractCompoundSet.class);
 
-	private Map<CharSequence, C> charSeqToCompound = new HashMap<CharSequence, C>();
+	private Map<CharSequence, C> charSeqToCompound = new HashMap<>();
 	private int maxCompoundCharSequenceLength = -1;
 	private Boolean compoundStringLengthEqual = null;
 
-	Map<C,Set<C>> equivalentsMap = new HashMap<C, Set<C>>();
+	Map<C,Set<C>> equivalentsMap = new HashMap<>();
 
 	protected void addCompound(C compound, C lowerCasedCompound, Iterable<C> equivalents) {
 		addCompound(compound);
@@ -61,7 +61,7 @@ public abstract class AbstractCompoundSet<C extends Compound> implements Compoun
 	}
 
 	protected void addCompound(C compound, C lowerCasedCompound, C... equivalents) {
-		List<C> equiv = new ArrayList<C>(equivalents.length);
+		List<C> equiv = new ArrayList<>(equivalents.length);
 		equiv.addAll(Arrays.asList(equivalents));
 		addCompound(compound, lowerCasedCompound, equiv);
 	}
@@ -69,7 +69,7 @@ public abstract class AbstractCompoundSet<C extends Compound> implements Compoun
 	protected void addEquivalent(C compound, C equivalent) {
 	 Set<C> s = equivalentsMap.get(compound);
 	 if ( s == null){
-		 s = new HashSet<C>();
+		 s = new HashSet<>();
 		 equivalentsMap.put(compound, s);
 	 }
 
@@ -170,7 +170,7 @@ public Set<C> getEquivalentCompounds(C compound) {
 
 	@Override
 public List<C> getAllCompounds() {
-		return new ArrayList<C>(charSeqToCompound.values());
+		return new ArrayList<>(charSeqToCompound.values());
 	}
 
 	private void assertCompound(C compound) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractCompoundTranslator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractCompoundTranslator.java
@@ -37,7 +37,7 @@ public abstract class AbstractCompoundTranslator<F extends Compound, T extends C
 	public AbstractCompoundTranslator(SequenceCreatorInterface<T> creator,
 			CompoundSet<F> fromCompoundSet, CompoundSet<T> toCompoundSet) {
 		this.creator = creator;
-		this.mapper = new HashMap<F, List<T>>();
+		this.mapper = new HashMap<>();
 		this.fromCompoundSet = fromCompoundSet;
 		this.toCompoundSet = toCompoundSet;
 	}
@@ -66,7 +66,7 @@ public abstract class AbstractCompoundTranslator<F extends Compound, T extends C
 
 	 List<T> l = mapper.get(source);
 	 if ( l == null) {
-		 l = new ArrayList<T>();
+		 l = new ArrayList<>();
 		 mapper.put(source, l);
 	 }
 		 l.addAll(Arrays.asList(targets));
@@ -97,7 +97,7 @@ public abstract class AbstractCompoundTranslator<F extends Compound, T extends C
 
 		@Override
 	public List<Sequence<T>> createSequences(Sequence<F> originalSequence) {
-		List<List<T>> workingList = new ArrayList<List<T>>();
+		List<List<T>> workingList = new ArrayList<>();
 		for (F source : originalSequence) {
 			List<T> compounds = translateMany(source);
 
@@ -126,7 +126,7 @@ public abstract class AbstractCompoundTranslator<F extends Compound, T extends C
 
 	protected void addCompoundsToList(List<T> compounds, List<List<T>> workingList) {
 		int size = compounds.size();
-		List<List<T>> currentWorkingList = new ArrayList<List<T>>();
+		List<List<T>> currentWorkingList = new ArrayList<>();
 		for (int i = 0; i < size; i++) {
 			boolean last = (i == (size - 1));
 			// If last run we add the compound to the top set of lists & then
@@ -147,7 +147,7 @@ public abstract class AbstractCompoundTranslator<F extends Compound, T extends C
 	}
 
 	protected List<Sequence<T>> workingListToSequences(List<List<T>> workingList) {
-		List<Sequence<T>> sequences = new ArrayList<Sequence<T>>();
+		List<Sequence<T>> sequences = new ArrayList<>();
 		for (List<T> seqList : workingList) {
 			sequences.add(getCreator().getSequence(seqList));
 		}
@@ -155,7 +155,7 @@ public abstract class AbstractCompoundTranslator<F extends Compound, T extends C
 	}
 
 	private List<List<T>> duplicateList(List<List<T>> incoming) {
-		List<List<T>> outgoing = new ArrayList<List<T>>();
+		List<List<T>> outgoing = new ArrayList<>();
 		for (List<T> current : incoming) {
 			outgoing.add(new ArrayList<T>(current));
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractNucleotideCompoundSet.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractNucleotideCompoundSet.java
@@ -46,7 +46,7 @@ public abstract class AbstractNucleotideCompoundSet<C extends NucleotideCompound
 		C upper = newNucleotideCompound(base.toUpperCase(), complement.toUpperCase(), upperEquivalents);
 		C lower = newNucleotideCompound(base.toLowerCase(), complement.toLowerCase(), lowerEquivalents);
 
-		List<C> equivalentCompounds = new ArrayList<C>();
+		List<C> equivalentCompounds = new ArrayList<>();
 
 		for(int i=0; i<equivalents.length; i++) {
 			equivalentCompounds.add(getCompoundForString(upperEquivalents[i]));
@@ -65,7 +65,7 @@ public abstract class AbstractNucleotideCompoundSet<C extends NucleotideCompound
 	 */
 	@SuppressWarnings("unchecked")
 	protected void calculateIndirectAmbiguities() {
-		Map<NucleotideCompound, List<NucleotideCompound>> equivalentsMap = new HashMap<NucleotideCompound, List<NucleotideCompound>>();
+		Map<NucleotideCompound, List<NucleotideCompound>> equivalentsMap = new HashMap<>();
 
 		List<NucleotideCompound> ambiguousCompounds = getAllCompounds().stream()		 
                                                                                .filter(compound -> compound.isAmbiguous())
@@ -116,7 +116,7 @@ public abstract class AbstractNucleotideCompoundSet<C extends NucleotideCompound
 
 			List<NucleotideCompound> listS = equivalentsMap.get(key);
 			if ( listS == null){
-				listS = new ArrayList<NucleotideCompound>();
+				listS = new ArrayList<>();
 				equivalentsMap.put(key, listS);
 			}
 			listS.add(value);
@@ -137,7 +137,7 @@ private NucleotideCompound toLowerCase(NucleotideCompound compound) {
 	 * @return The ambiguity symbol which represents this set of nucleotides best
 	 */
 	public NucleotideCompound getAmbiguity(NucleotideCompound... compounds) {
-		Set<NucleotideCompound> settedCompounds = new HashSet<NucleotideCompound>();
+		Set<NucleotideCompound> settedCompounds = new HashSet<>();
 		for(NucleotideCompound compound: compounds) {
 			for(NucleotideCompound subCompound: compound.getConstituents()) {
 				settedCompounds.add(getCompoundForString(subCompound.getBase().toUpperCase()));

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractSequence.java
@@ -65,15 +65,15 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	private Integer bioEnd = null;
 	private AbstractSequence<?> parentSequence = null;
 	private String source = null;
-	private ArrayList<String> notesList = new ArrayList<String>();
+	private ArrayList<String> notesList = new ArrayList<>();
 	private Double sequenceScore = null;
 	private FeaturesKeyWordInterface featuresKeyWord = null;
 	private DatabaseReferenceInterface databaseReferences = null;
 	private FeatureRetriever featureRetriever = null;
 	private ArrayList<FeatureInterface<AbstractSequence<C>, C>> features =
-			new ArrayList<FeatureInterface<AbstractSequence<C>, C>>();
+			new ArrayList<>();
 	private LinkedHashMap<String, ArrayList<FeatureInterface<AbstractSequence<C>, C>>> groupedFeatures =
-			new LinkedHashMap<String, ArrayList<FeatureInterface<AbstractSequence<C>, C>>>();
+			new LinkedHashMap<>();
 	private List<String> comments = new ArrayList<>();
 	private List<AbstractReference> references;
 
@@ -93,7 +93,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 
 	//  so it can be called from subclass constructors
 	protected void initSequenceStorage(String seqString) throws CompoundNotFoundException {
-		sequenceStorage = new ArrayListSequenceReader<C>();
+		sequenceStorage = new ArrayListSequenceReader<>();
 		sequenceStorage.setCompoundSet(this.getCompoundSet());
 		sequenceStorage.setContents(seqString);
 	}
@@ -354,7 +354,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	 */
 	public List<FeatureInterface<AbstractSequence<C>, C>> getFeatures(String featureType, int bioSequencePosition) {
 		ArrayList<FeatureInterface<AbstractSequence<C>, C>> featureHits =
-				new ArrayList<FeatureInterface<AbstractSequence<C>, C>>();
+				new ArrayList<>();
 		List<FeatureInterface<AbstractSequence<C>, C>> features = getFeaturesByType(featureType);
 		if (features != null) {
 			for (FeatureInterface<AbstractSequence<C>, C> feature : features) {
@@ -373,7 +373,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	 */
 	public List<FeatureInterface<AbstractSequence<C>, C>> getFeatures(int bioSequencePosition) {
 		ArrayList<FeatureInterface<AbstractSequence<C>, C>> featureHits =
-				new ArrayList<FeatureInterface<AbstractSequence<C>, C>>();
+				new ArrayList<>();
 		if (features != null) {
 			for (FeatureInterface<AbstractSequence<C>, C> feature : features) {
 				if (bioSequencePosition >= feature.getLocations().getStart().getPosition() && bioSequencePosition <= feature.getLocations().getEnd().getPosition()) {
@@ -401,7 +401,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	 */
 	public void addFeature(int bioStart, int bioEnd, FeatureInterface<AbstractSequence<C>, C> feature) {
 		SequenceLocation<AbstractSequence<C>, C> sequenceLocation =
-				new SequenceLocation<AbstractSequence<C>, C>(bioStart, bioEnd, this);
+				new SequenceLocation<>(bioStart, bioEnd, this);
 		feature.setLocation(sequenceLocation);
 		addFeature(feature);
 	}
@@ -416,7 +416,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 		features.add(feature);
 		ArrayList<FeatureInterface<AbstractSequence<C>, C>> featureList = groupedFeatures.get(feature.getType());
 		if (featureList == null) {
-			featureList = new ArrayList<FeatureInterface<AbstractSequence<C>, C>>();
+			featureList = new ArrayList<>();
 			groupedFeatures.put(feature.getType(), featureList);
 		}
 		featureList.add(feature);
@@ -447,7 +447,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	public List<FeatureInterface<AbstractSequence<C>, C>> getFeaturesByType(String type) {
 		List<FeatureInterface<AbstractSequence<C>, C>> features = groupedFeatures.get(type);
 		if (features == null) {
-			features = new ArrayList<FeatureInterface<AbstractSequence<C>, C>>();
+			features = new ArrayList<>();
 		}
 		return features;
 	}
@@ -609,7 +609,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 			//return parentSequence.getSequenceStorage();
 
 			if ( this.compoundSet.equals(parentSequence.getCompoundSet())){
-				sequenceStorage = new ArrayListSequenceReader<C>();
+				sequenceStorage = new ArrayListSequenceReader<>();
 				sequenceStorage.setCompoundSet(this.getCompoundSet());
 				try {
 					sequenceStorage.setContents(parentSequence.getSequenceAsString());
@@ -706,7 +706,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	 */
 	@Override
 	public SequenceView<C> getSubSequence(final Integer bioStart, final Integer bioEnd) {
-		return new SequenceProxyView<C>(this, bioStart, bioEnd);
+		return new SequenceProxyView<>(this, bioStart, bioEnd);
 	}
 
 	/**

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/SequenceMixin.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/SequenceMixin.java
@@ -113,7 +113,7 @@ public class SequenceMixin {
 	 * sequence. Any compound not in the Map will return a fraction of 0.
 	 */
 	public static <C extends Compound> Map<C, Double> getDistribution(Sequence<C> sequence) {
-		Map<C, Double> results = new HashMap<C, Double>();
+		Map<C, Double> results = new HashMap<>();
 		Map<C, Integer> composition = getComposition(sequence);
 		double length = sequence.getLength();
 		for (Map.Entry<C, Integer> entry : composition.entrySet()) {
@@ -133,7 +133,7 @@ public class SequenceMixin {
 	 * @return Counts for the instances of all compounds in the sequence
 	 */
 	public static <C extends Compound> Map<C, Integer> getComposition(Sequence<C> sequence) {
-		Map<C, Integer> results = new HashMap<C, Integer>();
+		Map<C, Integer> results = new HashMap<>();
 
 		for (C currentCompound : sequence) {
 			Integer currentInteger = results.get(currentCompound);
@@ -187,7 +187,7 @@ public class SequenceMixin {
 	 * the Compounds of that {@link Sequence}.
 	 */
 	public static <C extends Compound> List<C> toList(Sequence<C> sequence) {
-		List<C> list = new ArrayList<C>(sequence.getLength());
+		List<C> list = new ArrayList<>(sequence.getLength());
 		for (C compound : sequence) {
 			list.add(compound);
 		}
@@ -229,7 +229,7 @@ public class SequenceMixin {
 	 */
 	public static <C extends Compound> Iterator<C> createIterator(
 			Sequence<C> sequence) {
-		return new SequenceIterator<C>(sequence);
+		return new SequenceIterator<>(sequence);
 	}
 
 	/**
@@ -237,7 +237,7 @@ public class SequenceMixin {
 	 */
 	public static <C extends Compound> SequenceView<C> createSubSequence(
 			Sequence<C> sequence, int start, int end) {
-		return new SequenceProxyView<C>(sequence, start, end);
+		return new SequenceProxyView<>(sequence, start, end);
 	}
 
 	/**
@@ -250,7 +250,7 @@ public class SequenceMixin {
 	public static <C extends Compound> Sequence<C> shuffle(Sequence<C> sequence) {
 		List<C> compounds = sequence.getAsList();
 		Collections.shuffle(compounds);
-		return new ArrayListSequenceReader<C>(compounds,
+		return new ArrayListSequenceReader<>(compounds,
 				sequence.getCompoundSet());
 	}
 
@@ -275,8 +275,8 @@ public class SequenceMixin {
 	 * @return The list of non-overlapping K-mers
 	 */
 	public static <C extends Compound> List<SequenceView<C>> nonOverlappingKmers(Sequence<C> sequence, int kmer) {
-		List<SequenceView<C>> l = new ArrayList<SequenceView<C>>();
-		WindowedSequence<C> w = new WindowedSequence<C>(sequence, kmer);
+		List<SequenceView<C>> l = new ArrayList<>();
+		WindowedSequence<C> w = new WindowedSequence<>(sequence, kmer);
 		for(SequenceView<C> view: w) {
 			l.add(view);
 		}
@@ -293,9 +293,9 @@ public class SequenceMixin {
 	 * @return The list of overlapping K-mers
 	 */
 	public static <C extends Compound> List<SequenceView<C>> overlappingKmers(Sequence<C> sequence, int kmer) {
-		List<SequenceView<C>> l = new ArrayList<SequenceView<C>>();
+		List<SequenceView<C>> l = new ArrayList<>();
 		List<Iterator<SequenceView<C>>> windows
-				= new ArrayList<Iterator<SequenceView<C>>>();
+				= new ArrayList<>();
 
 		for(int i=1; i<=kmer; i++) {
 			if(i == 1) {
@@ -333,7 +333,7 @@ public class SequenceMixin {
 	 */
 	@SuppressWarnings({ "unchecked" })
 	public static <C extends Compound> SequenceView<C> inverse(Sequence<C> sequence) {
-		SequenceView<C> reverse = new ReversedSequenceView<C>(sequence);
+		SequenceView<C> reverse = new ReversedSequenceView<>(sequence);
 		if(sequence.getCompoundSet().isComplementable()) {
 			return new ComplementSequenceView(reverse);
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/SequenceProxyView.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/SequenceProxyView.java
@@ -117,12 +117,12 @@ public class SequenceProxyView<C extends Compound> implements SequenceView<C> {
 
 	@Override
 	public SequenceView<C> getSubSequence(final Integer bioStart, final Integer bioEnd) {
-		return new SequenceProxyView<C>(this, bioStart, bioEnd);
+		return new SequenceProxyView<>(this, bioStart, bioEnd);
 	}
 
 	@Override
 	public Iterator<C> iterator() {
-		return new SequenceMixin.SequenceIterator<C>(this);
+		return new SequenceMixin.SequenceIterator<>(this);
 	}
 
 	@Override

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/transcription/DNAToRNATranslator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/transcription/DNAToRNATranslator.java
@@ -65,7 +65,7 @@ public class DNAToRNATranslator extends AbstractCompoundTranslator<NucleotideCom
 		@Override
 		public List<Sequence<NucleotideCompound>> createSequences(Sequence<NucleotideCompound> originalSequence) {
 				if(shortCutTranslation) {
-						List<Sequence<NucleotideCompound>> result = new ArrayList<Sequence<NucleotideCompound>>(1);
+						List<Sequence<NucleotideCompound>> result = new ArrayList<>(1);
 						result.add(wrapToRna(originalSequence));
 						return result;
 				}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/transcription/Frame.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/transcription/Frame.java
@@ -83,7 +83,7 @@ public enum Frame {
 	public <C extends NucleotideCompound> Sequence<C> wrap(Sequence<C> incoming) {
 		Sequence<C> reversed;
 		if(reverse) {
-			reversed = new ComplementSequenceView<C>(new ReversedSequenceView<C>(incoming));
+			reversed = new ComplementSequenceView<>(new ReversedSequenceView<C>(incoming));
 		}
 		else {
 			reversed = incoming;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/transcription/RNAToAminoAcidTranslator.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/transcription/RNAToAminoAcidTranslator.java
@@ -81,9 +81,9 @@ public class RNAToAminoAcidTranslator extends
 		this.initMetOnly = initMetOnly;
 		this.translateNCodons = translateNCodons;
 
-		quickLookup = new HashMap<Table.CaseInsensitiveTriplet, Codon>(codons
+		quickLookup = new HashMap<>(codons
 				.getAllCompounds().size());
-		aminoAcidToCodon = new HashMap<AminoAcidCompound, List<Codon>>();
+		aminoAcidToCodon = new HashMap<>();
 
 		List<Codon> codonList = table.getCodons(nucleotides, aminoAcids);
 		for (Codon codon : codonList) {
@@ -92,7 +92,7 @@ public class RNAToAminoAcidTranslator extends
 
 			List<Codon> codonL = aminoAcidToCodon.get(codon.getAminoAcid());
 			if (codonL == null) {
-				codonL = new ArrayList<Codon>();
+				codonL = new ArrayList<>();
 				aminoAcidToCodon.put(codon.getAminoAcid(), codonL);
 			}
 			codonL.add(codon);
@@ -114,7 +114,7 @@ public class RNAToAminoAcidTranslator extends
 	public List<Sequence<AminoAcidCompound>> createSequences(
 			Sequence<NucleotideCompound> originalSequence) {
 
-		List<List<AminoAcidCompound>> workingList = new ArrayList<List<AminoAcidCompound>>();
+		List<List<AminoAcidCompound>> workingList = new ArrayList<>();
 
 		Iterable<SequenceView<NucleotideCompound>> iter = new WindowedSequence<NucleotideCompound>(
 				originalSequence, 3);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/transcription/TranscriptionEngine.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/transcription/TranscriptionEngine.java
@@ -125,7 +125,7 @@ public class TranscriptionEngine {
 	 */
 	public Map<Frame, Sequence<AminoAcidCompound>> multipleFrameTranslation(
 			Sequence<NucleotideCompound> dna, Frame... frames) {
-		Map<Frame, Sequence<AminoAcidCompound>> results = new EnumMap<Frame, Sequence<AminoAcidCompound>>(
+		Map<Frame, Sequence<AminoAcidCompound>> results = new EnumMap<>(
 				Frame.class);
 		for (Frame frame : frames) {
 			Sequence<NucleotideCompound> rna = getDnaRnaTranslator()

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/views/RnaSequenceView.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/views/RnaSequenceView.java
@@ -90,9 +90,9 @@ public class RnaSequenceView extends SequenceProxyView<NucleotideCompound> imple
 
 	protected void buildTranslators() {
 		Map<NucleotideCompound, NucleotideCompound> localDnaToRna =
-				new HashMap<NucleotideCompound, NucleotideCompound>();
+				new HashMap<>();
 		Map<NucleotideCompound, NucleotideCompound> localRnaToDna =
-				new HashMap<NucleotideCompound, NucleotideCompound>();
+				new HashMap<>();
 
 		NucleotideCompound thymine =
 				getViewedSequence().getCompoundSet().getCompoundForString("T");

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/FlatFileCache.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/FlatFileCache.java
@@ -48,7 +48,7 @@ public class FlatFileCache {
 	/**
 	 * The cache singleton.
 	 */
-	private static SoftHashMap<String, byte[]> cache = new SoftHashMap<String, byte[]>(0);
+	private static SoftHashMap<String, byte[]> cache = new SoftHashMap<>(0);
 
 
 	// no public constructor;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/PrettyXMLWriter.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/PrettyXMLWriter.java
@@ -41,10 +41,10 @@ public class PrettyXMLWriter implements XMLWriter {
 	private boolean afterNewline = true;
 	private int indent = 0;
 
-	private Map<String, String> namespacePrefixes = new HashMap<String, String>();
+	private Map<String, String> namespacePrefixes = new HashMap<>();
 	private int namespaceSeed = 0;
-	private LinkedList<List<String>> namespaceBindings = new LinkedList<List<String>>();
-	private List<String> namespacesDeclared = new ArrayList<String>();
+	private LinkedList<List<String>> namespaceBindings = new LinkedList<>();
+	private List<String> namespacesDeclared = new ArrayList<>();
 
 	public PrettyXMLWriter(PrintWriter writer) {
 		this.writer = writer;
@@ -113,7 +113,7 @@ public class PrettyXMLWriter implements XMLWriter {
 		namespacePrefixes.put(nsURI, prefix);
 		List<String> bindings = namespaceBindings.getLast();
 		if (bindings == null) {
-			bindings = new ArrayList<String>();
+			bindings = new ArrayList<>();
 			namespaceBindings.removeLast();
 			namespaceBindings.add(bindings);
 		}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
@@ -190,7 +190,7 @@ public class SingleLinkageClusterer {
 	private void updateIndicesToCheck(int m) {
 
 		if (indicesToCheck==null) {
-			indicesToCheck = new ArrayList<Integer>(numItems);
+			indicesToCheck = new ArrayList<>(numItems);
 
 			for (int i=0;i<numItems;i++) {
 				indicesToCheck.add(i);
@@ -250,7 +250,7 @@ public class SingleLinkageClusterer {
 			clusterIt();
 		}
 
-		Map<Integer, Set<Integer>> clusters = new TreeMap<Integer, Set<Integer>>();
+		Map<Integer, Set<Integer>> clusters = new TreeMap<>();
 
 		int clusterId = 1;
 
@@ -276,7 +276,7 @@ public class SingleLinkageClusterer {
 
 				if (firstClusterId==-1 && secondClusterId==-1) {
 					// neither member is in a cluster yet, let's assign a new cluster and put them both in
-					Set<Integer> members = new TreeSet<Integer>();
+					Set<Integer> members = new TreeSet<>();
 					members.add(dendrogram[i].getFirst());
 					members.add(dendrogram[i].getSecond());
 					clusters.put(clusterId, members);
@@ -319,7 +319,7 @@ public class SingleLinkageClusterer {
 		}
 
 		// reassigning cluster numbers by creating a new map (there can be gaps in the numbering if cluster-joining happened)
-		Map<Integer,Set<Integer>> finalClusters = new TreeMap<Integer, Set<Integer>>();
+		Map<Integer,Set<Integer>> finalClusters = new TreeMap<>();
 		int newClusterId = 1;
 		for (int oldClusterId:clusters.keySet()) {
 			finalClusters.put(newClusterId, clusters.get(oldClusterId));
@@ -336,7 +336,7 @@ public class SingleLinkageClusterer {
 				}
 			}
 			if (!isAlreadyClustered) {
-				Set<Integer> members = new TreeSet<Integer>();
+				Set<Integer> members = new TreeSet<>();
 				members.add(i);
 				finalClusters.put(newClusterId, members);
 				newClusterId++;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/SoftHashMap.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/SoftHashMap.java
@@ -46,16 +46,16 @@ public class SoftHashMap<K, V> extends AbstractMap<K, V> {
 	public static final int DEFAULT_LIMIT = 1;
 
 	/** The internal HashMap that stores SoftReference to actual data. */
-	private final Map<K, SoftReference<V>> map = new HashMap<K, SoftReference<V>>();
+	private final Map<K, SoftReference<V>> map = new HashMap<>();
 
 	/** Maximum Number of references you dont want GC to collect. */
 	private final int max_limit;
 
 	/** The FIFO list of hard references, order of last access. */
-	private final LinkedList<V> hardCache = new LinkedList<V>();
+	private final LinkedList<V> hardCache = new LinkedList<>();
 
 	/** Reference queue for cleared SoftReference objects. */
-	private final ReferenceQueue<V> queue = new ReferenceQueue<V>();
+	private final ReferenceQueue<V> queue = new ReferenceQueue<>();
 
 	public SoftHashMap() {
 		this(1000);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/XMLHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/XMLHelper.java
@@ -207,7 +207,7 @@ public class XMLHelper {
 	 * @throws XPathExpressionException
 	 */
 	public static ArrayList<Element> selectElements(Element element, String xpathExpression) throws XPathExpressionException {
-		ArrayList<Element> resultVector = new ArrayList<Element>();
+		ArrayList<Element> resultVector = new ArrayList<>();
 		if (element == null) {
 			return resultVector;
 		}

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/GeneFeatureHelper.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/GeneFeatureHelper.java
@@ -42,7 +42,7 @@ public class GeneFeatureHelper {
 	private static final Logger logger = LoggerFactory.getLogger(GeneFeatureHelper.class);
 
 	static public LinkedHashMap<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromUpperCaseExonFastaFile(File fastaSequenceFile, File uppercaseFastaFile, boolean throwExceptionGeneNotFound) throws Exception {
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = new LinkedHashMap<String, ChromosomeSequence>();
+		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = new LinkedHashMap<>();
 		LinkedHashMap<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
 		for (String accession : dnaSequenceList.keySet()) {
 			DNASequence contigSequence = dnaSequenceList.get(accession);
@@ -91,7 +91,7 @@ public class GeneFeatureHelper {
 						dnaSequence.getAccession().toString(), contigDNASequence.getAccession().toString(), bioStart, bioEnd, strand);
 				ChromosomeSequence chromosomeSequence = chromosomeSequenceList.get(accession);
 
-				ArrayList<Integer> exonBoundries = new ArrayList<Integer>();
+				ArrayList<Integer> exonBoundries = new ArrayList<>();
 
 				//look for transitions from lowercase to upper case
 				for (int i = 0; i < geneSequence.length(); i++) {
@@ -314,7 +314,7 @@ public class GeneFeatureHelper {
 	}
 
 	static public LinkedHashMap<String, ChromosomeSequence> getChromosomeSequenceFromDNASequence(LinkedHashMap<String, DNASequence> dnaSequenceList) {
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = new LinkedHashMap<String, ChromosomeSequence>();
+		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = new LinkedHashMap<>();
 		for (String key : dnaSequenceList.keySet()) {
 			DNASequence dnaSequence = dnaSequenceList.get(key);
 			ChromosomeSequence chromosomeSequence = new ChromosomeSequence(dnaSequence.getProxySequenceReader()); //we want the underlying sequence but don't need storage
@@ -836,7 +836,7 @@ public class GeneFeatureHelper {
 	}
 
 	static public LinkedHashMap<String, ProteinSequence> getProteinSequences(Collection<ChromosomeSequence> chromosomeSequences) throws Exception {
-		LinkedHashMap<String, ProteinSequence> proteinSequenceHashMap = new LinkedHashMap<String, ProteinSequence>();
+		LinkedHashMap<String, ProteinSequence> proteinSequenceHashMap = new LinkedHashMap<>();
 		for (ChromosomeSequence dnaSequence : chromosomeSequences) {
 			for (GeneSequence geneSequence : dnaSequence.getGeneSequences().values()) {
 				for (TranscriptSequence transcriptSequence : geneSequence.getTranscripts().values()) {
@@ -865,7 +865,7 @@ public class GeneFeatureHelper {
 	}
 
 	static public LinkedHashMap<String, GeneSequence> getGeneSequences(Collection<ChromosomeSequence> chromosomeSequences) throws Exception {
-		LinkedHashMap<String, GeneSequence> geneSequenceHashMap = new LinkedHashMap<String, GeneSequence>();
+		LinkedHashMap<String, GeneSequence> geneSequenceHashMap = new LinkedHashMap<>();
 		for (ChromosomeSequence chromosomeSequence : chromosomeSequences) {
 			for (GeneSequence geneSequence : chromosomeSequence.getGeneSequences().values()) {
 				geneSequenceHashMap.put(geneSequence.getAccession().getID(), geneSequence);

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/homology/BlastHomologyHits.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/homology/BlastHomologyHits.java
@@ -33,7 +33,7 @@ import java.util.LinkedHashMap;
 public class BlastHomologyHits {
 
 	static public LinkedHashMap<String, ArrayList<String>> getMatches(File xmlBlastHits, double ecutoff) throws Exception {
-		LinkedHashMap<String, ArrayList<String>> homologyHits = new LinkedHashMap<String, ArrayList<String>>();
+		LinkedHashMap<String, ArrayList<String>> homologyHits = new LinkedHashMap<>();
 		BlastXMLQuery blastXMLQuery = new BlastXMLQuery(xmlBlastHits.getAbsolutePath());
 		LinkedHashMap<String, ArrayList<String>> hits = blastXMLQuery.getHitsQueryDef(ecutoff);
 		for (String accessionid : hits.keySet()) {

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/homology/GFF3FromUniprotBlastHits.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/homology/GFF3FromUniprotBlastHits.java
@@ -79,7 +79,7 @@ public class GFF3FromUniprotBlastHits {
 				}
 				ArrayList<String> uniprotProteinHits = hits.get(accessionid);
 				String uniprotBestHit = uniprotProteinHits.get(0);
-				UniprotProxySequenceReader<AminoAcidCompound> uniprotSequence = new UniprotProxySequenceReader<AminoAcidCompound>(uniprotBestHit, AminoAcidCompoundSet.getAminoAcidCompoundSet());
+				UniprotProxySequenceReader<AminoAcidCompound> uniprotSequence = new UniprotProxySequenceReader<>(uniprotBestHit, AminoAcidCompoundSet.getAminoAcidCompoundSet());
 
 				ProteinSequence proteinSequence = new ProteinSequence(uniprotSequence);
 				String hitSequence = proteinSequence.getSequenceAsString();
@@ -89,7 +89,7 @@ public class GFF3FromUniprotBlastHits {
 					String predictedProteinSequence = transcriptSequence.getProteinSequence().getSequenceAsString();
 					ArrayList<ProteinSequence> cdsProteinList = transcriptSequence.getProteinCDSSequences();
 
-					ArrayList<CDSSequence> cdsSequenceList = new ArrayList<CDSSequence>(transcriptSequence.getCDSSequences().values());
+					ArrayList<CDSSequence> cdsSequenceList = new ArrayList<>(transcriptSequence.getCDSSequences().values());
 					String testSequence = "";
 					for (ProteinSequence cdsProteinSequence : cdsProteinList) {
 						testSequence = testSequence + cdsProteinSequence.getSequenceAsString();

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/io/fastq/FastqTools.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/io/fastq/FastqTools.java
@@ -133,7 +133,7 @@ public final class FastqTools
 		{
 			throw new IllegalArgumentException("fastq must not be null");
 		}
-		QualityFeature<AbstractSequence<NucleotideCompound>, NucleotideCompound> qualityScores = new QualityFeature<AbstractSequence<NucleotideCompound>, NucleotideCompound>("qualityScores", "sequencing");
+		QualityFeature<AbstractSequence<NucleotideCompound>, NucleotideCompound> qualityScores = new QualityFeature<>("qualityScores", "sequencing");
 		qualityScores.setQualities(toList(qualityScores(fastq)));
 		return qualityScores;
 	}
@@ -153,7 +153,7 @@ public final class FastqTools
 		{
 			throw new IllegalArgumentException("fastq must not be null");
 		}
-		QuantityFeature<AbstractSequence<NucleotideCompound>, NucleotideCompound> errorProbabilities = new QuantityFeature<AbstractSequence<NucleotideCompound>, NucleotideCompound>("errorProbabilities", "sequencing");
+		QuantityFeature<AbstractSequence<NucleotideCompound>, NucleotideCompound> errorProbabilities = new QuantityFeature<>("errorProbabilities", "sequencing");
 		errorProbabilities.setQuantities(toList(errorProbabilities(fastq)));
 		return errorProbabilities;
 	}

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/io/fastq/FastqVariant.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/io/fastq/FastqVariant.java
@@ -186,7 +186,7 @@ public enum FastqVariant
 
 
 	/** Map of FASTQ sequence format variants keyed by name and lowercase-with-dashes name. */
-	private static final Map<String, FastqVariant> FASTQ_VARIANTS = new HashMap<String, FastqVariant>(6);
+	private static final Map<String, FastqVariant> FASTQ_VARIANTS = new HashMap<>(6);
 
 	static
 	{

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/cytoband/CytobandParser.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/cytoband/CytobandParser.java
@@ -52,7 +52,7 @@ public class CytobandParser {
 		try {
 			SortedSet<Cytoband> cytobands = me.getAllCytobands(new URL(
 					DEFAULT_LOCATION));
-			SortedSet<StainType> types = new TreeSet<StainType>();
+			SortedSet<StainType> types = new TreeSet<>();
 			for (Cytoband c : cytobands) {
 				logger.info("Cytoband: {}", c);
 				if (!types.contains(c.getType()))
@@ -77,7 +77,7 @@ public class CytobandParser {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(
 				instream));
 		String line = null;
-		SortedSet<Cytoband> cytobands = new TreeSet<Cytoband>();
+		SortedSet<Cytoband> cytobands = new TreeSet<>();
 		while ((line = reader.readLine()) != null) {
 			String[] spl = line.split("\t");
 			if (spl.length != 5) {

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/geneid/GeneIDXMLReader.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/geneid/GeneIDXMLReader.java
@@ -51,7 +51,7 @@ public class GeneIDXMLReader {
 	}
 
 	public LinkedHashMap<String, ProteinSequence> getProteinSequences() throws Exception {
-		LinkedHashMap<String, ProteinSequence> proteinSequenceList = new LinkedHashMap<String, ProteinSequence>();
+		LinkedHashMap<String, ProteinSequence> proteinSequenceList = new LinkedHashMap<>();
 		ArrayList<Element> elementList = XMLHelper.selectElements(geneidDoc.getDocumentElement(), "prediction/gene/protein");
 		logger.info("{} hits", elementList.size());
 
@@ -68,7 +68,7 @@ public class GeneIDXMLReader {
 	}
 
 	public LinkedHashMap<String, DNASequence> getDNACodingSequences() throws Exception {
-		LinkedHashMap<String, DNASequence> dnaSequenceList = new LinkedHashMap<String, DNASequence>();
+		LinkedHashMap<String, DNASequence> dnaSequenceList = new LinkedHashMap<>();
 		ArrayList<Element> elementList = XMLHelper.selectElements(geneidDoc.getDocumentElement(), "prediction/gene/cDNA");
 		logger.info("{} hits", elementList.size());
 

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/genename/GeneChromosomePositionParser.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/genename/GeneChromosomePositionParser.java
@@ -79,7 +79,7 @@ public class GeneChromosomePositionParser {
 	public static List<GeneChromosomePosition> getChromosomeMappings(InputStream inStream) throws IOException {
 		BufferedReader reader = new BufferedReader(new InputStreamReader(inStream));
 
-		ArrayList<GeneChromosomePosition> gcps = new ArrayList<GeneChromosomePosition>();
+		ArrayList<GeneChromosomePosition> gcps = new ArrayList<>();
 
 		String line = null;
 		while ((line = reader.readLine()) != null) {
@@ -126,7 +126,7 @@ public class GeneChromosomePositionParser {
 
 	private static List<Integer> getIntegerList(String lst){
 		String[] spl = lst.split(",");
-		ArrayList<Integer> l = new ArrayList<Integer>();
+		ArrayList<Integer> l = new ArrayList<>();
 		for (String s : spl){
 			l.add(Integer.parseInt(s));
 		}

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/genename/GeneNamesParser.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/genename/GeneNamesParser.java
@@ -92,7 +92,7 @@ public class GeneNamesParser {
 	 */
 	public static List<GeneName> getGeneNames(InputStream inStream) throws IOException{
 
-		ArrayList<GeneName> geneNames = new ArrayList<GeneName>();
+		ArrayList<GeneName> geneNames = new ArrayList<>();
 		BufferedReader reader = new BufferedReader(new InputStreamReader(inStream));
 
 		// skip reading first line (it is the legend)

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/Feature.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/Feature.java
@@ -153,7 +153,7 @@ public class Feature implements FeatureI {
 		mFrame = feature.mFrame;
 		mAttributes = feature.mAttributes;
 		initAttributeHashMap();
-		mUserMap = new HashMap<String, String>(feature.mUserMap);
+		mUserMap = new HashMap<>(feature.mUserMap);
 	}
 
 	/**
@@ -177,7 +177,7 @@ public class Feature implements FeatureI {
 		mFrame = frame;
 		mAttributes = attributes;
 		initAttributeHashMap();
-		mUserMap = new HashMap<String, String>();
+		mUserMap = new HashMap<>();
 
 	}
 
@@ -199,7 +199,7 @@ public class Feature implements FeatureI {
 		return mUserMap;
 	}
 
-	 HashMap<String,String> attributeHashMap = new HashMap<String,String>();
+	 HashMap<String,String> attributeHashMap = new HashMap<>();
 
 	private void initAttributeHashMap(){
 	   String[] values = mAttributes.split(";");

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/FeatureHelper.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/FeatureHelper.java
@@ -38,7 +38,7 @@ public class FeatureHelper {
 	 */
 	static public LinkedHashMap<String,FeatureList> buildFeatureAtrributeIndex(String attribute,FeatureList list){
 
-		LinkedHashMap<String,FeatureList> featureHashMap = new LinkedHashMap<String,FeatureList>();
+		LinkedHashMap<String,FeatureList> featureHashMap = new LinkedHashMap<>();
 		FeatureList featureList = list.selectByAttribute(attribute);
 		for(FeatureI feature : featureList){
 			String value = feature.getAttribute(attribute);

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/FeatureList.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/FeatureList.java
@@ -40,7 +40,7 @@ import java.util.Map.Entry;
 @SuppressWarnings("serial")
 public class FeatureList extends ArrayList<FeatureI> {
 
-	 Map<String, Map<String,List<FeatureI>>> featindex = new HashMap<String,Map<String,List<FeatureI>>>();
+	 Map<String, Map<String,List<FeatureI>>> featindex = new HashMap<>();
 	Location mLocation;			//genomic location (union of feature locations)
 
 	/**
@@ -81,11 +81,11 @@ public class FeatureList extends ArrayList<FeatureI> {
 			if (featindex.containsKey(entry.getKey())){
 				Map<String,List<FeatureI>> feat = featindex.get(entry.getKey());
 				if (feat==null){
-					feat= new HashMap<String,List<FeatureI>>();
+					feat= new HashMap<>();
 				}
 				List<FeatureI> features = feat.get(entry.getValue());
 				if (features==null){
-					features = new ArrayList<FeatureI>();
+					features = new ArrayList<>();
 				}
 				features.add(feature);
 				feat.put(entry.getValue(), features);
@@ -185,7 +185,7 @@ public class FeatureList extends ArrayList<FeatureI> {
 	 * the order of features in the list.
 	 */
 	public Collection<String> groupValues() {
-		Set<String> set = new HashSet<String>();
+		Set<String> set = new HashSet<>();
 		for (FeatureI f : this) {
 			//enter in a set -- removes duplicates
 			set.add(f.group());
@@ -207,10 +207,10 @@ public class FeatureList extends ArrayList<FeatureI> {
 		if (featindex.containsKey(key)){
 			Map<String, List<FeatureI>> map = featindex.get(key);
 			Collection<String> result = map.keySet();
-			if (result == null) result = new HashSet<String>();
+			if (result == null) result = new HashSet<>();
 			return Collections.unmodifiableCollection(result);
 		}
-		LinkedHashMap<String, String> hash = new LinkedHashMap<String, String>();
+		LinkedHashMap<String, String> hash = new LinkedHashMap<>();
 		for (FeatureI f : this) {
 			//enter as a key -- removes duplicates
 			hash.put(f.getAttribute(key), null);

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Writer.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Writer.java
@@ -91,7 +91,7 @@ public class GFF3Writer {
 					outputStream.write(gff3line.getBytes());
 
 					String transcriptParentName = geneSequence.getAccession().getID() + "." + transcriptIndex;
-					ArrayList<CDSSequence> cdsSequenceList = new ArrayList<CDSSequence>(transcriptSequence.getCDSSequences().values());
+					ArrayList<CDSSequence> cdsSequenceList = new ArrayList<>(transcriptSequence.getCDSSequences().values());
 					Collections.sort(cdsSequenceList, new SequenceComparator());
 					for (CDSSequence cdsSequence : cdsSequenceList) {
 						gff3line = key + "\t" + cdsSequence.getSource() + "\t" + "CDS" + "\t" + cdsSequence.getBioBegin() + "\t" + cdsSequence.getBioEnd() + "\t";

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/twobit/TwoBitParser.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/twobit/TwoBitParser.java
@@ -52,7 +52,7 @@ public class TwoBitParser extends InputStream {
 	private File f;
 	private boolean reverse = false;
 	private String[] seq_names;
-	private HashMap<String,Long> seq2pos = new HashMap<String,Long>();
+	private HashMap<String,Long> seq2pos = new HashMap<>();
 	private String cur_seq_name;
 	private long[][] cur_nn_blocks;
 	private long[][] cur_mask_blocks;

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/query/BlastXMLQuery.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/query/BlastXMLQuery.java
@@ -47,7 +47,7 @@ public class BlastXMLQuery {
 	}
 
 	public LinkedHashMap<String, ArrayList<String>> getHitsQueryDef(double maxEScore) throws Exception {
-		LinkedHashMap<String, ArrayList<String>> hitsHashMap = new LinkedHashMap<String, ArrayList<String>>();
+		LinkedHashMap<String, ArrayList<String>> hitsHashMap = new LinkedHashMap<>();
 		logger.info("Query for hits");
 		ArrayList<Element> elementList = XMLHelper.selectElements(blastDoc.getDocumentElement(), "BlastOutput_iterations/Iteration[Iteration_hits]");
 		logger.info("{} hits", elementList.size());
@@ -69,7 +69,7 @@ public class BlastXMLQuery {
 					if (evalue <= maxEScore) {
 						ArrayList<String> hits = hitsHashMap.get(querydef);
 						if (hits == null) {
-							hits = new ArrayList<String>();
+							hits = new ArrayList<>();
 							hitsHashMap.put(querydef, hits);
 						}
 						hits.add(hitaccession);

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/uniprot/UniprotToFasta.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/uniprot/UniprotToFasta.java
@@ -67,10 +67,10 @@ public class UniprotToFasta {
 			String line = br.readLine();
 			String id = "";
 			StringBuffer sequence = new StringBuffer();
-			ArrayList<ProteinSequence> seqCodingRegionsList = new ArrayList<ProteinSequence>();
+			ArrayList<ProteinSequence> seqCodingRegionsList = new ArrayList<>();
 			int count = 0;
-			HashMap<String,String> uniqueGenes = new HashMap<String,String>();
-			HashMap<String,String> uniqueSpecies = new HashMap<String,String>();
+			HashMap<String,String> uniqueGenes = new HashMap<>();
+			HashMap<String,String> uniqueSpecies = new HashMap<>();
 			while(line != null){
 				if(line.startsWith("ID")){
 					String[] data = line.split(" ");

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/util/SplitFasta.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/util/SplitFasta.java
@@ -52,7 +52,7 @@ public class SplitFasta {
 			}else{
 				fileName = fileName + uniqueid + dnaSequence.getAccession().getID() + ".fna";
 			}
-			ArrayList<DNASequence> dnaList = new ArrayList<DNASequence>();
+			ArrayList<DNASequence> dnaList = new ArrayList<>();
 			dnaList.add(dnaSequence);
 			FastaWriterHelper.writeNucleotideSequence(new File(fileName), dnaList);
 		}

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/Component.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/Component.java
@@ -50,10 +50,10 @@ public final class Component {
 	 */
 	private static void lazyInit() {
 		if (components==null) {
-			components = new HashSet<Component>();
-			nonTerminalComps = new HashMap<Set<String>, Component>();
-			nTerminalAminoAcids = new HashMap<Set<String>, Component>();
-			cTerminalAminoAcids = new HashMap<Set<String>, Component>();
+			components = new HashSet<>();
+			nonTerminalComps = new HashMap<>();
+			nTerminalAminoAcids = new HashMap<>();
+			cTerminalAminoAcids = new HashMap<>();
 		}
 	}
 

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ModificationCategory.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ModificationCategory.java
@@ -108,7 +108,7 @@ public enum ModificationCategory {
 
 	private static Map<String, ModificationCategory> mapLabelCat;
 	static {
-		mapLabelCat = new HashMap<String, ModificationCategory>();
+		mapLabelCat = new HashMap<>();
 		for (ModificationCategory cat:ModificationCategory.values()) {
 			mapLabelCat.put(cat.label, cat);
 		}

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ModificationConditionImpl.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ModificationConditionImpl.java
@@ -49,7 +49,7 @@ public class ModificationConditionImpl implements ModificationCondition {
 
 
 		if (components.size() > 1) {
-			Set<Integer> indices = new HashSet<Integer>();
+			Set<Integer> indices = new HashSet<>();
 			for (ModificationLinkage linkage : linkages) {
 				indices.add(linkage.getIndexOfComponent1());
 				indices.add(linkage.getIndexOfComponent2());

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ModificationOccurrenceType.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ModificationOccurrenceType.java
@@ -73,7 +73,7 @@ public enum ModificationOccurrenceType {
 
 	private static Map<String, ModificationOccurrenceType> mapLabelOcc;
 	static {
-		mapLabelOcc = new HashMap<String, ModificationOccurrenceType>();
+		mapLabelOcc = new HashMap<>();
 		for (ModificationOccurrenceType occ:ModificationOccurrenceType.values()) {
 			mapLabelOcc.put(occ.label, occ);
 		}

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ProteinModificationImpl.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ProteinModificationImpl.java
@@ -251,7 +251,7 @@ implements ProteinModification , Comparable<ProteinModification> {
 		private String sysName = null;
 		private String formula = null;
 
-		private Set<String> keywords = new LinkedHashSet<String>();
+		private Set<String> keywords = new LinkedHashSet<>();
 
 		/**
 		 *
@@ -289,7 +289,7 @@ implements ProteinModification , Comparable<ProteinModification> {
 			this.sysName = copyFrom.getSystematicName();
 			this.formula = copyFrom.getFormula();
 
-			this.keywords = new LinkedHashSet<String>(copyFrom.getKeywords());
+			this.keywords = new LinkedHashSet<>(copyFrom.getKeywords());
 		}
 
 		public Builder setCategory(final ModificationCategory cat) {
@@ -448,7 +448,7 @@ implements ProteinModification , Comparable<ProteinModification> {
 		this.sysName = builder.sysName;
 		this.formula = builder.formula;
 
-		this.keywords = new LinkedHashSet<String>(builder.keywords);
+		this.keywords = new LinkedHashSet<>(builder.keywords);
 	}
 
 	@Override

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ProteinModificationRegistry.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/ProteinModificationRegistry.java
@@ -109,19 +109,19 @@ public class ProteinModificationRegistry {
 	private static synchronized void lazyInit(InputStream inStream) {
 		if (registry==null) {
 
-			registry = 	new HashSet<ProteinModification>();
-			byId = new HashMap<String, ProteinModification>();
-			byResidId = new HashMap<String, Set<ProteinModification>>();
-			byPsimodId = new HashMap<String, Set<ProteinModification>>();
-			byPdbccId = new HashMap<String, Set<ProteinModification>>();
-			byKeyword = new HashMap<String, Set<ProteinModification>>();
-			byComponent = new HashMap<Component, Set<ProteinModification>>();
-			byCategory = new EnumMap<ModificationCategory, Set<ProteinModification>>(
+			registry = 	new HashSet<>();
+			byId = new HashMap<>();
+			byResidId = new HashMap<>();
+			byPsimodId = new HashMap<>();
+			byPdbccId = new HashMap<>();
+			byKeyword = new HashMap<>();
+			byComponent = new HashMap<>();
+			byCategory = new EnumMap<>(
 					ModificationCategory.class);
 			for (ModificationCategory cat:ModificationCategory.values()) {
 				byCategory.put(cat, new HashSet<ProteinModification>());
 			}
-			byOccurrenceType = new EnumMap<ModificationOccurrenceType, Set<ProteinModification>>(
+			byOccurrenceType = new EnumMap<>(
 					ModificationOccurrenceType.class);
 			for (ModificationOccurrenceType occ:ModificationOccurrenceType.values()) {
 				byOccurrenceType.put(occ, new HashSet<ProteinModification>());
@@ -158,7 +158,7 @@ public class ProteinModificationRegistry {
 		for (Component comp:comps) {
 			Set<ProteinModification> mods = byComponent.get(comp);
 			if (mods==null) {
-				mods = new HashSet<ProteinModification>();
+				mods = new HashSet<>();
 				byComponent.put(comp, mods);
 			}
 			mods.add(modification);
@@ -168,7 +168,7 @@ public class ProteinModificationRegistry {
 		if (pdbccId!=null) {
 			Set<ProteinModification> mods = byPdbccId.get(pdbccId);
 			if (mods==null) {
-				mods = new HashSet<ProteinModification>();
+				mods = new HashSet<>();
 				byPdbccId.put(pdbccId, mods);
 			}
 			mods.add(modification);
@@ -178,7 +178,7 @@ public class ProteinModificationRegistry {
 		if (residId!=null) {
 			Set<ProteinModification> mods = byResidId.get(residId);
 			if (mods==null) {
-				mods = new HashSet<ProteinModification>();
+				mods = new HashSet<>();
 				byResidId.put(residId, mods);
 			}
 			mods.add(modification);
@@ -188,7 +188,7 @@ public class ProteinModificationRegistry {
 		if (psimodId!=null) {
 			Set<ProteinModification> mods = byPsimodId.get(psimodId);
 			if (mods==null) {
-				mods = new HashSet<ProteinModification>();
+				mods = new HashSet<>();
 				byPsimodId.put(psimodId, mods);
 			}
 			mods.add(modification);
@@ -197,7 +197,7 @@ public class ProteinModificationRegistry {
 		for (String keyword : modification.getKeywords()) {
 			Set<ProteinModification> mods = byKeyword.get(keyword);
 			if (mods==null) {
-				mods = new HashSet<ProteinModification>();
+				mods = new HashSet<>();
 				byKeyword.put(keyword, mods);
 			}
 			mods.add(modification);
@@ -308,7 +308,7 @@ public class ProteinModificationRegistry {
 		if (comps.length==0) {
 			return Collections.unmodifiableSet(mods);
 		} else {
-			Set<ProteinModification> ret = new HashSet<ProteinModification>(mods);
+			Set<ProteinModification> ret = new HashSet<>(mods);
 			for (Component comp:comps) {
 				mods = byComponent.get(comp);
 				if (mods==null) {

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/io/ComponentXMLConverter.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/io/ComponentXMLConverter.java
@@ -74,7 +74,7 @@ public class ComponentXMLConverter {
 		boolean isNTerminal = Boolean.parseBoolean(nTerminalS);
 		boolean isCTerminal = Boolean.parseBoolean(cTerminalS);
 
-		Set<String>pdbccIds = new HashSet<String>();
+		Set<String>pdbccIds = new HashSet<>();
 
 		NodeList valList = componentN.getChildNodes();
 		int numChildren  = valList.getLength();

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/io/ModifiedCompoundXMLConverter.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/io/ModifiedCompoundXMLConverter.java
@@ -110,7 +110,7 @@ public class ModifiedCompoundXMLConverter {
 		ProteinModification modification = null;
 		//Collection<StructureAtomLinkage> linkages = new ArrayList<StructureAtomLinkage>();
 		StructureAtomLinkage[] linkages = null;
-		List<StructureGroup> structureGroups = new ArrayList<StructureGroup>();
+		List<StructureGroup> structureGroups = new ArrayList<>();
 		try
 		{
 			//Convert string to XML document

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/io/ProteinModificationXmlReader.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/io/ProteinModificationXmlReader.java
@@ -121,14 +121,14 @@ public final class ProteinModificationXmlReader {
 				Node compsNode = nodes.get(0);
 
 				// keep track of the labels of component indices
-				Map<String,Integer> mapLabelComp = new HashMap<String,Integer>();
+				Map<String,Integer> mapLabelComp = new HashMap<>();
 
 				Map<String,List<Node>> compInfoNodes = getChildNodes(compsNode);
 
 				// components
 				List<Node> compNodes = compInfoNodes.get("Component");
 				int sizeComp = compNodes.size();
-				List<Component> comps = new ArrayList<Component>(sizeComp);
+				List<Component> comps = new ArrayList<>(sizeComp);
 				for (int iComp=0; iComp<sizeComp; iComp++) {
 					Node compNode = compNodes.get(iComp);
 					// comp label
@@ -146,7 +146,7 @@ public final class ProteinModificationXmlReader {
 					}
 
 					// comp PDBCC ID
-					Set<String> compIds = new HashSet<String>();
+					Set<String> compIds = new HashSet<>();
 					List<Node> compIdNodes = getChildNodes(compNode).get("Id");
 					if (compIdNodes!=null) {
 						for (Node compIdNode : compIdNodes) {
@@ -199,7 +199,7 @@ public final class ProteinModificationXmlReader {
 				List<ModificationLinkage> linkages = null;
 				if (bondNodes!=null) {
 					int sizeBonds = bondNodes.size();
-					linkages = new ArrayList<ModificationLinkage>(sizeBonds);
+					linkages = new ArrayList<>(sizeBonds);
 					for (int iBond=0; iBond<sizeBonds; iBond++) {
 						Node bondNode = bondNodes.get(iBond);
 						Map<String,List<Node>> bondChildNodes = getChildNodes(bondNode);
@@ -342,7 +342,7 @@ public final class ProteinModificationXmlReader {
 		if (parent==null)
 			return Collections.emptyMap();
 
-		Map<String,List<Node>> children = new HashMap<String,List<Node>>();
+		Map<String,List<Node>> children = new HashMap<>();
 
 		NodeList nodes = parent.getChildNodes();
 		int nNodes = nodes.getLength();
@@ -354,7 +354,7 @@ public final class ProteinModificationXmlReader {
 			String name = node.getNodeName();
 			List<Node> namesakes = children.get(name);
 			if (namesakes==null) {
-				namesakes = new ArrayList<Node>();
+				namesakes = new ArrayList<>();
 				children.put(name, namesakes);
 			}
 			namesakes.add(node);

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/structure/ModifiedCompoundImpl.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/structure/ModifiedCompoundImpl.java
@@ -75,7 +75,7 @@ implements ModifiedCompound, Serializable, Comparable<ModifiedCompound> {
 			throw new IllegalArgumentException("Null argument(s)");
 		}
 
-		groups = new HashSet<StructureGroup>(1);
+		groups = new HashSet<>(1);
 		groups.add(modifiedResidue);
 
 		// is it possible that components be added by addLinkage later?
@@ -101,7 +101,7 @@ implements ModifiedCompound, Serializable, Comparable<ModifiedCompound> {
 			throw new IllegalArgumentException("at least one linkage.");
 		}
 
-		this.groups = new HashSet<StructureGroup>();
+		this.groups = new HashSet<>();
 
 		addAtomLinkages(linkages);
 
@@ -128,7 +128,7 @@ implements ModifiedCompound, Serializable, Comparable<ModifiedCompound> {
 			modification = originalModification;
 		else {
 			int nRes = 0;
-			Set<String> ligands = new HashSet<String>();
+			Set<String> ligands = new HashSet<>();
 			for (StructureGroup group : groups) {
 				if (group.isAminoAcid()) {
 					nRes ++;
@@ -174,7 +174,7 @@ implements ModifiedCompound, Serializable, Comparable<ModifiedCompound> {
 
 	@Override
 	public Set<StructureGroup> getGroups(boolean isAminoAcid) {
-		Set<StructureGroup> result = new HashSet<StructureGroup>();
+		Set<StructureGroup> result = new HashSet<>();
 		for (StructureGroup group : groups) {
 			if (group.isAminoAcid() == isAminoAcid) {
 				result.add(group);
@@ -194,7 +194,7 @@ implements ModifiedCompound, Serializable, Comparable<ModifiedCompound> {
 		if (atomLinkages==null) {
 			return Collections.emptySet();
 		} else {
-			Set<StructureAtomLinkage> result = new HashSet<StructureAtomLinkage>();
+			Set<StructureAtomLinkage> result = new HashSet<>();
 			for (Set<StructureAtomLinkage> linkages : atomLinkages.values()) {
 				result.addAll(linkages);
 			}
@@ -218,17 +218,17 @@ implements ModifiedCompound, Serializable, Comparable<ModifiedCompound> {
 			throw new IllegalArgumentException("Null linkage");
 		}
 
-		Set<StructureGroup> gs = new HashSet<StructureGroup>(2);
+		Set<StructureGroup> gs = new HashSet<>(2);
 		gs.add(linkage.getAtom1().getGroup());
 		gs.add(linkage.getAtom2().getGroup());
 
 		if (atomLinkages==null) {
-			atomLinkages = new HashMap<Set<StructureGroup>, Set<StructureAtomLinkage>>();
+			atomLinkages = new HashMap<>();
 		}
 
 		Set<StructureAtomLinkage> linkages = atomLinkages.get(gs);
 		if (linkages == null) {
-			linkages = new HashSet<StructureAtomLinkage>();
+			linkages = new HashSet<>();
 			atomLinkages.put(gs, linkages);
 			groups.addAll(gs); // it's possible of new groups
 		};

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/structure/ProteinModificationIdentifier.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/structure/ProteinModificationIdentifier.java
@@ -267,9 +267,9 @@ public class ProteinModificationIdentifier {
 		}
 
 
-		residues = new ArrayList<Group>();
-		List<Group> ligands = new ArrayList<Group>();
-		Map<Component, Set<Group>> mapCompGroups = new HashMap<Component, Set<Group>>();
+		residues = new ArrayList<>();
+		List<Group> ligands = new ArrayList<>();
+		Map<Component, Set<Group>> mapCompGroups = new HashMap<>();
 
 		for (Chain chain : chains) {
 
@@ -292,7 +292,7 @@ public class ProteinModificationIdentifier {
 			}
 			logger.warn("No amino acids found for {}. Either you did not parse the PDB file with alignSEQRES records, or this record does not contain any amino acids.", pdbId);
 		}
-		List<ModifiedCompound> modComps = new ArrayList<ModifiedCompound>();
+		List<ModifiedCompound> modComps = new ArrayList<>();
 
 		for (ProteinModification mod : potentialModifications) {
 			ModificationCondition condition = mod.getCondition();
@@ -333,10 +333,10 @@ public class ProteinModificationIdentifier {
 	}
 
 	private void reset() {
-		identifiedModifiedCompounds = new LinkedHashSet<ModifiedCompound>();
+		identifiedModifiedCompounds = new LinkedHashSet<>();
 		if (recordUnidentifiableModifiedCompounds) {
-			unidentifiableAtomLinkages = new LinkedHashSet<StructureAtomLinkage>();
-			unidentifiableModifiedResidues = new LinkedHashSet<StructureGroup>();
+			unidentifiableAtomLinkages = new LinkedHashSet<>();
+			unidentifiableModifiedResidues = new LinkedHashSet<>();
 		}
 
 	}
@@ -392,7 +392,7 @@ public class ProteinModificationIdentifier {
 		// ligands to amino acid bonds for same modification of unknown category
 		// will be combined in mergeModComps()
 		// TODO: how about chain-chain links?
-		List<Group> identifiedGroups = new ArrayList<Group>();
+		List<Group> identifiedGroups = new ArrayList<>();
 		for (StructureGroup num : mc.getGroups(false)) {
 			Group group;
 			try {
@@ -464,7 +464,7 @@ public class ProteinModificationIdentifier {
 	 * Merge identified modified compounds if linked.
 	 */
 	private void mergeModComps(List<ModifiedCompound> modComps) {
-		TreeSet<Integer> remove = new TreeSet<Integer>();
+		TreeSet<Integer> remove = new TreeSet<>();
 		int n = modComps.size();
 		for (int icurr=1; icurr<n; icurr++) {
 			ModifiedCompound curr = modComps.get(icurr);
@@ -512,7 +512,7 @@ public class ProteinModificationIdentifier {
 			List<Group> ligands) {
 
 		// first put identified linkages in a map for fast query
-		Set<StructureAtomLinkage> identifiedLinkages = new HashSet<StructureAtomLinkage>();
+		Set<StructureAtomLinkage> identifiedLinkages = new HashSet<>();
 		for (ModifiedCompound mc : modComps) {
 			identifiedLinkages.addAll(mc.getAtomLinkages());
 		}
@@ -555,7 +555,7 @@ public class ProteinModificationIdentifier {
 	}
 
 	private void recordUnidentifiableModifiedResidues(List<ModifiedCompound> modComps) {
-		Set<StructureGroup> identifiedComps = new HashSet<StructureGroup>();
+		Set<StructureGroup> identifiedComps = new HashSet<>();
 		for (ModifiedCompound mc : modComps) {
 			identifiedComps.addAll(mc.getGroups(true));
 		}
@@ -592,7 +592,7 @@ public class ProteinModificationIdentifier {
 			throw new IllegalArgumentException("Null argument(s).");
 		}
 
-		Map<Component,Set<Component>> mapSingleMultiComps = new HashMap<Component,Set<Component>>();
+		Map<Component,Set<Component>> mapSingleMultiComps = new HashMap<>();
 		for (ProteinModification mod : modifications) {
 			ModificationCondition condition = mod.getCondition();
 			for (Component comp : condition.getComponents()) {
@@ -601,7 +601,7 @@ public class ProteinModificationIdentifier {
 							comp.isNTerminal(), comp.isCTerminal());
 					Set<Component> mult = mapSingleMultiComps.get(single);
 					if (mult == null) {
-						mult = new HashSet<Component>();
+						mult = new HashSet<>();
 						mapSingleMultiComps.put(single, mult);
 					}
 					mult.add(comp);
@@ -621,7 +621,7 @@ public class ProteinModificationIdentifier {
 				for (Component comp : unionComponentSet(ligandsWildCard, comps)) {
 					Set<Group> gs = saveTo.get(comp);
 					if (gs==null) {
-						gs = new LinkedHashSet<Group>();
+						gs = new LinkedHashSet<>();
 						saveTo.put(comp, gs);
 					}
 					gs.add(group);
@@ -647,7 +647,7 @@ public class ProteinModificationIdentifier {
 				for (Component comp : unionComponentSet(residuesWildCard, comps)) {
 					Set<Group> gs = saveTo.get(comp);
 					if (gs==null) {
-						gs = new LinkedHashSet<Group>();
+						gs = new LinkedHashSet<>();
 						saveTo.put(comp, gs);
 					}
 					gs.add(group);
@@ -671,7 +671,7 @@ public class ProteinModificationIdentifier {
 				for (Component comp : unionComponentSet(nTermWildCard, comps)) {
 					Set<Group> gs = saveTo.get(comp);
 					if (gs==null) {
-						gs = new LinkedHashSet<Group>();
+						gs = new LinkedHashSet<>();
 						saveTo.put(comp, gs);
 					}
 					gs.add(res);
@@ -693,7 +693,7 @@ public class ProteinModificationIdentifier {
 				for (Component comp : unionComponentSet(cTermWildCard, comps)) {
 					Set<Group> gs = saveTo.get(comp);
 					if (gs==null) {
-						gs = new LinkedHashSet<Group>();
+						gs = new LinkedHashSet<>();
 						saveTo.put(comp, gs);
 					}
 					gs.add(res);
@@ -712,7 +712,7 @@ public class ProteinModificationIdentifier {
 		if (set2 == null)
 			return set1;
 
-		Set<Component> set = new HashSet<Component>(set1.size()+set2.size());
+		Set<Component> set = new HashSet<>(set1.size()+set2.size());
 		set.addAll(set1);
 		set.addAll(set2);
 
@@ -728,7 +728,7 @@ public class ProteinModificationIdentifier {
 		int nLink = linkages.size();
 
 		List<List<Atom[]>> matchedAtomsOfLinkages =
-				new ArrayList<List<Atom[]>>(nLink);
+				new ArrayList<>(nLink);
 
 		for (int iLink=0; iLink<nLink; iLink++) {
 			ModificationLinkage linkage = linkages.get(iLink);
@@ -741,7 +741,7 @@ public class ProteinModificationIdentifier {
 			Set<Group> groups1 = mapCompGroups.get(comp1);
 			Set<Group> groups2 = mapCompGroups.get(comp2);
 
-			List<Atom[]> list = new ArrayList<Atom[]>();
+			List<Atom[]> list = new ArrayList<>();
 
 			List<String> potentialNamesOfAtomOnGroup1 = linkage.getPDBNameOfPotentialAtomsOnComponent1();
 			for (String name : potentialNamesOfAtomOnGroup1) {
@@ -810,9 +810,9 @@ public class ProteinModificationIdentifier {
 
 		int nLink = matchedAtomsOfLinkages.size();
 		int[] indices = new int[nLink];
-		Set<ModifiedCompound> identifiedCompounds = new HashSet<ModifiedCompound>();
+		Set<ModifiedCompound> identifiedCompounds = new HashSet<>();
 		while (indices[0]<matchedAtomsOfLinkages.get(0).size()) {
-			List<Atom[]> atomLinkages = new ArrayList<Atom[]>(nLink);
+			List<Atom[]> atomLinkages = new ArrayList<>(nLink);
 			for (int iLink=0; iLink<nLink; iLink++) {
 				Atom[] atoms = matchedAtomsOfLinkages.get(iLink).get(indices[iLink]);
 				atomLinkages.add(atoms);
@@ -821,7 +821,7 @@ public class ProteinModificationIdentifier {
 				// matched
 
 				int n = atomLinkages.size();
-				List<StructureAtomLinkage> linkages = new ArrayList<StructureAtomLinkage>(n);
+				List<StructureAtomLinkage> linkages = new ArrayList<>(n);
 				for (int i=0; i<n; i++) {
 					Atom[] linkage = atomLinkages.get(i);
 					StructureAtomLinkage link = StructureUtil.getStructureAtomLinkage(

--- a/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/structure/StructureUtil.java
+++ b/biojava-modfinder/src/main/java/org/biojava/nbio/protmod/structure/StructureUtil.java
@@ -180,7 +180,7 @@ public final class StructureUtil {
 			throw new IllegalArgumentException("bondLengthTolerance cannot be negative.");
 		}
 
-		List<Atom[]> ret = new ArrayList<Atom[]>();
+		List<Atom[]> ret = new ArrayList<>();
 
 		if (potentialNamesOfAtomOnGroup1 == null) {
 			// if empty name, search for all atoms
@@ -323,7 +323,7 @@ public final class StructureUtil {
 		}
 
 		int n = atoms.size();
-		List<String> ret = new ArrayList<String>(n);
+		List<String> ret = new ArrayList<>(n);
 		for (int i=0; i<n; i++) {
 			ret.add(atoms.get(i).getName());
 		}

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Ontology.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Ontology.java
@@ -294,13 +294,13 @@ public interface Ontology  {
 		private final OntologyOps ops;
 
 		{
-			terms            = new HashMap<String, Term>();
-			triples          = new HashSet<Triple>();
-			subjectTriples   = new HashMap<Term, Set<Triple>>();
-			objectTriples    = new HashMap<Term, Set<Triple>>();
-			relationTriples  = new HashMap<Term, Set<Triple>>();
-			remoteTerms      = new HashMap<Term, RemoteTerm>();
-			localRemoteTerms = new HashSet<Term>();
+			terms            = new HashMap<>();
+			triples          = new HashSet<>();
+			subjectTriples   = new HashMap<>();
+			objectTriples    = new HashMap<>();
+			relationTriples  = new HashMap<>();
+			remoteTerms      = new HashMap<>();
+			localRemoteTerms = new HashSet<>();
 		}
 
 		public Impl(String name, String description) {
@@ -337,7 +337,7 @@ public interface Ontology  {
 
 		@Override
 		public Set<Term> getTerms() {
-			return new HashSet<Term>(terms.values());
+			return new HashSet<>(terms.values());
 		}
 
 		@Override
@@ -384,7 +384,7 @@ public interface Ontology  {
 				return Collections.unmodifiableSet(new HashSet<Triple>(base));
 			}
 
-			Set<Triple> retval = new HashSet<Triple>();
+			Set<Triple> retval = new HashSet<>();
 			for (Iterator<Triple> i = base.iterator(); i.hasNext(); ) {
 				Triple t = i.next();
 				if (subject != null && t.getSubject() != subject) {
@@ -566,7 +566,7 @@ public interface Ontology  {
 		private void pushTriple(Map<Term,Set<Triple>> m, Term key, Triple t) {
 			Set<Triple> s = m.get(key);
 			if (s == null) {
-				s = new HashSet<Triple>();
+				s = new HashSet<>();
 				m.put(key, s);
 			}
 			s.add(t);

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Term.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Term.java
@@ -155,7 +155,7 @@ public interface Term extends Annotatable {
 			this.description = description;
 			this.ontology = ontology;
 
-			this.synonyms = new TreeSet<Object>();
+			this.synonyms = new TreeSet<>();
 			if (synonyms!=null) this.synonyms.addAll(Arrays.asList(synonyms));
 		}
 

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Triple.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/Triple.java
@@ -182,7 +182,7 @@ extends Term {
 			this.name = name;
 			this.description = description;
 
-			this.synonyms = new TreeSet<Object>();
+			this.synonyms = new TreeSet<>();
 			if (synonyms!=null) this.synonyms.addAll(Arrays.asList(synonyms));
 		}
 

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/io/GOParser.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/io/GOParser.java
@@ -48,7 +48,7 @@ public class GOParser {
 			Ontology onto = factory.createOntology(ontoName, ontoDescription);
 			Term isa = onto.importTerm(OntoTools.IS_A, null);
 			Term partof = null; // fixme: onto.importTerm(OntoTools.PART_OF, null);
-			List<Term> termStack = new ArrayList<Term>();
+			List<Term> termStack = new ArrayList<>();
 			String line;
 			while ((line = goFile.readLine()) != null) {
 				int leadSpaces = 0;
@@ -122,7 +122,7 @@ public class GOParser {
 		} else {
 			Term t = onto.createTerm(termName, termDesc);
 			if (toke.hasMoreTokens()) {
-				List<String> secondaries = new ArrayList<String>();
+				List<String> secondaries = new ArrayList<>();
 				while (toke.hasMoreTokens()) {
 					secondaries.add(toke.nextToken());
 				}

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/obo/OboFileHandler.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/obo/OboFileHandler.java
@@ -90,7 +90,7 @@ public class OboFileHandler implements OboFileEventListener {
 
 	@Override
 	public void documentStart() {
-		termStack = new ArrayList<Term>();
+		termStack = new ArrayList<>();
 	}
 
 	@Override

--- a/biojava-ontology/src/main/java/org/biojava/nbio/ontology/obo/OboFileParser.java
+++ b/biojava-ontology/src/main/java/org/biojava/nbio/ontology/obo/OboFileParser.java
@@ -61,10 +61,10 @@ public class OboFileParser {
 
 
 	protected static final Map<Character, Character> escapeChars =
-		new HashMap<Character, Character>();
+		new HashMap<>();
 
 	protected static final Map<Character, Character> unescapeChars =
-		new HashMap<Character, Character>();
+		new HashMap<>();
 
 	static {
 		escapeChars.put('n', '\n');
@@ -114,7 +114,7 @@ public class OboFileParser {
 
 
 	public OboFileParser(){
-		listeners = new ArrayList<OboFileEventListener>();
+		listeners = new ArrayList<>();
 	}
 
 
@@ -316,7 +316,7 @@ public class OboFileParser {
 	}
 
 	protected Map<String,Object>[] getDbxrefList(String line, int startoffset, int endoffset) throws IOException {
-		Vector<Map<String,Object>> temp = new Vector<Map<String,Object>>();
+		Vector<Map<String,Object>> temp = new Vector<>();
 		boolean stop = false;
 		while (!stop) {
 			int braceIndex = findUnescaped(line, '{', startoffset, endoffset);
@@ -381,7 +381,7 @@ public class OboFileParser {
 		}
 
 
-		Map<String, Object> m = new HashMap<String, Object>();
+		Map<String, Object> m = new HashMap<>();
 		m.put("xref",xref_str);
 		m.put("desc",desc_str);
 		return m;

--- a/biojava-protein-disorder/src/main/java/demo/PredictDisorder.java
+++ b/biojava-protein-disorder/src/main/java/demo/PredictDisorder.java
@@ -59,7 +59,7 @@ public class PredictDisorder {
 	private static ProteinSequence getUniprot(String uniProtID) throws Exception {
 
 		AminoAcidCompoundSet set = AminoAcidCompoundSet.getAminoAcidCompoundSet();
-		UniprotProxySequenceReader<AminoAcidCompound> uniprotSequence = new UniprotProxySequenceReader<AminoAcidCompound>(uniProtID,set);
+		UniprotProxySequenceReader<AminoAcidCompound> uniprotSequence = new UniprotProxySequenceReader<>(uniProtID,set);
 
 		ProteinSequence seq = new ProteinSequence(uniprotSequence);
 

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/data/sequence/SequenceUtil.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/data/sequence/SequenceUtil.java
@@ -250,7 +250,7 @@ public final class SequenceUtil {
 	 */
 	public static List<FastaSequence> readFasta(final InputStream inStream)
 		throws IOException {
-	final List<FastaSequence> seqs = new ArrayList<FastaSequence>();
+	final List<FastaSequence> seqs = new ArrayList<>();
 
 	final BufferedReader infasta = new BufferedReader(
 		new InputStreamReader(inStream, "UTF8"), 16000);

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/Jronn.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/Jronn.java
@@ -214,7 +214,7 @@ public class Jronn implements Serializable {
 
 		int count=0;
 		int regionLen=0;
-		List<Range> ranges = new ArrayList<Range>();
+		List<Range> ranges = new ArrayList<>();
 		for(float score: scores) {
 			count++;
 			// Round to 2 decimal points before comparison
@@ -245,7 +245,7 @@ public class Jronn implements Serializable {
 	 * @see #getDisorder(FastaSequence)
 	 */
 	public static Map<FastaSequence,float[]> getDisorderScores(List<FastaSequence> sequences) {
-		Map<FastaSequence,float[]> results = new TreeMap<FastaSequence, float[]>();
+		Map<FastaSequence,float[]> results = new TreeMap<>();
 		results = sequences.stream().collect(Collectors.toMap(fastaSequence ->  fastaSequence, fastaSequence -> predictSerial(fastaSequence)));
 		return results;
 	}
@@ -258,7 +258,7 @@ public class Jronn implements Serializable {
 	 * @see #getDisorder(FastaSequence)
 	 */
 	public static Map<FastaSequence,Range[]> getDisorder(List<FastaSequence> sequences) {
-		Map<FastaSequence,Range[]> disorderRanges = new TreeMap<FastaSequence,Range[]>();
+		Map<FastaSequence,Range[]> disorderRanges = new TreeMap<>();
 		disorderRanges = sequences.stream().collect(Collectors.toMap(fastaSequence -> fastaSequence, fastaSequence -> getDisorder(fastaSequence) ));
 		return disorderRanges;
 	}

--- a/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ModelLoader.java
+++ b/biojava-protein-disorder/src/main/java/org/biojava/nbio/ronn/ModelLoader.java
@@ -155,7 +155,7 @@ public final class ModelLoader {
 
 	}
 
-	private static final Map<Integer, Model> models = new HashMap<Integer, Model>();
+	private static final Map<Integer, Model> models = new HashMap<>();
 
 	public Model getModel(final int modelNum) {
 	return ModelLoader.models.get(modelNum);

--- a/biojava-structure-gui/src/main/java/demo/DemoAlignmentFromFasta.java
+++ b/biojava-structure-gui/src/main/java/demo/DemoAlignmentFromFasta.java
@@ -81,7 +81,7 @@ public class DemoAlignmentFromFasta {
 		//   "4HHB.A:1-15" (residue range)
 		// For this example, the built-in fasta parser will extract the correct accession.
 		SequenceHeaderParserInterface<ProteinSequence, AminoAcidCompound> headerParser;
-		headerParser = new GenericFastaHeaderParser<ProteinSequence, AminoAcidCompound>();
+		headerParser = new GenericFastaHeaderParser<>();
 
 		// Create AtomCache to fetch structures from the PDB
 		AtomCache cache = new AtomCache();

--- a/biojava-structure-gui/src/main/java/demo/DemoMultipleMC.java
+++ b/biojava-structure-gui/src/main/java/demo/DemoMultipleMC.java
@@ -97,9 +97,9 @@ public class DemoMultipleMC {
 		//Load the CA atoms of the structures
 		AtomCache cache = new AtomCache();
 
-		List<StructureIdentifier> identifiers = new ArrayList<StructureIdentifier>();
+		List<StructureIdentifier> identifiers = new ArrayList<>();
 
-		List<Atom[]> atomArrays = new ArrayList<Atom[]>();
+		List<Atom[]> atomArrays = new ArrayList<>();
 		for (String name:names)	{
 			atomArrays.add(cache.getAtoms(name));
 			identifiers.add(new SubstructureIdentifier(name));

--- a/biojava-structure-gui/src/main/java/demo/DemoStructureFromFasta.java
+++ b/biojava-structure-gui/src/main/java/demo/DemoStructureFromFasta.java
@@ -73,7 +73,7 @@ public class DemoStructureFromFasta {
 		//   "4HHB.A:1-15" (residue range)
 		// For this example, the built-in fasta parser will extract the correct accession.
 		SequenceHeaderParserInterface<ProteinSequence, AminoAcidCompound> headerParser;
-		headerParser = new GenericFastaHeaderParser<ProteinSequence, AminoAcidCompound>();
+		headerParser = new GenericFastaHeaderParser<>();
 
 		// Create AtomCache to fetch structures from the PDB
 		AtomCache cache = new AtomCache();

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DisplayAFP.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DisplayAFP.java
@@ -56,7 +56,7 @@ public class DisplayAFP {
 
 	//TODO: same as getEqrPos??? !!!
 	public static final List<Integer> getEQRAlignmentPos(AFPChain afpChain){
-		List<Integer> lst = new ArrayList<Integer>();
+		List<Integer> lst = new ArrayList<>();
 
 		char[] s1 = afpChain.getAlnseq1();
 		char[] s2 = afpChain.getAlnseq2();
@@ -107,7 +107,7 @@ public class DisplayAFP {
 	 * @param ca
 	 */
 	public static final List<String> getPDBresnum(int aligPos, AFPChain afpChain, Atom[] ca){
-		List<String> lst = new ArrayList<String>();
+		List<String> lst = new ArrayList<>();
 		if ( aligPos > 1) {
 			System.err.println("multiple alignments not supported yet!");
 			return lst;
@@ -407,7 +407,7 @@ public class DisplayAFP {
 	 * @throws StructureException
 	 */
 	public static final Atom[] getAtomArray(Atom[] ca,List<Group> hetatms ) throws StructureException{
-		List<Atom> atoms = new ArrayList<Atom>();
+		List<Atom> atoms = new ArrayList<>();
 		Collections.addAll(atoms, ca);
 
 		logger.debug("got {} hetatoms", hetatms.size());
@@ -436,7 +436,7 @@ public class DisplayAFP {
 
 	public static final StructureAlignmentJmol display(AFPChain afpChain,Group[] twistedGroups, Atom[] ca1, Atom[] ca2,List<Group> hetatms1, List<Group> hetatms2 ) throws StructureException {
 
-		List<Atom> twistedAs = new ArrayList<Atom>();
+		List<Atom> twistedAs = new ArrayList<>();
 
 		for ( Group g: twistedGroups){
 			if ( g == null )
@@ -560,7 +560,7 @@ public class DisplayAFP {
 
 		Group[] twistedGroups = AlignmentTools.prepareGroupsForDisplay(afpChain,ca1, ca2);
 
-		List<Atom> twistedAs = new ArrayList<Atom>();
+		List<Atom> twistedAs = new ArrayList<>();
 
 		for ( Group g: twistedGroups){
 			if ( g == null )

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DotPlotPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/DotPlotPanel.java
@@ -76,7 +76,7 @@ public class DotPlotPanel extends ScaleableMatrixPanel {
 		int[][][] optAln = alignment.getOptAln(); // [block #][{0,1} chain index][pos]
 
 		for(;alignNumber < optAln.length;alignNumber++) {
-			List<int[]> alignPairs = new ArrayList<int[]>();
+			List<int[]> alignPairs = new ArrayList<>();
 			for(int pos = 0; pos<optAln[alignNumber][0].length; pos++ ) {
 				alignPairs.add( new int[] {
 						optAln[alignNumber][0][pos],

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MultipleAlignmentCalc.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MultipleAlignmentCalc.java
@@ -78,7 +78,7 @@ public class MultipleAlignmentCalc implements AlignmentCalculationRunnable {
 				parent.getMultipleStructureAligner();
 		try {
 
-			List<Atom[]> atomArrays = new ArrayList<Atom[]>();
+			List<Atom[]> atomArrays = new ArrayList<>();
 			for (Structure s:structures){
 				Atom[] ca = StructureTools.getRepresentativeAtomArray(s);
 				atomArrays.add(ca);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MultipleAlignmentJmolDisplay.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/MultipleAlignmentJmolDisplay.java
@@ -76,7 +76,7 @@ public class MultipleAlignmentJmolDisplay  {
 	public static List<String> getPDBresnum(int structNum,
 			MultipleAlignment multAln, Atom[] ca){
 
-		List<String> lst = new ArrayList<String>();
+		List<String> lst = new ArrayList<>();
 
 		for(Block block : multAln.getBlocks() ) {
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ParameterGUI.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/ParameterGUI.java
@@ -82,7 +82,7 @@ public class ParameterGUI extends JFrame{
 		assert(names.size() == types.size());
 		assert(names.size() == helps.size());
 
-		textFields = new ArrayList<Component>();
+		textFields = new ArrayList<>();
 		Box vBox = Box.createVerticalBox();
 
 		for (int i = 0 ; i < keys.size(); i++){

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/AligPanelMouseMotionListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/AligPanelMouseMotionListener.java
@@ -44,7 +44,7 @@ public class AligPanelMouseMotionListener implements MouseMotionListener, MouseL
 
 	public AligPanelMouseMotionListener(AligPanel parent){
 		this.parent = parent;
-		aligPosListeners = new ArrayList<AlignmentPositionListener>();
+		aligPosListeners = new ArrayList<>();
 		prevPos = -1;
 		isDragging = false;
 		selectionStart = null;

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/MultipleAligPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/MultipleAligPanel.java
@@ -139,7 +139,7 @@ implements AlignmentPositionListener, WindowListener {
 		this.multAln = ensemble.getMultipleAlignment(0);
 
 		//Create the sequence alignment and the structure-sequence mapping.
-		this.mapSeqToStruct = new ArrayList<Integer>();
+		this.mapSeqToStruct = new ArrayList<>();
 		this.alnSeq = MultipleAlignmentTools.getSequenceAlignment(
 				this.multAln, this.mapSeqToStruct);
 
@@ -162,7 +162,7 @@ implements AlignmentPositionListener, WindowListener {
 		this.multAln = msa;
 
 		//Create the sequence alignment and the structure-sequence mapping.
-		this.mapSeqToStruct = new ArrayList<Integer>();
+		this.mapSeqToStruct = new ArrayList<>();
 		this.alnSeq = MultipleAlignmentTools.getSequenceAlignment(
 				this.multAln, this.mapSeqToStruct);
 
@@ -225,7 +225,7 @@ implements AlignmentPositionListener, WindowListener {
 			else isGapped = true;
 
 			//Loop through every structure to get all the points
-			List<Point> points = new ArrayList<Point>();
+			List<Point> points = new ArrayList<>();
 			for (int str=0; str<size; str++) points.add(
 					coordManager.getPanelPos(str,i));
 			Point p1 = points.get(0);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/MultipleAligPanelMouseMotionListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/aligpanel/MultipleAligPanelMouseMotionListener.java
@@ -52,7 +52,7 @@ implements MouseMotionListener, MouseListener {
 
 	public MultipleAligPanelMouseMotionListener(MultipleAligPanel parent){
 		this.parent = parent;
-		aligPosListeners = new ArrayList<AlignmentPositionListener>();
+		aligPosListeners = new ArrayList<>();
 		prevPos = -1;
 		isDragging = false;
 		selectionStart = null;

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/DefaultAutoSuggestProvider.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/DefaultAutoSuggestProvider.java
@@ -30,7 +30,7 @@ public class DefaultAutoSuggestProvider implements AutoSuggestProvider {
 
 	@Override
 	public Vector<String> getSuggestion(String userInput) {
-		Vector<String> data = new Vector<String>();
+		Vector<String> data = new Vector<>();
 
 		data.add(userInput + " no AutoSuggestProvider registered yet!");
 		return data;

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/JAutoSuggest.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/JAutoSuggest.java
@@ -247,7 +247,7 @@ public class JAutoSuggest extends JTextField{
 		lastWord = "";
 		regular = getFont();
 		busy = new Font(getFont().getName(), Font.ITALIC, getFont().getSize());
-		suggestions = new Vector<String>();
+		suggestions = new Vector<>();
 		defaultText = DEFAULT_TEXT;
 
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/SCOPAutoSuggestProvider.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/autosuggest/SCOPAutoSuggestProvider.java
@@ -47,7 +47,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 
 		long timeS = System.currentTimeMillis();
 
-		List<ScopDomain> domains = new ArrayList<ScopDomain>();
+		List<ScopDomain> domains = new ArrayList<>();
 
 		domains = getPossibleScopDomains(userInput);
 
@@ -55,7 +55,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 
 		// convert domains to Strings
 
-		Vector<String> v=new Vector<String>();
+		Vector<String> v=new Vector<>();
 
 		int counter = 0;
 		for ( ScopDomain d : domains){
@@ -82,7 +82,7 @@ public class SCOPAutoSuggestProvider implements AutoSuggestProvider{
 
 	private List<ScopDomain> getPossibleScopDomains(String userInput) {
 
-		List<ScopDomain> domains = new ArrayList<ScopDomain>();
+		List<ScopDomain> domains = new ArrayList<>();
 
 		ScopDatabase scop = ScopFactory.getSCOP();
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/MultipleAlignmentJmol.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/MultipleAlignmentJmol.java
@@ -113,7 +113,7 @@ public class MultipleAlignmentJmol extends AbstractAlignmentJmol {
 		frame.setJMenuBar(menu);
 		this.multAln = msa;
 		this.transformedAtoms = rotatedAtoms;
-		this.selectedStructures = new ArrayList<JCheckBox>();
+		this.selectedStructures = new ArrayList<>();
 
 		frame.addWindowListener(new WindowAdapter() {
 
@@ -432,7 +432,7 @@ public class MultipleAlignmentJmol extends AbstractAlignmentJmol {
 		// Color the equivalent residues of every structure
 		StringBuffer sel = new StringBuffer();
 		sel.append("select *; color lightgrey; backbone 0.1; ");
-		List<List<String>> allPDB = new ArrayList<List<String>>();
+		List<List<String>> allPDB = new ArrayList<>();
 
 		// Get the aligned residues of every structure
 		for (int i = 0; i < multAln.size(); i++) {
@@ -508,7 +508,7 @@ public class MultipleAlignmentJmol extends AbstractAlignmentJmol {
 			int str, int colorPos, int blockNum) {
 
 		// Obtain the residues aligned in this block of the structure
-		List<String> pdb = new ArrayList<String>();
+		List<String> pdb = new ArrayList<>();
 		for (int i = 0; i < alignRes.get(str).size(); i++) {
 
 			// Handle gaps - only color if it is not null

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/RasmolCommandListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/RasmolCommandListener.java
@@ -50,7 +50,7 @@ MouseListener {
 	public RasmolCommandListener(JmolPanel panel, JTextField field){
 		textfield = field;
 		jmolPanel = panel;
-		history = new ArrayList<String>();
+		history = new ArrayList<>();
 		historyPosition = -2; // -2 = history = empty;
 	}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/StructureAlignmentJmol.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/align/gui/jmol/StructureAlignmentJmol.java
@@ -256,7 +256,7 @@ public class StructureAlignmentJmol extends AbstractAlignmentJmol implements Cha
 		zoomSlider.setMajorTickSpacing(100);
 		zoomSlider.setPaintTicks(true);
 
-		Hashtable<Integer, JLabel> labelTable = new Hashtable<Integer, JLabel>();
+		Hashtable<Integer, JLabel> labelTable = new Hashtable<>();
 		labelTable.put(0,new JLabel("0%"));
 		labelTable.put(100,new JLabel("100%"));
 		labelTable.put(200,new JLabel("200%"));
@@ -559,8 +559,8 @@ public class StructureAlignmentJmol extends AbstractAlignmentJmol implements Cha
 		c1 = ColorUtils.getIntermediate(ColorUtils.orange, end1, blockNum, bk);
 		c2 = ColorUtils.getIntermediate(ColorUtils.cyan, end2, blockNum, bk);
 
-		List<String> pdb1 = new ArrayList<String>();
-		List<String> pdb2 = new ArrayList<String>();
+		List<String> pdb1 = new ArrayList<>();
+		List<String> pdb2 = new ArrayList<>();
 		for (int i = 0; i < optLen[bk]; i++) {
 			///
 			int pos1 = optAln[bk][0][i];

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/ScaleableMatrixPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/ScaleableMatrixPanel.java
@@ -198,7 +198,7 @@ implements ChangeListener, ActionListener {
 
 
 	protected static Map<String,ContinuousColorMapper> createGradients() {
-		SortedMap<String,ContinuousColorMapper> gradients = new TreeMap<String,ContinuousColorMapper>();
+		SortedMap<String,ContinuousColorMapper> gradients = new TreeMap<>();
 
 		int i = 0; //prepend number, since sorted alphabetically
 		ColorSpace hsv = HSVColorSpace.getHSVColorSpace();

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/SequenceDisplay.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/SequenceDisplay.java
@@ -232,7 +232,7 @@ public class SequenceDisplay extends JPanel implements ChangeListener {
 
 		this.setLayout(new BoxLayout(this,BoxLayout.Y_AXIS));
 
-		apos = new ArrayList<AlignedPosition>();
+		apos = new ArrayList<>();
 	}
 
 	public void clearListeners(){

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBUploadPanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/PDBUploadPanel.java
@@ -79,7 +79,7 @@ implements StructurePairSelector {
 
 	public static JComboBox<String> getFileFormatSelect(){
 		JComboBox<String> fileType = new JComboBox<>();
-			fileType = new JComboBox<String>(new String[] {UserConfiguration.PDB_FORMAT,UserConfiguration.MMCIF_FORMAT});
+			fileType = new JComboBox<>(new String[] {UserConfiguration.PDB_FORMAT,UserConfiguration.MMCIF_FORMAT});
 			fileType.setSelectedIndex(0);
 			fileType.setMaximumSize(new Dimension(10,50));
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/SelectMultiplePanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/SelectMultiplePanel.java
@@ -90,7 +90,7 @@ public class SelectMultiplePanel extends JPanel {
 
 	public List<Structure> getStructures() throws StructureException {
 
-		List<Structure> structures = new ArrayList<Structure>();
+		List<Structure> structures = new ArrayList<>();
 
 		for (StructureIdentifier name:getNames()){
 			structures.add(getStructure(name));
@@ -100,7 +100,7 @@ public class SelectMultiplePanel extends JPanel {
 
 	public List<StructureIdentifier> getNames() {
 
-		List<StructureIdentifier> names = new ArrayList<StructureIdentifier>();
+		List<StructureIdentifier> names = new ArrayList<>();
 
 		String raw = input.getText().trim();
 		String[] split = raw.split(" ");

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/SequenceMouseListener.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/SequenceMouseListener.java
@@ -86,7 +86,7 @@ MouseMotionListener
 
 		coordManager = new CoordManager();
 
-		alignmentPositionListeners = new ArrayList<AlignmentPositionListener>();
+		alignmentPositionListeners = new ArrayList<>();
 		//renderer.getLayeredPane().addMouseListener(popupFrame);
 
 	}

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/SequenceScalePanel.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/SequenceScalePanel.java
@@ -105,7 +105,7 @@ extends JPanel{
 		setPrefSize();
 		coordManager = new CoordManager();
 
-		apos = new ArrayList<AlignedPosition>();
+		apos = new ArrayList<>();
 
 	}
 

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/color/GradientMapper.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/gui/util/color/GradientMapper.java
@@ -61,7 +61,7 @@ public class GradientMapper implements ContinuousColorMapper, Map<Double, Color>
 		this(negInf,posInf,ColorSpace.getInstance(ColorSpace.CS_sRGB));
 	}
 	public GradientMapper(Color negInf, Color posInf, ColorSpace cspace) {
-		mapping = new TreeMap<Double,Color>();
+		mapping = new TreeMap<>();
 		mapping.put(Double.NEGATIVE_INFINITY, negInf);
 		mapping.put(Double.POSITIVE_INFINITY, posInf);
 		interpolator = new LinearColorInterpolator(cspace);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryDisplay.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/gui/SymmetryDisplay.java
@@ -239,7 +239,7 @@ public class SymmetryDisplay {
 		for (Axis a : symmAxes) {
 			RotationAxis rot = a.getRotationAxis();
 			List<List<Integer>> cyclicForm = axes.getRepeatsCyclicForm(a);
-			List<Atom> repAtoms = new ArrayList<Atom>();
+			List<Atom> repAtoms = new ArrayList<>();
 			for(List<Integer> cycle : cyclicForm) {
 				for(Integer repeat : cycle) {
 					repAtoms.addAll(Arrays.asList(repeats.get(repeat)));

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/jmolScript/JmolSymmetryScriptGeneratorH.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/jmolScript/JmolSymmetryScriptGeneratorH.java
@@ -423,7 +423,7 @@ public class JmolSymmetryScriptGeneratorH extends JmolSymmetryScriptGenerator {
 					Color4f c = colors[i];
 					List<String> ids = colorMap.get(c);
 					if (ids == null) {
-						ids = new ArrayList<String>();
+						ids = new ArrayList<>();
 						colorMap.put(c,  ids);
 					}
 					String id = getChainSpecification(modelNumbers, chainIds, j);
@@ -454,7 +454,7 @@ public class JmolSymmetryScriptGeneratorH extends JmolSymmetryScriptGenerator {
 			Color4f c = colors[seqClusterIds.get(i)];
 			List<String> ids = colorMap.get(c);
 			if (ids == null) {
-				ids = new ArrayList<String>();
+				ids = new ArrayList<>();
 				colorMap.put(c,  ids);
 			}
 			String id = getChainSpecification(modelNumbers, chainIds, i);
@@ -504,7 +504,7 @@ public class JmolSymmetryScriptGeneratorH extends JmolSymmetryScriptGenerator {
 					c.scale(scale);
 					List<String> ids = colorMap.get(c);
 					if (ids == null) {
-						ids = new ArrayList<String>();
+						ids = new ArrayList<>();
 						colorMap.put(c,  ids);
 					}
 					String id = getChainSpecification(modelNumbers, chainIds, subunit);

--- a/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/jmolScript/JmolSymmetryScriptGeneratorPointGroup.java
+++ b/biojava-structure-gui/src/main/java/org/biojava/nbio/structure/symmetry/jmolScript/JmolSymmetryScriptGeneratorPointGroup.java
@@ -332,7 +332,7 @@ public abstract class JmolSymmetryScriptGeneratorPointGroup extends JmolSymmetry
 				Color4f c = colors[colorIndex];
 				List<String> ids = colorMap.get(c);
 				if (ids == null) {
-					ids = new ArrayList<String>();
+					ids = new ArrayList<>();
 					colorMap.put(c,  ids);
 				}
 				String id = getChainSpecification(modelNumbers, chainIds, subunit);
@@ -362,7 +362,7 @@ public abstract class JmolSymmetryScriptGeneratorPointGroup extends JmolSymmetry
 			Color4f c = colors[seqClusterIds.get(i)];
 			List<String> ids = colorMap.get(c);
 			if (ids == null) {
-				ids = new ArrayList<String>();
+				ids = new ArrayList<>();
 				colorMap.put(c,  ids);
 			}
 			String id = getChainSpecification(modelNumbers, chainIds, i);
@@ -414,7 +414,7 @@ public abstract class JmolSymmetryScriptGeneratorPointGroup extends JmolSymmetry
 				Color4f c = colors[colorIndex];
 				List<String> ids = colorMap.get(c);
 				if (ids == null) {
-					ids = new ArrayList<String>();
+					ids = new ArrayList<>();
 					colorMap.put(c,  ids);
 				}
 				for (int subunit: orbits.get(i)) {
@@ -431,7 +431,7 @@ public abstract class JmolSymmetryScriptGeneratorPointGroup extends JmolSymmetry
 				Color4f c = new Color4f(colors[i]);
 				List<String> ids = colorMap.get(c);
 				if (ids == null) {
-					ids = new ArrayList<String>();
+					ids = new ArrayList<>();
 					colorMap.put(c,  ids);
 				}
 				List<Integer> orbit = orbits.get(i);
@@ -542,7 +542,7 @@ public abstract class JmolSymmetryScriptGeneratorPointGroup extends JmolSymmetry
 				Color4f c = colors[i];
 				List<String> ids = colorMap.get(c);
 				if (ids == null) {
-					ids = new ArrayList<String>();
+					ids = new ArrayList<>();
 					colorMap.put(c, ids);
 				}
 				ids.add(id);
@@ -947,7 +947,7 @@ public abstract class JmolSymmetryScriptGeneratorPointGroup extends JmolSymmetry
 
 
 	private List<Rotation> getUniqueAxes() {
-		List<Rotation> uniqueRotations = new ArrayList<Rotation>();
+		List<Rotation> uniqueRotations = new ArrayList<>();
 
 		for (int i = 0, n = rotationGroup.getOrder(); i < n; i++) {
 			Rotation rotationI = rotationGroup.getRotation(i);

--- a/biojava-structure/src/main/java/demo/DemoMultipleMC.java
+++ b/biojava-structure/src/main/java/demo/DemoMultipleMC.java
@@ -92,9 +92,9 @@ public class DemoMultipleMC {
 
 		//Load the CA atoms of the structures
 		AtomCache cache = new AtomCache();
-		List<Atom[]> atomArrays = new ArrayList<Atom[]>();
+		List<Atom[]> atomArrays = new ArrayList<>();
 
-		List<StructureIdentifier> ids = new ArrayList<StructureIdentifier>();
+		List<StructureIdentifier> ids = new ArrayList<>();
 		for (String name:names)	{
 			StructureIdentifier id = new StructureName(name);
 			ids.add(id);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomPositionMap.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/AtomPositionMap.java
@@ -153,7 +153,7 @@ public class AtomPositionMap {
 	 * @param atoms
 	 */
 	public AtomPositionMap(Atom[] atoms, GroupMatcher matcher) {
-		hashMap = new HashMap<ResidueNumber, Integer>();
+		hashMap = new HashMap<>();
 		for (int i = 0; i < atoms.length; i++) {
 			Group group = atoms[i].getGroup();
 			ResidueNumber rn = group.getResidueNumber();
@@ -164,7 +164,7 @@ public class AtomPositionMap {
 			}
 		}
 		Comparator<ResidueNumber> vc = new ValueComparator<ResidueNumber, Integer>(hashMap);
-		treeMap = new TreeMap<ResidueNumber, Integer>(vc);
+		treeMap = new TreeMap<>(vc);
 		treeMap.putAll(hashMap);
 	}
 
@@ -341,7 +341,7 @@ public class AtomPositionMap {
 		String currentChain = "";
 		ResidueNumber first = null;
 		ResidueNumber prev = null;
-		List<ResidueRangeAndLength> ranges = new ArrayList<ResidueRangeAndLength>();
+		List<ResidueRangeAndLength> ranges = new ArrayList<>();
 		for (ResidueNumber rn : treeMap.keySet()) {
 			if (!rn.getChainName().equals(currentChain)) {
 				if (first != null) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/BondImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/BondImpl.java
@@ -90,7 +90,7 @@ public class BondImpl implements Bond {
 	private void addSelfToAtoms() {
 		List<Bond> bonds = atomA.getBonds();
 		if (bonds==null) {
-			bonds = new ArrayList<Bond>(AtomImpl.BONDS_INITIAL_CAPACITY);
+			bonds = new ArrayList<>(AtomImpl.BONDS_INITIAL_CAPACITY);
 			atomA.setBonds(bonds);
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Element.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Element.java
@@ -191,7 +191,7 @@ public enum Element {
 	private static final Map<String,Element> allElements ;
 
 	static {
-		allElements = new HashMap<String,Element>();
+		allElements = new HashMap<>();
 		for (Element e : Element.values()){
 			allElements.put(e.toString().toLowerCase(), e);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/EntityInfo.java
@@ -159,11 +159,11 @@ public class EntityInfo implements Serializable {
 		this.title = c.title;
 
 		if (c.synonyms!=null) {
-			this.synonyms = new ArrayList<String>();
+			this.synonyms = new ArrayList<>();
 			synonyms.addAll(c.synonyms);
 		}
 		if (c.ecNums!=null) {
-			this.ecNums = new ArrayList<String>();
+			this.ecNums = new ArrayList<>();
 			ecNums.addAll(c.ecNums);
 		}
 
@@ -380,7 +380,7 @@ public class EntityInfo implements Serializable {
 			return;
 		}
 
-		Map<ResidueNumber,Integer> resNums2ResSerials = new HashMap<ResidueNumber, Integer>();
+		Map<ResidueNumber,Integer> resNums2ResSerials = new HashMap<>();
 		chains2pdbResNums2ResSerials.put(c.getId(), resNums2ResSerials);
 
 		for (int i=0;i<c.getSeqResGroups().size();i++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ExperimentalTechnique.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ExperimentalTechnique.java
@@ -71,7 +71,7 @@ public enum ExperimentalTechnique {
 
 
 	 private static HashMap<String, ExperimentalTechnique> initExpTechStr2Value() {
-		HashMap<String, ExperimentalTechnique> expTechStr2Value = new HashMap<String, ExperimentalTechnique>();
+		HashMap<String, ExperimentalTechnique> expTechStr2Value = new HashMap<>();
 		for(ExperimentalTechnique exp:ExperimentalTechnique.values()) {
 			expTechStr2Value.put(exp.getName(), exp);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/GroupType.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/GroupType.java
@@ -95,7 +95,7 @@ public enum GroupType {
 	 * @return
 	 */
 	private static Set<ResidueType> matchPolymerTypes(Set<PolymerType> allowedTypes) {
-		Set<ResidueType> matched = new HashSet<ResidueType>();
+		Set<ResidueType> matched = new HashSet<>();
 		for(ResidueType restype : ResidueType.values()) {
 			if(allowedTypes.contains(restype.polymerType)) {
 				matched.add(restype);
@@ -109,7 +109,7 @@ public enum GroupType {
 	 * @return
 	 */
 	private static Set<ResidueType> getHetatmTypes() {
-		Set<ResidueType> unmatched = new HashSet<ResidueType>();
+		Set<ResidueType> unmatched = new HashSet<>();
 		for(ResidueType restype : ResidueType.values()) {
 			if(!AMINOACID.getResidueTypes().contains(restype) &&
 					!NUCLEOTIDE.getResidueTypes().contains(restype) ) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/JournalArticle.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/JournalArticle.java
@@ -32,8 +32,8 @@ import java.util.List;
 public class JournalArticle implements Serializable {
 
 	private static final long serialVersionUID = 5062668226159515468L;
-	private List<Author> authorList = new ArrayList<Author>();
-	private List<Author> editorList = new ArrayList<Author>();
+	private List<Author> authorList = new ArrayList<>();
+	private List<Author> editorList = new ArrayList<>();
 	private String title = "";
 	private String ref = "";
 	private String journalName = "";

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Mutator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Mutator.java
@@ -59,7 +59,7 @@ public class Mutator{
 	List<String> supportedAtoms;
 
 	public Mutator(){
-		supportedAtoms = new ArrayList<String>();
+		supportedAtoms = new ArrayList<>();
 		supportedAtoms.add("N");
 		supportedAtoms.add("CA");
 		supportedAtoms.add("C");

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/PDBHeader.java
@@ -104,7 +104,7 @@ public class PDBHeader implements PDBRecord {
 		rFree = DEFAULT_RFREE;
 		rWork = DEFAULT_RFREE;
 
-		bioAssemblies = new LinkedHashMap<Integer, BioAssemblyInfo>();
+		bioAssemblies = new LinkedHashMap<>();
 		crystallographicInfo = new PDBCrystallographicInfo();
 
 		keywords       = new ArrayList<>();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRange.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRange.java
@@ -137,7 +137,7 @@ public class ResidueRange {
 		}
 
 		String[] parts = s.split(",");
-		List<ResidueRange> list = new ArrayList<ResidueRange>(parts.length);
+		List<ResidueRange> list = new ArrayList<>(parts.length);
 		for (String part : parts) {
 			list.add(parse(part));
 		}
@@ -352,7 +352,7 @@ public class ResidueRange {
 	}
 
 	public static List<ResidueRange> parseMultiple(List<String> ranges) {
-		List<ResidueRange> rrs = new ArrayList<ResidueRange>(ranges.size());
+		List<ResidueRange> rrs = new ArrayList<>(ranges.size());
 		for (String range : ranges) {
 			ResidueRange rr = ResidueRange.parse(range);
 			if (rr != null) rrs.add(rr);
@@ -361,7 +361,7 @@ public class ResidueRange {
 	}
 
 	public static List<String> toStrings(List<? extends ResidueRange> ranges) {
-		List<String> list = new ArrayList<String>(ranges.size());
+		List<String> list = new ArrayList<>(ranges.size());
 		for (ResidueRange range : ranges) {
 			list.add(range.toString());
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRangeAndLength.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ResidueRangeAndLength.java
@@ -129,7 +129,7 @@ public class ResidueRangeAndLength extends ResidueRange {
 
 
 	public static List<ResidueRangeAndLength> parseMultiple(List<String> ranges, AtomPositionMap map) {
-		List<ResidueRangeAndLength> rrs = new ArrayList<ResidueRangeAndLength>(ranges.size());
+		List<ResidueRangeAndLength> rrs = new ArrayList<>(ranges.size());
 		for (String range : ranges) {
 			ResidueRangeAndLength rr = ResidueRangeAndLength.parse(range, map);
 			if (rr != null) rrs.add(rr);
@@ -145,7 +145,7 @@ public class ResidueRangeAndLength extends ResidueRange {
 	 */
 	public static List<ResidueRangeAndLength> parseMultiple(String s, AtomPositionMap map) {
 		String[] parts = s.split(",");
-		List<ResidueRangeAndLength> list = new ArrayList<ResidueRangeAndLength>(parts.length);
+		List<ResidueRangeAndLength> list = new ArrayList<>(parts.length);
 		for (String part : parts) {
 			list.add(parse(part, map));
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/Site.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/Site.java
@@ -42,7 +42,7 @@ public class Site implements PDBRecord, Comparable<Site> {
 	private static final String lineEnd = System.getProperty("line.separator");
 
 	private String siteID = "";
-	private List<Group> groups = new ArrayList<Group>();
+	private List<Group> groups = new ArrayList<>();
 	//variables for REMARK 800
 	private String evCode = "";
 	private String description = "";

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StandardAminoAcid.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StandardAminoAcid.java
@@ -64,7 +64,7 @@ public final class StandardAminoAcid {
 	 * @author Tamas Horvath provided the standard amino acids
 	 */
 	static {
-		aminoAcids = new HashMap<String,AminoAcid>();
+		aminoAcids = new HashMap<>();
 
 
 		InputStream fileStream = StandardAminoAcid.class.getClassLoader().getResourceAsStream(STANDARD_AMINOS_FILE);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureImpl.java
@@ -126,7 +126,7 @@ public class StructureImpl implements Structure {
 
 		// go through each chain and clone chain
 		for (int i=0;i<nrModels();i++){
-			List<Chain> cloned_model = new ArrayList<Chain>();
+			List<Chain> cloned_model = new ArrayList<>();
 
 			for (int j=0;j<size(i);j++){
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/StructureTools.java
@@ -171,7 +171,7 @@ public class StructureTools {
 	private static final Set<String> AMINOACID_BACKBONE_ATOMS;
 
 	static {
-		nucleotides30 = new HashMap<String, Character>();
+		nucleotides30 = new HashMap<>();
 		nucleotides30.put("DA", 'A');
 		nucleotides30.put("DC", 'C');
 		nucleotides30.put("DG", 'G');
@@ -215,14 +215,14 @@ public class StructureTools {
 		// store nucleic acids (C, G, A, T, U, and I), and
 		// the modified versions of nucleic acids (+C, +G, +A, +T, +U, and +I),
 		// and
-		nucleotides23 = new HashMap<String, Character>();
+		nucleotides23 = new HashMap<>();
 		String[] names = { "C", "G", "A", "T", "U", "I", "+C", "+G", "+A",
 				"+T", "+U", "+I" };
 		for (String n : names) {
 			nucleotides23.put(n, n.charAt(n.length() - 1));
 		}
 
-		aminoAcids = new HashMap<String, Character>();
+		aminoAcids = new HashMap<>();
 		aminoAcids.put("GLY", 'G');
 		aminoAcids.put("ALA", 'A');
 		aminoAcids.put("VAL", 'V');
@@ -254,7 +254,7 @@ public class StructureTools {
 		aminoAcids.put("PYH", 'O');
 		aminoAcids.put("PYL", 'O');
 
-		hBondDonorAcceptors = new HashSet<Element>();
+		hBondDonorAcceptors = new HashSet<>();
 		hBondDonorAcceptors.add(Element.N);
 		hBondDonorAcceptors.add(Element.O);
 		hBondDonorAcceptors.add(Element.S);
@@ -320,7 +320,7 @@ public class StructureTools {
 	public static Atom[] getAtomArray(Structure s, String[] atomNames) {
 		List<Chain> chains = s.getModel(0);
 
-		List<Atom> atoms = new ArrayList<Atom>();
+		List<Atom> atoms = new ArrayList<>();
 
 		extractAtoms(atomNames, chains, atoms);
 		return atoms.toArray(new Atom[0]);
@@ -787,7 +787,7 @@ public class StructureTools {
 			for (Group g : c.getAtomGroups()) {
 
 				// a temp container for the atoms of this group
-				List<Atom> thisGroupAtoms = new ArrayList<Atom>();
+				List<Atom> thisGroupAtoms = new ArrayList<>();
 				// flag to check if this group contains all the requested atoms.
 				boolean thisGroupAllAtoms = true;
 				for (String atomName : atomNames) {
@@ -927,7 +927,7 @@ public class StructureTools {
 	public static Atom[] cloneAtomArray(Atom[] ca) {
 		Atom[] newCA = new Atom[ca.length];
 
-		List<Chain> model = new ArrayList<Chain>();
+		List<Chain> model = new ArrayList<>();
 		int apos = -1;
 		for (Atom a : ca) {
 			apos++;
@@ -973,7 +973,7 @@ public class StructureTools {
 	public static Group[] cloneGroups(Atom[] ca) {
 		Group[] newGroup = new Group[ca.length];
 
-		List<Chain> model = new ArrayList<Chain>();
+		List<Chain> model = new ArrayList<>();
 		int apos = -1;
 		for (Atom a : ca) {
 			apos++;
@@ -1081,7 +1081,7 @@ public class StructureTools {
 	 */
 	public static Atom[] getAtomCAArray(Structure s) {
 
-		List<Atom> atoms = new ArrayList<Atom>();
+		List<Atom> atoms = new ArrayList<>();
 
 		for (Chain c : s.getChains()) {
 			for (Group g : c.getAtomGroups()) {
@@ -1460,12 +1460,12 @@ public class StructureTools {
 		// for speed, we avoid calculating square roots
 		radius = radius * radius;
 
-		Map<Group, Double> distances = new HashMap<Group, Double>();
+		Map<Group, Double> distances = new HashMap<>();
 
 		// we only need this if we're averaging distances
 		// note that we can't use group.getAtoms().size() because some the
 		// group's atoms be outside the shell
-		Map<Group, Integer> atomCounts = new HashMap<Group, Integer>();
+		Map<Group, Integer> atomCounts = new HashMap<>();
 
 		for (Chain chain : structure.getChains()) {
 			groupLoop: for (Group chainGroup : chain.getAtomGroups()) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/SubstructureIdentifier.java
@@ -109,7 +109,7 @@ public class SubstructureIdentifier implements StructureIdentifier {
 
 			this.ranges = ResidueRange.parseMultiple(rangeStr);
 		} else {
-			this.ranges = new LinkedList<ResidueRange>();
+			this.ranges = new LinkedList<>();
 		}
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/AFPTwister.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/AFPTwister.java
@@ -295,7 +295,7 @@ public class AFPTwister {
 	private static Atom[] getAtoms(Atom[] ca, int[] positions, int length,
 			boolean clone) {
 
-		List<Atom> atoms = new ArrayList<Atom>();
+		List<Atom> atoms = new ArrayList<>();
 		for (int i = 0; i < length; i++) {
 			int p = positions[i];
 			Atom a;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/StructureAlignmentFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/StructureAlignmentFactory.java
@@ -135,7 +135,7 @@ public class StructureAlignmentFactory {
 
 	public static String[] getAllAlgorithmNames(){
 		StructureAlignment[] algos = getAllAlgorithms();
-		List<String> names = new ArrayList<String>();
+		List<String> names = new ArrayList<>();
 
 		for (StructureAlignment alg : algos){
 			names.add(alg.getAlgorithmName());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/AbstractUserArgumentProcessor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/AbstractUserArgumentProcessor.java
@@ -82,7 +82,7 @@ public abstract class AbstractUserArgumentProcessor implements UserArgumentProce
 
 	protected StartupParameters params ;
 
-	public static final List<String> mandatoryArgs= new ArrayList<String>();
+	public static final List<String> mandatoryArgs= new ArrayList<>();
 
 	protected AbstractUserArgumentProcessor(){
 		params = getStartupParametersInstance();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CECalculator.java
@@ -118,7 +118,7 @@ public class CECalculator {
 		dist1= new double[0][0];
 		dist2= new double[0][0];
 		this.params = params;
-		matrixListeners = new ArrayList<MatrixListener>();
+		matrixListeners = new ArrayList<>();
 
 	}
 
@@ -1143,7 +1143,7 @@ nBestTrace=nTrace;
 		}
 
 		// start to convert CE internal datastructure to generic AFPChain one...
-		List<AFP> afpSet = new ArrayList<AFP>();
+		List<AFP> afpSet = new ArrayList<>();
 		for (int afp=0;afp<nBestTrace;afp++){
 			// fill in data from nBestTrace into AFP
 
@@ -1923,7 +1923,7 @@ nBestTrace=nTrace;
 	 */
 	private Atom[] getAtoms(Atom[] ca,  int length, boolean clone) throws StructureException{
 
-		List<Atom> atoms = new ArrayList<Atom>();
+		List<Atom> atoms = new ArrayList<>();
 		for ( int i = 0 ; i < length ; i++){
 
 			Atom a;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCPMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCPMain.java
@@ -415,8 +415,8 @@ public class CeCPMain extends CeMain {
 
 		// Fix numbering:
 		// First, split up the atoms into left and right blocks
-		List< ResiduePair > left = new ArrayList<ResiduePair>(); // residues from left of duplication
-		List< ResiduePair > right = new ArrayList<ResiduePair>(); // residues from right of duplication
+		List< ResiduePair > left = new ArrayList<>(); // residues from left of duplication
+		List< ResiduePair > right = new ArrayList<>(); // residues from right of duplication
 
 		for(int i=0;i<optLen[0];i++) {
 			if( optAln[0][1][i] >= firstRes && optAln[0][1][i] <= lastRes ) { // not trimmed
@@ -432,7 +432,7 @@ public class CeCPMain extends CeMain {
 		alignLen = 0;
 
 		// Now we don't care about left/right, so just call them "blocks"
-		List<List<ResiduePair>> blocks = new ArrayList<List<ResiduePair>>(2);
+		List<List<ResiduePair>> blocks = new ArrayList<>(2);
 		if( !left.isEmpty() ) {
 			blocks.add(left);
 			alignLen += left.size();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCalculatorEnhanced.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeCalculatorEnhanced.java
@@ -116,7 +116,7 @@ public class CeCalculatorEnhanced {
 		dist1= new double[0][0];
 		dist2= new double[0][0];
 		this.params = params;
-		matrixListeners = new ArrayList<MatrixListener>();
+		matrixListeners = new ArrayList<>();
 
 	}
 
@@ -1134,7 +1134,7 @@ nBestTrace=nTrace;
 		}
 
 		// start to convert CE internal datastructure to generic AFPChain one...
-		List<AFP> afpSet = new ArrayList<AFP>();
+		List<AFP> afpSet = new ArrayList<>();
 		for (int afp=0;afp<nBestTrace;afp++){
 			// fill in data from nBestTrace into AFP
 
@@ -2013,7 +2013,7 @@ nBestTrace=nTrace;
 	 */
 	private Atom[] getAtoms(Atom[] ca,  int length, boolean clone) throws StructureException{
 
-		List<Atom> atoms = new ArrayList<Atom>();
+		List<Atom> atoms = new ArrayList<>();
 		for ( int i = 0 ; i < length ; i++){
 
 			Atom a;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/CeParameters.java
@@ -205,7 +205,7 @@ public class CeParameters implements ConfigStrucAligParams  {
 
 	@Override
 	public List<String> getUserConfigHelp() {
-		List<String> params =new ArrayList<String>();
+		List<String> params =new ArrayList<>();
 		String helpMaxGap = "This parameter configures the maximum gap size G, that is applied during the AFP extension. The larger the value, the longer the calculation time can become, Default value is 30. Set to 0 for no limit. " ;
 		//String helpRmsdThr = "This configures the RMSD threshold applied during the trace of the fragment matrix.";
 		String helpWinSize = "This configures the fragment size m of Aligned Fragment Pairs (AFPs).";
@@ -222,7 +222,7 @@ public class CeParameters implements ConfigStrucAligParams  {
 
 	@Override
 	public List<String> getUserConfigParameters() {
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("MaxGapSize");
 		//params.add("RmsdThr");
 		params.add("WinSize");
@@ -236,7 +236,7 @@ public class CeParameters implements ConfigStrucAligParams  {
 
 	@Override
 	public List<String> getUserConfigParameterNames(){
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("max. gap size G (during AFP extension).");
 		//params.add("RMSD threshold during trace of the fragment matrix.");
 		params.add("fragment size m");
@@ -250,7 +250,7 @@ public class CeParameters implements ConfigStrucAligParams  {
 	@Override
 	@SuppressWarnings("rawtypes")
 	public List<Class> getUserConfigTypes() {
-		List<Class> params = new ArrayList<Class>();
+		List<Class> params = new ArrayList<>();
 		params.add(Integer.class);
 		//params.add(Double.class);
 		params.add(Integer.class);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/OptimalCECPMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/ce/OptimalCECPMain.java
@@ -126,7 +126,7 @@ public class OptimalCECPMain extends CeMain {
 					"Permutation point ("+cp+") must be between -ca2.length and ca2.length-1" );
 		}
 
-		List<T> temp = new ArrayList<T>(cp);
+		List<T> temp = new ArrayList<>(cp);
 
 		// shift residues left
 		for(int i=0;i<cp;i++) {
@@ -333,7 +333,7 @@ public class OptimalCECPMain extends CeMain {
 		int[] optLen = afpChain.getOptLen();
 
 		// the processed alignment
-		List<List<List<Integer>>> blocks = new ArrayList<List<List<Integer>>>(afpChain.getBlockNum()*2);
+		List<List<List<Integer>>> blocks = new ArrayList<>(afpChain.getBlockNum()*2);
 
 		//Update residue indices
 		// newi = (oldi-cp) % N
@@ -342,7 +342,7 @@ public class OptimalCECPMain extends CeMain {
 				continue;
 
 			// set up storage for the current block
-			List<List<Integer>> currBlock = new ArrayList<List<Integer>>(2);
+			List<List<Integer>> currBlock = new ArrayList<>(2);
 			currBlock.add( new ArrayList<Integer>());
 			currBlock.add( new ArrayList<Integer>());
 			blocks.add(currBlock);
@@ -356,7 +356,7 @@ public class OptimalCECPMain extends CeMain {
 				//this happens when the new alignment crosses the protein terminus
 				if( optAln[block][1][pos-1]+cp<ca2len &&
 						optAln[block][1][pos]+cp >= ca2len) {
-					currBlock = new ArrayList<List<Integer>>(2);
+					currBlock = new ArrayList<>(2);
 					currBlock.add( new ArrayList<Integer>());
 					currBlock.add( new ArrayList<Integer>());
 					blocks.add(currBlock);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/client/StructureName.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/client/StructureName.java
@@ -329,7 +329,7 @@ public class StructureName implements Comparable<StructureName>, Serializable, S
 	}
 
 	private static Set<String> getChainNames(SubstructureIdentifier si) {
-		Set<String> chains = new TreeSet<String>();
+		Set<String> chains = new TreeSet<>();
 		List<ResidueRange> ranges = si.getResidueRanges();
 		for(ResidueRange range : ranges) {
 			String chainName = range.getChainName();
@@ -604,7 +604,7 @@ public class StructureName implements Comparable<StructureName>, Serializable, S
 	 * @return The best match for name among the domains of scopDB, or null if none match.
 	 */
 	public static ScopDomain guessScopDomain(String name, ScopDatabase scopDB) {
-		List<ScopDomain> matches = new LinkedList<ScopDomain>();
+		List<ScopDomain> matches = new LinkedList<>();
 
 		// Try exact match first
 		ScopDomain domain = scopDB.getDomainByScopID(name);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPCalculator.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/AFPCalculator.java
@@ -48,7 +48,7 @@ public class AFPCalculator
 
 	public static void extractAFPChains(FatCatParameters params, AFPChain afpChain,Atom[] ca1,Atom[] ca2) throws StructureException {
 
-		List<AFP> afpSet = new ArrayList<AFP>();
+		List<AFP> afpSet = new ArrayList<>();
 		afpChain.setAfpSet(afpSet);
 
 		if ( debug )

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FatCatParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/fatcat/calc/FatCatParameters.java
@@ -366,7 +366,7 @@ public class FatCatParameters implements ConfigStrucAligParams
 
 	@Override
 	public List<String> getUserConfigHelp() {
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		String fragLen = "The length of the fragments.";
 		String rmsdCutHelp = "The RMSD cutoff to be used during AFP detection.";
 		String disCutHelp = "The distance cutoff used when calculate the connectivity of AFP pairs";
@@ -382,7 +382,7 @@ public class FatCatParameters implements ConfigStrucAligParams
 
 	@Override
 	public List<String> getUserConfigParameterNames() {
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("Fragment Length");
 		params.add("RMSD Cutoff");
 		params.add("AFP Distance Cutoff");
@@ -393,7 +393,7 @@ public class FatCatParameters implements ConfigStrucAligParams
 
 	@Override
 	public List<String> getUserConfigParameters() {
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("FragLen");
 		params.add("RmsdCut");
 		params.add("DisCut");
@@ -406,7 +406,7 @@ public class FatCatParameters implements ConfigStrucAligParams
 	@SuppressWarnings({  "rawtypes" })
 	public List<Class> getUserConfigTypes() {
 
-		List<Class> params = new ArrayList<Class>();
+		List<Class> params = new ArrayList<>();
 		params.add(Integer.class);
 		params.add(Double.class);
 		params.add(Double.class);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/helper/JointFragments.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/helper/JointFragments.java
@@ -40,7 +40,7 @@ public class JointFragments {
 
 		List<int[]> idxlist;
 		public JointFragments(){
-			idxlist = new ArrayList<int[]>();
+			idxlist = new ArrayList<>();
 			rms = 999;
 		}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AFPChain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/model/AFPChain.java
@@ -180,7 +180,7 @@ public class AFPChain implements Serializable, Cloneable {
 		this.alignScoreUpdate = o.alignScoreUpdate;
 		this.afpChainTwiNum = o.afpChainTwiNum;
 		this.minLen = o.minLen;
-		this.afpSet = new ArrayList<AFP>(o.afpSet);
+		this.afpSet = new ArrayList<>(o.afpSet);
 		this.afpIndex = o.afpIndex == null? null: o.afpIndex.clone();
 		this.afpAftIndex = o.afpAftIndex == null? null: o.afpAftIndex.clone();
 		this.afpBefIndex = o.afpBefIndex == null? null: o.afpBefIndex.clone();
@@ -440,7 +440,7 @@ public class AFPChain implements Serializable, Cloneable {
 
 		blockResSize = new int[maxTra+1];
 
-		afpSet = new ArrayList<AFP>();
+		afpSet = new ArrayList<>();
 		totalLenIni = totalLenOpt = 0;
 		totalRmsdIni = totalRmsdOpt = 0.0;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/AbstractScoresCache.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/AbstractScoresCache.java
@@ -48,7 +48,7 @@ public abstract class AbstractScoresCache implements ScoresCache {
 	@Override
 	public void putScore(String property, Double score) {
 		if(scores == null) {
-			scores = new TreeMap<String, Double>();
+			scores = new TreeMap<>();
 		}
 		scores.put(property, score);
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/BlockImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/BlockImpl.java
@@ -80,7 +80,7 @@ public class BlockImpl extends AbstractScoresCache implements Serializable,
 		this.alignRes = null;
 		if (b.alignRes != null) {
 			// Make a deep copy of everything
-			alignRes = new ArrayList<List<Integer>>();
+			alignRes = new ArrayList<>();
 			for (int k = 0; k < b.size(); k++) {
 				alignRes.add(new ArrayList<Integer>(b.alignRes.get(k)));
 			}
@@ -188,7 +188,7 @@ public class BlockImpl extends AbstractScoresCache implements Serializable,
 		if (alignResCounts != null)
 			return alignResCounts;
 
-		alignResCounts = new ArrayList<Integer>(size());
+		alignResCounts = new ArrayList<>(size());
 		for (int s = 0; s < size(); s++) {
 			int count = 0;
 			for (int r = 0; r < length(); r++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/BlockSetImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/BlockSetImpl.java
@@ -98,7 +98,7 @@ public class BlockSetImpl extends AbstractScoresCache implements Serializable,
 		blocks = null;
 		if (bs.blocks != null) {
 			// Make a deep copy of everything
-			this.blocks = new ArrayList<Block>();
+			this.blocks = new ArrayList<>();
 			for (Block b : bs.blocks) {
 				Block newB = b.clone();
 				newB.setBlockSet(this);
@@ -143,7 +143,7 @@ public class BlockSetImpl extends AbstractScoresCache implements Serializable,
 	@Override
 	public List<Block> getBlocks() {
 		if (blocks == null)
-			blocks = new ArrayList<Block>();
+			blocks = new ArrayList<>();
 		return blocks;
 	}
 
@@ -232,7 +232,7 @@ public class BlockSetImpl extends AbstractScoresCache implements Serializable,
 		if (alignResCounts != null)
 			return alignResCounts;
 
-		alignResCounts = new ArrayList<Integer>(size());
+		alignResCounts = new ArrayList<>(size());
 		for (int s = 0; s < size(); s++)
 			alignResCounts.add(0);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/MultipleAlignmentEnsembleImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/MultipleAlignmentEnsembleImpl.java
@@ -115,7 +115,7 @@ public class MultipleAlignmentEnsembleImpl extends AbstractScoresCache
 		distanceMatrix = null;
 		if (e.distanceMatrix != null) {
 			// Make a deep copy of everything
-			distanceMatrix = new ArrayList<Matrix>();
+			distanceMatrix = new ArrayList<>();
 			for (Matrix mat : e.distanceMatrix) {
 				distanceMatrix.add((Matrix) mat.clone());
 			}
@@ -124,7 +124,7 @@ public class MultipleAlignmentEnsembleImpl extends AbstractScoresCache
 		multipleAlignments = null;
 		if (e.multipleAlignments != null) {
 			// Make a deep copy of everything
-			multipleAlignments = new ArrayList<MultipleAlignment>();
+			multipleAlignments = new ArrayList<>();
 			for (MultipleAlignment msa : e.multipleAlignments) {
 				MultipleAlignment newMSA = msa.clone();
 				newMSA.setEnsemble(this);
@@ -133,10 +133,10 @@ public class MultipleAlignmentEnsembleImpl extends AbstractScoresCache
 		}
 
 		if (e.atomArrays != null) {
-			atomArrays = new ArrayList<Atom[]>(e.atomArrays);
+			atomArrays = new ArrayList<>(e.atomArrays);
 		}
 		if (e.structureIdentifiers != null) {
-			structureIdentifiers = new ArrayList<StructureIdentifier>(
+			structureIdentifiers = new ArrayList<>(
 					e.structureIdentifiers);
 		}
 	}
@@ -326,7 +326,7 @@ public class MultipleAlignmentEnsembleImpl extends AbstractScoresCache
 	 */
 	public void updateAtomArrays() throws IOException, StructureException {
 		AtomCache cache = new AtomCache();
-		atomArrays = new ArrayList<Atom[]>();
+		atomArrays = new ArrayList<>();
 		for (StructureIdentifier name : getStructureIdentifiers()) {
 			Atom[] array = cache.getRepresentativeAtoms(name);
 			atomArrays.add(array);
@@ -346,7 +346,7 @@ public class MultipleAlignmentEnsembleImpl extends AbstractScoresCache
 	public void updateDistanceMatrix() {
 
 		// Reset the distance Matrix variable
-		distanceMatrix = new ArrayList<Matrix>();
+		distanceMatrix = new ArrayList<>();
 
 		for (int s = 0; s < size(); s++) {
 			Atom[] ca = atomArrays.get(s);
@@ -359,7 +359,7 @@ public class MultipleAlignmentEnsembleImpl extends AbstractScoresCache
 	public List<MultipleAlignment> getMultipleAlignments() {
 
 		if (multipleAlignments == null) {
-			multipleAlignments = new ArrayList<MultipleAlignment>();
+			multipleAlignments = new ArrayList<>();
 		}
 		return multipleAlignments;
 	}
@@ -377,7 +377,7 @@ public class MultipleAlignmentEnsembleImpl extends AbstractScoresCache
 	@Override
 	public void addMultipleAlignment(MultipleAlignment alignment) {
 		if (multipleAlignments == null) {
-			multipleAlignments = new ArrayList<MultipleAlignment>();
+			multipleAlignments = new ArrayList<>();
 		}
 		multipleAlignments.add(alignment);
 		alignment.setEnsemble(this);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/MultipleAlignmentImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/MultipleAlignmentImpl.java
@@ -100,7 +100,7 @@ public class MultipleAlignmentImpl extends AbstractScoresCache implements
 		blockSets = null;
 		if (ma.blockSets != null) {
 			// Make a deep copy of everything
-			this.blockSets = new ArrayList<BlockSet>();
+			this.blockSets = new ArrayList<>();
 			for (BlockSet bs : ma.blockSets) {
 				BlockSet newBS = bs.clone();
 				newBS.setMultipleAlignment(this);
@@ -127,7 +127,7 @@ public class MultipleAlignmentImpl extends AbstractScoresCache implements
 
 	@Override
 	public String toString() {
-		List<String> ids = new ArrayList<String>(parent
+		List<String> ids = new ArrayList<>(parent
 				.getStructureIdentifiers().size());
 		for (StructureIdentifier i : parent.getStructureIdentifiers()) {
 			ids.add(i.getIdentifier());
@@ -147,13 +147,13 @@ public class MultipleAlignmentImpl extends AbstractScoresCache implements
 	@Override
 	public List<BlockSet> getBlockSets() {
 		if (blockSets == null)
-			blockSets = new ArrayList<BlockSet>();
+			blockSets = new ArrayList<>();
 		return blockSets;
 	}
 
 	@Override
 	public List<Block> getBlocks() {
-		List<Block> blocks = new ArrayList<Block>();
+		List<Block> blocks = new ArrayList<>();
 		for (BlockSet bs : getBlockSets()) {
 			blocks.addAll(bs.getBlocks());
 		}
@@ -263,7 +263,7 @@ public class MultipleAlignmentImpl extends AbstractScoresCache implements
 		if (alignResCounts != null)
 			return alignResCounts;
 
-		alignResCounts = new ArrayList<Integer>(size());
+		alignResCounts = new ArrayList<>(size());
 		for (int s = 0; s < size(); s++)
 			alignResCounts.add(0);
 
@@ -282,7 +282,7 @@ public class MultipleAlignmentImpl extends AbstractScoresCache implements
 			return coverages;
 
 		List<Integer> counts = getAlignResCounts();
-		coverages = new ArrayList<Double>(size());
+		coverages = new ArrayList<>(size());
 		for (int s = 0; s < size(); s++)
 			coverages.add(counts.get(s)
 					/ (double) getAtomArrays().get(s).length);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/mc/MultipleMcMain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/mc/MultipleMcMain.java
@@ -124,7 +124,7 @@ public class MultipleMcMain implements MultipleStructureAligner {
 		int size = atomArrays.size();
 
 		//List to store the all-to-all alignments
-		List<List<AFPChain>> afpAlignments = new ArrayList<List<AFPChain>>();
+		List<List<AFPChain>> afpAlignments = new ArrayList<>();
 		for (int i=0; i<size; i++){
 			afpAlignments.add(new ArrayList<AFPChain>());
 			for (int j=0; j<size; j++)
@@ -133,7 +133,7 @@ public class MultipleMcMain implements MultipleStructureAligner {
 
 		int threads = params.getNrThreads();
 		ExecutorService executor = Executors.newFixedThreadPool(threads);
-		List<Future<AFPChain>> afpFuture = new ArrayList<Future<AFPChain>>();
+		List<Future<AFPChain>> afpFuture = new ArrayList<>();
 
 		//Create all the possible protein pairwise combinations
 		//(N*(N-1)/2) and call the pairwise alignment algorithm
@@ -184,7 +184,7 @@ public class MultipleMcMain implements MultipleStructureAligner {
 
 		int size = afpAlignments.size();
 
-		List<Double> RMSDs = new ArrayList<Double>();
+		List<Double> RMSDs = new ArrayList<>();
 		for (int i=0; i<afpAlignments.size(); i++){
 			double rmsd=0.0;
 			for (int j=0; j<size; j++){
@@ -226,10 +226,10 @@ public class MultipleMcMain implements MultipleStructureAligner {
 		int length = 0;  //the number of residues of the reference structure
 		if (ref==0) length = afpList.get(1).getCa1Length();
 		else length = afpList.get(0).getCa2Length();
-		SortedSet<Integer> flexibleBoundaries = new TreeSet<Integer>();
+		SortedSet<Integer> flexibleBoundaries = new TreeSet<>();
 
 		//Stores the equivalencies of all the structures as a double List
-		List<List<Integer>> equivalencies = new ArrayList<List<Integer>>();
+		List<List<Integer>> equivalencies = new ArrayList<>();
 		for (int str=0; str<size; str++){
 			equivalencies.add(new ArrayList<Integer>());
 			for (int res=0; res<length; res++){
@@ -305,7 +305,7 @@ public class MultipleMcMain implements MultipleStructureAligner {
 				if (lastB.getAlignRes() == null){
 					//Initialize the aligned residues list
 					List<List<Integer>> alnRes =
-							new ArrayList<List<Integer>>(size);
+							new ArrayList<>(size);
 
 					for (int k=0; k<size; k++) {
 						alnRes.add(new ArrayList<Integer>());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/mc/MultipleMcOptimizer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/mc/MultipleMcOptimizer.java
@@ -125,7 +125,7 @@ public class MultipleMcOptimizer implements Callable<MultipleAlignment> {
 		imposer = new CoreSuperimposer(reference);
 
 		if (params.getConvergenceSteps() == 0) {
-			List<Integer> lens = new ArrayList<Integer>();
+			List<Integer> lens = new ArrayList<>();
 			for (int i = 0; i < size; i++)
 				lens.add(atomArrays.get(i).length);
 			convergenceSteps = Collections.min(lens) * size;
@@ -142,8 +142,8 @@ public class MultipleMcOptimizer implements Callable<MultipleAlignment> {
 		Lmin = params.getMinBlockLen();
 
 		// Delete all shorter than Lmin blocks, and empty blocksets
-		List<Block> toDelete = new ArrayList<Block>();
-		List<BlockSet> emptyBs = new ArrayList<BlockSet>();
+		List<Block> toDelete = new ArrayList<>();
+		List<BlockSet> emptyBs = new ArrayList<>();
 
 		for (Block b : msa.getBlocks()) {
 			if (b.getCoreLength() < Lmin) {
@@ -183,12 +183,12 @@ public class MultipleMcOptimizer implements Callable<MultipleAlignment> {
 	private void initialize() throws StructureException {
 
 		// Initialize alignment variables
-		freePool = new ArrayList<SortedSet<Integer>>();
-		List<List<Integer>> aligned = new ArrayList<List<Integer>>();
+		freePool = new ArrayList<>();
+		List<List<Integer>> aligned = new ArrayList<>();
 
 		// Generate freePool residues from the ones not aligned
 		for (int i = 0; i < size; i++) {
-			List<Integer> residues = new ArrayList<Integer>();
+			List<Integer> residues = new ArrayList<>();
 			for (BlockSet bs : msa.getBlockSets()) {
 				for (Block b : bs.getBlocks()) {
 					for (int l = 0; l < b.length(); l++) {
@@ -219,9 +219,9 @@ public class MultipleMcOptimizer implements Callable<MultipleAlignment> {
 
 		// Initialize the history variables
 		if (history) {
-			lengthHistory = new ArrayList<Integer>();
-			rmsdHistory = new ArrayList<Double>();
-			scoreHistory = new ArrayList<Double>();
+			lengthHistory = new ArrayList<>();
+			rmsdHistory = new ArrayList<>();
+			scoreHistory = new ArrayList<>();
 		}
 	}
 
@@ -249,9 +249,9 @@ public class MultipleMcOptimizer implements Callable<MultipleAlignment> {
 
 			// Save the state of the system
 			MultipleAlignment lastMSA = msa.clone();
-			List<SortedSet<Integer>> lastFreePool = new ArrayList<SortedSet<Integer>>();
+			List<SortedSet<Integer>> lastFreePool = new ArrayList<>();
 			for (int k = 0; k < size; k++) {
-				SortedSet<Integer> p = new TreeSet<Integer>();
+				SortedSet<Integer> p = new TreeSet<>();
 				for (Integer l : freePool.get(k))
 					p.add(l);
 				lastFreePool.add(p);
@@ -349,10 +349,10 @@ public class MultipleMcOptimizer implements Callable<MultipleAlignment> {
 
 		boolean shrinkedAny = false;
 
-		List<List<Integer>> shrinkColumns = new ArrayList<List<Integer>>();
+		List<List<Integer>> shrinkColumns = new ArrayList<>();
 		// Loop for each Block
 		for (Block b : msa.getBlocks()) {
-			List<Integer> shrinkCol = new ArrayList<Integer>();
+			List<Integer> shrinkCol = new ArrayList<>();
 			// Loop for each column in the Block
 			for (int res = 0; res < b.length(); res++) {
 				int gapCount = 0;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/mc/MultipleMcParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/mc/MultipleMcParameters.java
@@ -54,7 +54,7 @@ public class MultipleMcParameters implements ConfigStrucAligParams {
 	@Override
 	public List<String> getUserConfigParameters() {
 
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("RandomSeed");
 		params.add("MinBlockLen");
 		params.add("MinAlignedStructures");
@@ -69,7 +69,7 @@ public class MultipleMcParameters implements ConfigStrucAligParams {
 	@Override
 	public List<String> getUserConfigParameterNames() {
 
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("Random Seed");
 		params.add("Minimum Block Length");
 		params.add("Minimum Structures per Column");
@@ -85,7 +85,7 @@ public class MultipleMcParameters implements ConfigStrucAligParams {
 	@SuppressWarnings("rawtypes")
 	public List<Class> getUserConfigTypes() {
 
-		List<Class> params = new ArrayList<Class>();
+		List<Class> params = new ArrayList<>();
 		params.add(Integer.class);
 		params.add(Integer.class);
 		params.add(Integer.class);
@@ -100,7 +100,7 @@ public class MultipleMcParameters implements ConfigStrucAligParams {
 	@Override
 	public List<String> getUserConfigHelp() {
 
-		List<String> params =new ArrayList<String>();
+		List<String> params =new ArrayList<>();
 		String randomSeed =
 				"Random seed for the optimizer random number generator.";
 		String minBlockLen =

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/CoreSuperimposer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/CoreSuperimposer.java
@@ -127,8 +127,8 @@ public class CoreSuperimposer implements MultipleSuperimposer {
 				Atom[] ref = atomArrays.get(reference);
 				Atom[] curr = atomArrays.get(i);
 
-				List<Atom> atomSet1 = new ArrayList<Atom>();
-				List<Atom> atomSet2 = new ArrayList<Atom>();
+				List<Atom> atomSet1 = new ArrayList<>();
+				List<Atom> atomSet2 = new ArrayList<>();
 
 				for( Block blk : bs.getBlocks() ) {
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentDisplay.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentDisplay.java
@@ -69,7 +69,7 @@ public class MultipleAlignmentDisplay {
 								+ atomArrays.get(i).length);
 		}
 
-		List<Atom[]> rotatedAtoms = new ArrayList<Atom[]>();
+		List<Atom[]> rotatedAtoms = new ArrayList<>();
 
 		// TODO implement independent BlockSet superposition of the structure
 		List<Matrix4d> transf = multAln.getBlockSet(0).getTransformations();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentScorer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentScorer.java
@@ -66,7 +66,7 @@ public class MultipleAlignmentScorer {
 		alignment.putScore(RMSD, getRMSD(trans));
 
 		// Put AvgTM-Score
-		List<Integer> lengths = new ArrayList<Integer>(alignment.size());
+		List<Integer> lengths = new ArrayList<>(alignment.size());
 		for (Atom[] atoms : alignment.getAtomArrays()) {
 			lengths.add(atoms.length);
 		}
@@ -237,7 +237,7 @@ public class MultipleAlignmentScorer {
 
 		List<Atom[]> trans = MultipleAlignmentTools.transformAtoms(alignment);
 
-		List<Integer> lengths = new ArrayList<Integer>(alignment.size());
+		List<Integer> lengths = new ArrayList<>(alignment.size());
 		for (Atom[] atoms : alignment.getAtomArrays()) {
 			lengths.add(atoms.length);
 		}
@@ -314,7 +314,7 @@ public class MultipleAlignmentScorer {
 
 		List<Atom[]> trans = MultipleAlignmentTools.transformAtoms(alignment);
 
-		List<Integer> lengths = new ArrayList<Integer>(alignment.size());
+		List<Integer> lengths = new ArrayList<>(alignment.size());
 		for (Atom[] atoms : alignment.getAtomArrays()) {
 			lengths.add(atoms.length);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentTools.java
@@ -108,7 +108,7 @@ public class MultipleAlignmentTools {
 			MultipleAlignment alignment, final List<Integer> mapSeqToStruct) {
 
 		// Initialize sequence variables
-		List<String> alnSequences = new ArrayList<String>();
+		List<String> alnSequences = new ArrayList<>();
 		for (int str = 0; str < alignment.size(); str++)
 			alnSequences.add("");
 		mapSeqToStruct.clear();
@@ -116,13 +116,13 @@ public class MultipleAlignmentTools {
 		int globalPos = -1;
 
 		// Initialize helper variables in constucting the sequence alignment
-		List<SortedSet<Integer>> freePool = new ArrayList<SortedSet<Integer>>();
-		List<SortedSet<Integer>> blockStarts = new ArrayList<SortedSet<Integer>>();
-		List<List<Integer>> aligned = new ArrayList<List<Integer>>();
+		List<SortedSet<Integer>> freePool = new ArrayList<>();
+		List<SortedSet<Integer>> blockStarts = new ArrayList<>();
+		List<List<Integer>> aligned = new ArrayList<>();
 
 		// Generate freePool residues from the ones not aligned
 		for (int i = 0; i < alignment.size(); i++) {
-			List<Integer> residues = new ArrayList<Integer>();
+			List<Integer> residues = new ArrayList<>();
 			freePool.add(new TreeSet<Integer>());
 			blockStarts.add(new TreeSet<Integer>());
 			for (BlockSet bs : alignment.getBlockSets()) {
@@ -346,7 +346,7 @@ public class MultipleAlignmentTools {
 			MultipleAlignment alignment, List<Integer> mapSeqToStruct) {
 
 		// Initialize sequence variables
-		List<String> alnSequences = new ArrayList<String>();
+		List<String> alnSequences = new ArrayList<>();
 		for (int str = 0; str < alignment.size(); str++)
 			alnSequences.add("");
 		mapSeqToStruct.clear();
@@ -661,7 +661,7 @@ public class MultipleAlignmentTools {
 		}
 
 		List<Atom[]> atomArrays = alignment.getAtomArrays();
-		List<Atom[]> transformed = new ArrayList<Atom[]>(atomArrays.size());
+		List<Atom[]> transformed = new ArrayList<>(atomArrays.size());
 
 		// Loop through structures
 		for (int i = 0; i < atomArrays.size(); i++) {
@@ -729,7 +729,7 @@ public class MultipleAlignmentTools {
 	 */
 	public static List<Integer> getCorePositions(Block block) {
 
-		List<Integer> corePositions = new ArrayList<Integer>();
+		List<Integer> corePositions = new ArrayList<>();
 
 		for (int col = 0; col < block.length(); col++) {
 			boolean core = true;
@@ -800,9 +800,9 @@ public class MultipleAlignmentTools {
 							+ "the structures aligned are not proteins");
 		}
 
-		MultipleSequenceAlignment<ProteinSequence, AminoAcidCompound> msa = new MultipleSequenceAlignment<ProteinSequence, AminoAcidCompound>();
+		MultipleSequenceAlignment<ProteinSequence, AminoAcidCompound> msa = new MultipleSequenceAlignment<>();
 
-		Map<String, Integer> uniqueID = new HashMap<String, Integer>();
+		Map<String, Integer> uniqueID = new HashMap<>();
 		List<String> seqs = getSequenceAlignment(msta);
 		for (int i = 0; i < msta.size(); i++) {
 			// Make sure the identifiers are unique (required by AccessionID)
@@ -875,7 +875,7 @@ public class MultipleAlignmentTools {
 			for (int j = i; j < msa.size(); j++) {
 				if (i == j)
 					rmsdMat.set(i, j, 0.0);
-				List<Atom[]> compared = new ArrayList<Atom[]>();
+				List<Atom[]> compared = new ArrayList<>();
 				compared.add(superposed.get(i));
 				compared.add(superposed.get(j));
 				double rmsd = MultipleAlignmentScorer.getRMSD(compared);
@@ -947,7 +947,7 @@ public class MultipleAlignmentTools {
 		BasicSymmetricalDistanceMatrix rmsdDist = (BasicSymmetricalDistanceMatrix) DistanceMatrixCalculator
 				.structuralDistance(rmsdMat, 1, 5, 0.4);
 		// Set the identifiers of the matrix
-		Map<String, Integer> alreadySeen = new HashMap<String, Integer>();
+		Map<String, Integer> alreadySeen = new HashMap<>();
 		for (int i = 0; i < msta.size(); i++) {
 			// Make sure the identifiers are unique
 			String id = msta.getStructureIdentifier(i).toString();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentWriter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/MultipleAlignmentWriter.java
@@ -95,7 +95,7 @@ public class MultipleAlignmentWriter {
 		fatcat.append(alignment.toString() + "\n\n");
 
 		// Get the alignment sequences and the mapping
-		List<Integer> mapSeqToStruct = new ArrayList<Integer>();
+		List<Integer> mapSeqToStruct = new ArrayList<>();
 		List<String> alnSequences = MultipleAlignmentTools
 				.getSequenceAlignment(alignment, mapSeqToStruct);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/ReferenceSuperimposer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/multiple/util/ReferenceSuperimposer.java
@@ -125,8 +125,8 @@ public class ReferenceSuperimposer implements MultipleSuperimposer {
 				Atom[] ref = atomArrays.get(reference);
 				Atom[] curr = atomArrays.get(i);
 
-				List<Atom> atomSet1 = new ArrayList<Atom>();
-				List<Atom> atomSet2 = new ArrayList<Atom>();
+				List<Atom> atomSet1 = new ArrayList<>();
+				List<Atom> atomSet2 = new ArrayList<>();
 
 				for( Block blk : bs.getBlocks() ) {
 					if( blk.size() != atomArrays.size()) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/FragmentJoiner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/FragmentJoiner.java
@@ -118,7 +118,7 @@ public class FragmentJoiner {
 													 StrucAligParameters params) throws StructureException {
 
 		//the final list of joined fragments stores as apairs
-		List<JointFragments> fll = new ArrayList<JointFragments>();
+		List<JointFragments> fll = new ArrayList<>();
 
 		FragmentPair[] tmpfidx = new FragmentPair[fraglst.length];
 		for ( int i=0 ; i < fraglst.length; i++){
@@ -203,7 +203,7 @@ public class FragmentJoiner {
 		Collections.sort(fll,comp);
 		Collections.reverse(fll);
 		int m = Math.min(params.getMaxrefine(),fll.size());
-		List<JointFragments> retlst = new ArrayList<JointFragments>();
+		List<JointFragments> retlst = new ArrayList<>();
 		for ( int i = 0 ; i < m ; i++){
 			JointFragments jf = fll.get(i);
 			retlst.add(jf);
@@ -372,7 +372,7 @@ public class FragmentJoiner {
 		int[] used = new int[n];
 
 		//the final list of joined fragments stores as apairs
-		List<JointFragments> fll = new ArrayList<JointFragments>();
+		List<JointFragments> fll = new ArrayList<>();
 
 		double adiff = angleDiff * Math.PI / 180d;
 		logger.debug("addiff{}", adiff);
@@ -443,7 +443,7 @@ public class FragmentJoiner {
 		Collections.sort(fll,comp);
 		Collections.reverse(fll);
 		int m = Math.min(maxRefine,fll.size());
-		List<JointFragments> retlst = new ArrayList<JointFragments>();
+		List<JointFragments> retlst = new ArrayList<>();
 		for ( int i = 0 ; i < m ; i++){
 			JointFragments jf = fll.get(i);
 			retlst.add(jf);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/Gotoh.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/pairwise/Gotoh.java
@@ -209,7 +209,7 @@ public class Gotoh {
 
 		int  n;
 		IndexPair[] backId = new IndexPair[a.getRows()+1+a.getCols()+1];
-		List<IndexPair> path = new ArrayList<IndexPair>();
+		List<IndexPair> path = new ArrayList<>();
 
 		backId[0] = new IndexPair((short)(a.getRows()),(short)(a.getCols()));
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/quaternary/QsAlign.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/quaternary/QsAlign.java
@@ -94,7 +94,7 @@ public class QsAlign {
 		List<SubunitCluster> c2 = SubunitClusterer.cluster(s2, cParams).getClusters();
 
 		// STEP 2: match each subunit cluster between groups O(N^2*L^2) - inter
-		Map<Integer, Integer> clusterMap = new HashMap<Integer, Integer>();
+		Map<Integer, Integer> clusterMap = new HashMap<>();
 		for (int i = 0; i < c1.size(); i++) {
 			for (int j = 0; j < c2.size(); j++) {
 
@@ -123,15 +123,15 @@ public class QsAlign {
 			// Take a cluster match as reference
 			int index1 = 0;
 			int index2 = clust1.size() - clust2.size();
-			Map<Integer, Integer> subunitMap = new HashMap<Integer, Integer>();
+			Map<Integer, Integer> subunitMap = new HashMap<>();
 			subunitMap.put(index1, index2);
 
 			// Map cluster id to their subunit matching
-			Map<Integer, Map<Integer, Integer>> clustSubunitMap = new HashMap<Integer, Map<Integer, Integer>>();
+			Map<Integer, Map<Integer, Integer>> clustSubunitMap = new HashMap<>();
 			clustSubunitMap.put(globalKey, subunitMap);
 
 			// Change order of key set so that globalKey is first
-			List<Integer> keySet = new ArrayList<Integer>(clusterMap.keySet());
+			List<Integer> keySet = new ArrayList<>(clusterMap.keySet());
 			keySet.remove((Integer) globalKey);
 			keySet.add(0, globalKey);
 
@@ -141,7 +141,7 @@ public class QsAlign {
 				if (key == globalKey)
 					subunitMap = clustSubunitMap.get(key);
 				else
-					subunitMap = new HashMap<Integer, Integer>();
+					subunitMap = new HashMap<>();
 
 				// Obtain the clusters of each subunit group
 				clust1 = c1.get(key);
@@ -224,11 +224,11 @@ public class QsAlign {
 			logger.info("Cluster Subunit Map: " + clustSubunitMap.toString());
 
 			// Unfold the nested map into subunit map and alignment
-			subunitMap = new HashMap<Integer, Integer>();
-			List<Integer> alignRes1 = new ArrayList<Integer>();
-			List<Integer> alignRes2 = new ArrayList<Integer>();
-			List<Atom> atomArray1 = new ArrayList<Atom>();
-			List<Atom> atomArray2 = new ArrayList<Atom>();
+			subunitMap = new HashMap<>();
+			List<Integer> alignRes1 = new ArrayList<>();
+			List<Integer> alignRes2 = new ArrayList<>();
+			List<Atom> atomArray1 = new ArrayList<>();
+			List<Atom> atomArray2 = new ArrayList<>();
 
 			for (int key : clustSubunitMap.keySet()) {
 
@@ -274,7 +274,7 @@ public class QsAlign {
 			// Fill in the alignment information
 			BlockSet bs = new BlockSetImpl(msa);
 			Block b = new BlockImpl(bs);
-			List<List<Integer>> alignRes = new ArrayList<List<Integer>>(2);
+			List<List<Integer>> alignRes = new ArrayList<>(2);
 			alignRes.add(alignRes1);
 			alignRes.add(alignRes2);
 			b.setAlignRes(alignRes);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3DParameters.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/seq/SmithWaterman3DParameters.java
@@ -42,7 +42,7 @@ public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 
 	@Override
 	public List<String> getUserConfigHelp() {
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("The Gap open penalty");
 		params.add("The Gap extension penalty");
 		params.add("The maximum RMSD of superposition allowed");
@@ -54,7 +54,7 @@ public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 
 	@Override
 	public List<String> getUserConfigParameterNames() {
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("Gap Open");
 		params.add("Gap Extension");
 		params.add("Maximum RMSD");
@@ -65,7 +65,7 @@ public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 
 	@Override
 	public List<String> getUserConfigParameters() {
-		List<String> params = new ArrayList<String>();
+		List<String> params = new ArrayList<>();
 		params.add("GapOpen");
 		params.add("GapExtend");
 		params.add("MaxRmsd");
@@ -77,7 +77,7 @@ public class SmithWaterman3DParameters implements ConfigStrucAligParams {
 	@Override
 	@SuppressWarnings("rawtypes")
 	public List<Class> getUserConfigTypes() {
-		List<Class> params = new ArrayList<Class>();
+		List<Class> params = new ArrayList<>();
 		params.add(Short.class);
 		params.add(Short.class);
 		params.add(Double.class);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AFPAlignmentDisplay.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AFPAlignmentDisplay.java
@@ -90,7 +90,7 @@ public class AFPAlignmentDisplay
 	}
 
 	public static Atom[] getAlignedAtoms1(AFPChain afpChain,Atom[] ca1){
-		List<Atom> atoms = new ArrayList<Atom>();
+		List<Atom> atoms = new ArrayList<>();
 
 		int blockNum = afpChain.getBlockNum();
 
@@ -111,7 +111,7 @@ public class AFPAlignmentDisplay
 	}
 	public static Atom[] getAlignedAtoms2(AFPChain afpChain,Atom[] ca2){
 
-		List<Atom> atoms = new ArrayList<Atom>();
+		List<Atom> atoms = new ArrayList<>();
 
 		int blockNum = afpChain.getBlockNum();
 
@@ -329,7 +329,7 @@ public class AFPAlignmentDisplay
 
 		if ( seq1 == null || seq2 == null){
 			logger.warn("Can't calc %ID for an empty alignment! ");
-			Map<String, Double> m = new HashMap<String, Double>();
+			Map<String, Double> m = new HashMap<>();
 			m.put("similarity", similarity);
 			m.put("identity", identity);
 			return m;
@@ -369,7 +369,7 @@ public class AFPAlignmentDisplay
 			similarity = (similarity) / eqr;
 			identity = identity/eqr;
 		}
-		Map<String, Double> m = new HashMap<String, Double>();
+		Map<String, Double> m = new HashMap<>();
 		m.put("similarity", similarity);
 		m.put("identity", identity);
 
@@ -400,7 +400,7 @@ public class AFPAlignmentDisplay
 
 		Group[] twistedGroups = AlignmentTools.prepareGroupsForDisplay(afpChain,ca1, ca2);
 
-		List<Atom> twistedAs = new ArrayList<Atom>();
+		List<Atom> twistedAs = new ArrayList<>();
 
 		for ( Group g: twistedGroups){
 			if ( g == null )
@@ -412,8 +412,8 @@ public class AFPAlignmentDisplay
 		}
 		Atom[] twistedAtoms = twistedAs.toArray(new Atom[twistedAs.size()]);
 
-		List<Group> hetatms  = new ArrayList<Group>();
-		List<Group> nucs1    = new ArrayList<Group>();
+		List<Group> hetatms  = new ArrayList<>();
+		List<Group> nucs1    = new ArrayList<>();
 		Group g1 = ca1[0].getGroup();
 		Chain c1 = null;
 		if ( g1 != null) {
@@ -423,8 +423,8 @@ public class AFPAlignmentDisplay
 				nucs1  = c1.getAtomGroups(GroupType.NUCLEOTIDE);
 			}
 		}
-		List<Group> hetatms2 = new ArrayList<Group>();
-		List<Group> nucs2    = new ArrayList<Group>();
+		List<Group> hetatms2 = new ArrayList<>();
+		List<Group> nucs2    = new ArrayList<>();
 		Group g2 = ca2[0].getGroup();
 		Chain c2 = null;
 		if ( g2 != null){

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/AlignmentTools.java
@@ -157,7 +157,7 @@ public class AlignmentTools {
 	 * @throws StructureException If afpChain is not one-to-one
 	 */
 	public static Map<Integer, Integer> alignmentAsMap(AFPChain afpChain) throws StructureException {
-		Map<Integer,Integer> map = new HashMap<Integer,Integer>();
+		Map<Integer,Integer> map = new HashMap<>();
 
 		if( afpChain.getAlnLength() < 1 ) {
 			return map;
@@ -223,11 +223,11 @@ public class AlignmentTools {
 
 		if(k<0) throw new IllegalArgumentException("k must be positive");
 		if(k==1) {
-			return new HashMap<S,T>(alignmentMap);
+			return new HashMap<>(alignmentMap);
 		}
 		// Convert to lists to establish a fixed order
-		List<S> preimage = new ArrayList<S>(alignmentMap.keySet()); // currently unmodified
-		List<S> image = new ArrayList<S>(preimage);
+		List<S> preimage = new ArrayList<>(alignmentMap.keySet()); // currently unmodified
+		List<S> image = new ArrayList<>(preimage);
 
 		for(int n=1;n<k;n++) {
 			// apply alignment
@@ -241,7 +241,7 @@ public class AlignmentTools {
 
 
 
-		Map<S, T> imageMap = new HashMap<S,T>(alignmentMap.size());
+		Map<S, T> imageMap = new HashMap<>(alignmentMap.size());
 
 		//TODO handle nulls consistently.
 		// assure that all the residues in the domain are valid keys
@@ -321,8 +321,8 @@ public class AlignmentTools {
 	 */
 	public static int getSymmetryOrder(Map<Integer, Integer> alignment, Map<Integer,Integer> identity,
 									   final int maxSymmetry, final float minimumMetricChange) {
-		List<Integer> preimage = new ArrayList<Integer>(alignment.keySet()); // currently unmodified
-		List<Integer> image = new ArrayList<Integer>(preimage);
+		List<Integer> preimage = new ArrayList<>(alignment.keySet()); // currently unmodified
+		List<Integer> image = new ArrayList<>(preimage);
 
 		int bestSymmetry = 1;
 		double bestMetric = Double.POSITIVE_INFINITY; //lower is better
@@ -443,10 +443,10 @@ public class AlignmentTools {
 	 */
 	public static Map<Integer, Integer> guessSequentialAlignment(
 			Map<Integer,Integer> alignment, boolean inverseAlignment) {
-		Map<Integer,Integer> identity = new HashMap<Integer,Integer>();
+		Map<Integer,Integer> identity = new HashMap<>();
 
-		SortedSet<Integer> aligned1 = new TreeSet<Integer>();
-		SortedSet<Integer> aligned2 = new TreeSet<Integer>();
+		SortedSet<Integer> aligned1 = new TreeSet<>();
+		SortedSet<Integer> aligned2 = new TreeSet<>();
 
 		for(Entry<Integer,Integer> pair : alignment.entrySet()) {
 			aligned1.add(pair.getKey());
@@ -480,18 +480,18 @@ public class AlignmentTools {
 	public static List<List<List<Integer>>> getOptAlnAsList(AFPChain afpChain) {
 		int[][][] optAln = afpChain.getOptAln();
 		int[] optLen = afpChain.getOptLen();
-		List<List<List<Integer>>> blocks = new ArrayList<List<List<Integer>>>(afpChain.getBlockNum());
+		List<List<List<Integer>>> blocks = new ArrayList<>(afpChain.getBlockNum());
 		for(int blockNum=0;blockNum<afpChain.getBlockNum();blockNum++) {
 			//TODO could improve speed an memory by wrapping the arrays with
 			// an unmodifiable list, similar to Arrays.asList(...) but with the
 			// correct size parameter.
-			List<Integer> align1 = new ArrayList<Integer>(optLen[blockNum]);
-			List<Integer> align2 = new ArrayList<Integer>(optLen[blockNum]);
+			List<Integer> align1 = new ArrayList<>(optLen[blockNum]);
+			List<Integer> align2 = new ArrayList<>(optLen[blockNum]);
 			for(int pos=0;pos<optLen[blockNum];pos++) {
 				align1.add(optAln[blockNum][0][pos]);
 				align2.add(optAln[blockNum][1][pos]);
 			}
-			List<List<Integer>> block = new ArrayList<List<Integer>>(2);
+			List<List<Integer>> block = new ArrayList<>(2);
 			block.add(align1);
 			block.add(align2);
 			blocks.add(block);
@@ -627,7 +627,7 @@ public class AlignmentTools {
 
 		// Determine block lengths
 		// Split blocks if residue indices don't increase monotonically
-		List<Integer> newBlkLen = new ArrayList<Integer>();
+		List<Integer> newBlkLen = new ArrayList<>();
 		boolean blockChanged = false;
 		for(int blk=0;blk<blockNum;blk++) {
 			int currLen=1;
@@ -655,7 +655,7 @@ public class AlignmentTools {
 		}
 
 		// Split blocks
-		List<int[][]> blocks = new ArrayList<int[][]>( newBlkLen.size() );
+		List<int[][]> blocks = new ArrayList<>( newBlkLen.size() );
 
 		int oldBlk = 0;
 		int pos = 0;
@@ -758,7 +758,7 @@ public class AlignmentTools {
 		// increasing monotonically.
 		Integer[] res1 = alignment.keySet().toArray(new Integer[0]);
 		Arrays.sort(res1);
-		List<Integer> blockLens = new ArrayList<Integer>(2);
+		List<Integer> blockLens = new ArrayList<>(2);
 		int optLength = 0;
 		Integer lastRes = alignment.get(res1[0]);
 		int blkLen = lastRes==null?0:1;
@@ -989,17 +989,17 @@ public class AlignmentTools {
 	 */
 	public static <S,T> String toConciseAlignmentString(Map<S,T> alignment, Map<T,S> identity) {
 		// Clone input to prevent changes
-		Map<S,T> alig = new HashMap<S,T>(alignment);
+		Map<S,T> alig = new HashMap<>(alignment);
 
 		// Generate inverse alignment
-		Map<S,List<S>> inverse = new HashMap<S,List<S>>();
+		Map<S,List<S>> inverse = new HashMap<>();
 		for(Entry<S,T> e: alig.entrySet()) {
 			S val = identity.get(e.getValue());
 			if( inverse.containsKey(val) ) {
 				List<S> l = inverse.get(val);
 				l.add(e.getKey());
 			} else {
-				List<S> l = new ArrayList<S>();
+				List<S> l = new ArrayList<>();
 				l.add(e.getKey());
 				inverse.put(val,l);
 			}
@@ -1058,7 +1058,7 @@ public class AlignmentTools {
 	 * @see #toConciseAlignmentString(Map, Map)
 	 */
 	public static Map<Integer, Integer> fromConciseAlignmentString(String string) {
-		Map<Integer, Integer> map = new HashMap<Integer, Integer>();
+		Map<Integer, Integer> map = new HashMap<>();
 		boolean matches = true;
 		while (matches) {
 			Pattern pattern = Pattern.compile("(\\d+)>(\\d+)");
@@ -1201,7 +1201,7 @@ public class AlignmentTools {
 	 */
 	public static final List<Chain> getAlignedModel(Atom[] ca){
 
-		List<Chain> model = new ArrayList<Chain>();
+		List<Chain> model = new ArrayList<>();
 		for ( Atom a: ca){
 
 			Group g = a.getGroup();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/CliTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/util/CliTools.java
@@ -100,14 +100,14 @@ public class CliTools {
 			throw new ConfigurationException("Couldn't get information for target bean " + ex.getMessage());
 		}
 
-		Map<String,PropertyDescriptor> propertiesByName = new HashMap<String, PropertyDescriptor>();
+		Map<String,PropertyDescriptor> propertiesByName = new HashMap<>();
 		for (PropertyDescriptor pd : bi.getPropertyDescriptors() ) {
 			propertiesByName.put(pd.getName(), pd);
 		}
 
-		List<String> anonArgs = new ArrayList<String>();
-		Map<PropertyDescriptor,List<String>> arrayProps = new HashMap<PropertyDescriptor, List<String>>();
-		Set<PropertyDescriptor> usedProps = new HashSet<PropertyDescriptor>();
+		List<String> anonArgs = new ArrayList<>();
+		Map<PropertyDescriptor,List<String>> arrayProps = new HashMap<>();
+		Set<PropertyDescriptor> usedProps = new HashSet<>();
 
 		boolean stdInUsed = false;
 		boolean stdOutUsed = false;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/AFPChainXMLParser.java
@@ -223,7 +223,7 @@ public class AFPChainXMLParser
 	}
 
 	public static AFPChain[] parseMultiXML(String xml) throws IOException {
-		List<AFPChain> afpChains = new ArrayList<AFPChain>();
+		List<AFPChain> afpChains = new ArrayList<>();
 
 		try
 		{
@@ -316,7 +316,7 @@ public class AFPChainXMLParser
 				a.setBlockShiftVector(blockShiftVector);
 
 				int afpNum = Integer.parseInt(getAttribute(rootElement,"afpNum"));
-				List<AFP> afpSet = new ArrayList<AFP>();
+				List<AFP> afpSet = new ArrayList<>();
 				for (int afp=0;afp<afpNum;afp++){
 					afpSet.add( new AFP());
 				}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/MultipleAlignmentXMLParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/MultipleAlignmentXMLParser.java
@@ -77,7 +77,7 @@ public class MultipleAlignmentXMLParser {
 			throws ParserConfigurationException, SAXException, IOException {
 
 		List<MultipleAlignmentEnsemble> ensembles =
-				new ArrayList<MultipleAlignmentEnsemble>();
+				new ArrayList<>();
 
 		//Convert string to XML document
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
@@ -178,7 +178,7 @@ public class MultipleAlignmentXMLParser {
 	private static Block parseBlock(Node root, BlockSet blockSet) {
 
 		Block b = new BlockImpl(blockSet);
-		List<List<Integer>> alignRes = new ArrayList<List<Integer>>();
+		List<List<Integer>> alignRes = new ArrayList<>();
 		b.setAlignRes(alignRes);
 		NodeList children = root.getChildNodes();
 
@@ -276,7 +276,7 @@ public class MultipleAlignmentXMLParser {
 	private static void parseStructures(Node root,
 			MultipleAlignmentEnsemble ensemble) {
 
-		List<StructureIdentifier> names = new ArrayList<StructureIdentifier>();
+		List<StructureIdentifier> names = new ArrayList<>();
 		ensemble.setStructureIdentifiers(names);
 
 		NamedNodeMap atts = root.getAttributes();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/PdbPairXMLConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/PdbPairXMLConverter.java
@@ -44,7 +44,7 @@ public class PdbPairXMLConverter {
 	public static final String DEFAULT_METHOD_NAME = FatCatRigid.algorithmName;
 
 	public static PdbPairsMessage convertXMLtoPairs(String xml) {
-		SortedSet<PdbPair>  pairs = new TreeSet<PdbPair>();
+		SortedSet<PdbPair>  pairs = new TreeSet<>();
 		PdbPairsMessage message = new PdbPairsMessage();
 		try
 		{

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/PdbPairsMessage.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/align/xml/PdbPairsMessage.java
@@ -40,7 +40,7 @@ public class PdbPairsMessage {
 
 		method = PdbPairXMLConverter.DEFAULT_METHOD_NAME;
 
-		pairs = new TreeSet<PdbPair>();
+		pairs = new TreeSet<>();
 
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/asa/GroupAsa.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/asa/GroupAsa.java
@@ -44,7 +44,7 @@ public class GroupAsa implements Serializable {
 
 	private static HashMap<Character,Double>  initTriPeptAsas() {
 		// ASA in extended tripeptide conformation (GLY-X-GLY) from Miller et al JMB 1987 (for calculation of relative ASAs)
-		HashMap<Character,Double> map = new HashMap<Character,Double>();
+		HashMap<Character,Double> map = new HashMap<>();
 		map.put('A', 113.0);
 		map.put('R', 241.0);
 		map.put('N', 158.0);
@@ -223,8 +223,8 @@ public class GroupAsa implements Serializable {
 		GroupAsa n = new GroupAsa(this.g);
 		n.setAsaC(this.getAsaC());
 		n.setAsaU(this.getAsaU());
-		n.atomAsaUs = new ArrayList<Double>(this.atomAsaUs.size());
-		n.atomAsaCs = new ArrayList<Double>(this.atomAsaCs.size());
+		n.atomAsaUs = new ArrayList<>(this.atomAsaUs.size());
+		n.atomAsaCs = new ArrayList<>(this.atomAsaCs.size());
 		for (int i=0;i<this.atomAsaUs.size();i++) {
 			n.atomAsaUs.add(this.atomAsaUs.get(i));
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cath/CathDomain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cath/CathDomain.java
@@ -423,7 +423,7 @@ public class CathDomain implements Serializable, StructureIdentifier {
 	 * @throws StructureException 
 	 */
 	public Set<String> getChains() throws StructureException {
-		Set<String> chains = new HashSet<String>();
+		Set<String> chains = new HashSet<>();
 		List<ResidueRange> rrs = toCanonical().getResidueRanges();
 		for (ResidueRange rr : rrs) chains.add(rr.getChainName());
 		return chains;
@@ -436,7 +436,7 @@ public class CathDomain implements Serializable, StructureIdentifier {
 
 	@Override
 	public SubstructureIdentifier toCanonical() throws StructureException{
-		List<ResidueRange> ranges = new ArrayList<ResidueRange>();
+		List<ResidueRange> ranges = new ArrayList<>();
 		String chain = String.valueOf(getDomainName().charAt(getDomainName().length() - 3));
 		for (CathSegment segment : this.getSegments()) {
 			ranges.add(new ResidueRange(chain, segment.getStart(), segment.getStop()));

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cath/CathFactory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cath/CathFactory.java
@@ -45,7 +45,7 @@ public class CathFactory {
 
 	private static CathDatabase cath;
 
-	private static Map<String, CathDatabase> versions = new HashMap<String, CathDatabase>();
+	private static Map<String, CathDatabase> versions = new HashMap<>();
 
 	/**
 	 * Sets the default (singleton) CathDatabase.

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cath/CathInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cath/CathInstallation.java
@@ -97,11 +97,11 @@ public class CathInstallation implements CathDatabase{
 		cathVersion = DEFAULT_VERSION;
 		cathDownloadUrl = CATH_DOWNLOAD_URL;
 
-		pdbMap = new HashMap<String, List<CathDomain>>();
-		domainMap = new HashMap<String ,CathDomain>();
-		cathTree = new HashMap<String, CathNode>();
+		pdbMap = new HashMap<>();
+		domainMap = new HashMap< >();
+		cathTree = new HashMap<>();
 
-		if (parseCathFragments) fragmentMap = new HashMap<String,List<CathFragment>>();
+		if (parseCathFragments) fragmentMap = new HashMap<>();
 
 	}
 
@@ -207,7 +207,7 @@ public class CathInstallation implements CathDatabase{
 			ensureDomallInstalled();
 		}
 		ensureNodeListInstalled();
-		List<CathDomain> matches = new ArrayList<CathDomain>();
+		List<CathDomain> matches = new ArrayList<>();
 		CathNode node;
 		for ( String nodeId : cathTree.keySet() ) {
 			if ( (node = cathTree.get(nodeId)).getCategory() == category ) {
@@ -224,7 +224,7 @@ public class CathInstallation implements CathDatabase{
 		} else {
 			ensureDomallInstalled();
 		}
-		List<CathDomain> matches = new ArrayList<CathDomain>();
+		List<CathDomain> matches = new ArrayList<>();
 		for ( String k : domainMap.keySet() ) {
 			if ( domainMap.get(k).getCATH().startsWith(query) ) {
 				matches.add( domainMap.get(k) );
@@ -236,7 +236,7 @@ public class CathInstallation implements CathDatabase{
 	@Override
 	public List<CathNode> getTree(CathDomain domain) {
 		CathNode node = getCathNode( domain.getCATH() );
-		List<CathNode> tree = new ArrayList<CathNode>();
+		List<CathNode> tree = new ArrayList<>();
 		while (node != null) {
 			node = getCathNode( node.getParentId() );
 			if (node != null) tree.add(node);
@@ -248,14 +248,14 @@ public class CathInstallation implements CathDatabase{
 	@Override
 	public List<CathDomain> filterByNodeName(String query) {
 		ensureNodeListInstalled();
-		List<CathNode> matchingNodes = new ArrayList<CathNode>();
+		List<CathNode> matchingNodes = new ArrayList<>();
 		CathNode node;
 		for ( String nodeId : cathTree.keySet() ) {
 			if ( (node = cathTree.get(nodeId) ).getDescription().startsWith(query) ) {
 				matchingNodes.add(node);
 			}
 		}
-		List<CathDomain> matches = new ArrayList<CathDomain>();
+		List<CathDomain> matches = new ArrayList<>();
 		for (CathNode n : matchingNodes) {
 			matches.addAll(getDomainsByNodeId(n.getNodeId()));
 		}
@@ -269,7 +269,7 @@ public class CathInstallation implements CathDatabase{
 		} else {
 			ensureDomallInstalled();
 		}
-		List<CathDomain> matches = new ArrayList<CathDomain>();
+		List<CathDomain> matches = new ArrayList<>();
 		for ( String k : domainMap.keySet() ) {
 			if ( domainMap.get(k).getName().startsWith(query) ) {
 				matches.add( domainMap.get(k) );
@@ -328,7 +328,7 @@ public class CathInstallation implements CathDatabase{
 		} else {
 			ensureDomallInstalled();
 		}
-		List<CathDomain> domains = new ArrayList<CathDomain>();
+		List<CathDomain> domains = new ArrayList<>();
 		for (String domainName : domainMap.keySet()) {
 			CathDomain description = domainMap.get(domainName);
 			if ( description.getCATH().startsWith(nodeId) ) {
@@ -366,7 +366,7 @@ public class CathInstallation implements CathDatabase{
 			if ( pdbMap.containsKey(pdbId)){
 				domainList = pdbMap.get(pdbId);
 			} else {
-				domainList = new ArrayList<CathDomain>();
+				domainList = new ArrayList<>();
 				pdbMap.put(pdbId,domainList);
 			}
 
@@ -447,7 +447,7 @@ public class CathInstallation implements CathDatabase{
 			} else if ( line.startsWith("DSEQS") ) {
 				seqs = seqs.append( line.substring(10) );
 			} else if ( line.startsWith("NSEGMENTS") ) {
-				segments = new ArrayList<CathSegment>();
+				segments = new ArrayList<>();
 			} else if ( line.startsWith("SEGMENT") ) {
 				segment = new CathSegment();
 				sseqh = new StringBuilder();
@@ -484,7 +484,7 @@ public class CathInstallation implements CathDatabase{
 				if ( pdbMap.containsKey(pdbId)){
 					domainList = pdbMap.get(pdbId);
 				} else {
-					domainList = new ArrayList<CathDomain>();
+					domainList = new ArrayList<>();
 					pdbMap.put(pdbId,domainList);
 				}
 
@@ -584,7 +584,7 @@ public class CathInstallation implements CathDatabase{
 					continue;
 				}
 
-				List<CathSegment> segments = new ArrayList<CathSegment>(numberOfSegments);
+				List<CathSegment> segments = new ArrayList<>(numberOfSegments);
 				segIdx = 1; // Offset from domIdx.
 				for (int j=1; j<=numberOfSegments; j++) {
 					CathSegment segment = new CathSegment();
@@ -611,7 +611,7 @@ public class CathInstallation implements CathDatabase{
 				domIdx += 6*numberOfSegments + 1;
 			}
 			if (parseCathFragments) {
-			List<CathFragment> fragments = new ArrayList<CathFragment>(numberOfFragments);
+			List<CathFragment> fragments = new ArrayList<>(numberOfFragments);
 				for (int i=1; i<=numberOfFragments; i++) {
 					CathFragment fragment = new CathFragment();
 					fragment.setFragmentId(i);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitCluster.java
@@ -679,9 +679,9 @@ public class SubunitCluster {
 		}
 
 		// Divide the Subunits in their repeats
-		List<Subunit> newSubunits = new ArrayList<Subunit>(subunits.size()
+		List<Subunit> newSubunits = new ArrayList<>(subunits.size()
 				* columns.size());
-		List<List<Integer>> newSubunitEQR = new ArrayList<List<Integer>>(
+		List<List<Integer>> newSubunitEQR = new ArrayList<>(
 				subunits.size() * columns.size());
 
 		for (int s = 0; s < subunits.size(); s++) {
@@ -700,7 +700,7 @@ public class SubunitCluster {
 						.get(s).getStructure()));
 
 				// Recalculate equivalent residues
-				List<Integer> eqr = new ArrayList<Integer>();
+				List<Integer> eqr = new ArrayList<>();
 				for (int p = 0; p < columns.get(r).size(); p++) {
 					eqr.add(subunitEQR.get(s).get(columns.get(r).get(p))
 							- start);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/cluster/SubunitExtractor.java
@@ -66,7 +66,7 @@ public class SubunitExtractor {
 			int absMinLen, double fraction, int minLen) {
 
 		// The extracted subunit container
-		List<Subunit> subunits = new ArrayList<Subunit>();
+		List<Subunit> subunits = new ArrayList<>();
 
 		for (Chain c : structure.getPolyChains()) {
 			// Only take protein chains
@@ -107,7 +107,7 @@ public class SubunitExtractor {
 		int minLength = Integer.MAX_VALUE;
 
 		// Extract the length List, the min and the max
-		List<Integer> lengths = new ArrayList<Integer>();
+		List<Integer> lengths = new ArrayList<>();
 		for (int i = 0; i < subunits.size(); i++) {
 			if (subunits.get(i).size() >= absMinLen) {
 				maxLength = Math.max(subunits.get(i).size(), maxLength);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/AtomContactSet.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/AtomContactSet.java
@@ -42,7 +42,7 @@ public class AtomContactSet implements Serializable, Iterable<AtomContact> {
 
 	public AtomContactSet(double cutoff) {
 		this.cutoff = cutoff;
-		this.contacts = new HashMap<Pair<AtomIdentifier>,AtomContact>();
+		this.contacts = new HashMap<>();
 	}
 
 	public void add(AtomContact contact) {
@@ -87,7 +87,7 @@ public class AtomContactSet implements Serializable, Iterable<AtomContact> {
 	}
 
 	private Pair<AtomIdentifier> getAtomIdPairFromContact(AtomContact contact) {
-		Pair<AtomIdentifier> pair = new Pair<AtomIdentifier>(
+		Pair<AtomIdentifier> pair = new Pair<>(
 				new AtomIdentifier(contact.getPair().getFirst().getPDBserial(),contact.getPair().getFirst().getGroup().getChainId()),
 				new AtomIdentifier(contact.getPair().getSecond().getPDBserial(),contact.getPair().getSecond().getGroup().getChainId()));
 
@@ -132,7 +132,7 @@ public class AtomContactSet implements Serializable, Iterable<AtomContact> {
 					String.format("%.2f", distance)+" is larger than contacts' distance cutoff "+
 					String.format("%.2f", cutoff));
 
-		List<AtomContact> list = new ArrayList<AtomContact>();
+		List<AtomContact> list = new ArrayList<>();
 		for (AtomContact contact:this.contacts.values()) {
 			if (contact.getDistance()<distance) {
 				list.add(contact);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/Contact.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/Contact.java
@@ -42,7 +42,7 @@ public class Contact implements Serializable {
 	}
 
 	public Pair<Integer> getIndexPair() {
-		return new Pair<Integer>(i,j);
+		return new Pair<>(i,j);
 	}
 
 	public int getI() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GridCell.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GridCell.java
@@ -40,8 +40,8 @@ public class GridCell {
 	private ArrayList<Integer> jIndices;
 
 	public GridCell(Grid parent){
-		iIndices = new ArrayList<Integer>();
-		jIndices = new ArrayList<Integer>();
+		iIndices = new ArrayList<>();
+		jIndices = new ArrayList<>();
 		this.grid = parent;
 	}
 
@@ -70,7 +70,7 @@ public class GridCell {
 	 */
 	public List<Contact> getContactsWithinCell(){
 
-		List<Contact> contacts = new ArrayList<Contact>();
+		List<Contact> contacts = new ArrayList<>();
 
 		Point3d[] iAtoms = grid.getIAtoms();
 		Point3d[] jAtoms = grid.getJAtoms();
@@ -110,7 +110,7 @@ public class GridCell {
 	 */
 	public List<Contact> getContactsToOtherCell(GridCell otherCell){
 
-		List<Contact> contacts = new ArrayList<Contact>();
+		List<Contact> contacts = new ArrayList<>();
 
 		Point3d[] iAtoms = grid.getIAtoms();
 		Point3d[] jAtoms = grid.getJAtoms();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GroupContact.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GroupContact.java
@@ -41,7 +41,7 @@ public class GroupContact implements Serializable {
 	private List<AtomContact> atomContacts;
 
 	public GroupContact() {
-		atomContacts = new ArrayList<AtomContact>();
+		atomContacts = new ArrayList<>();
 	}
 
 	public void addAtomContact(AtomContact atomContact) {
@@ -82,7 +82,7 @@ public class GroupContact implements Serializable {
 	 */
 	public List<AtomContact> getContactsWithinDistance(double distance) {
 
-		List<AtomContact> list = new ArrayList<AtomContact>();
+		List<AtomContact> list = new ArrayList<>();
 		for (AtomContact contact:this.atomContacts) {
 			if (contact.getDistance()<distance) {
 				list.add(contact);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GroupContactSet.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/GroupContactSet.java
@@ -43,7 +43,7 @@ public class GroupContactSet implements Serializable, Iterable<GroupContact>{
 	private HashMap<Pair<ResidueIdentifier>, GroupContact> contacts;
 
 	public GroupContactSet() {
-		contacts = new HashMap<Pair<ResidueIdentifier>, GroupContact>();
+		contacts = new HashMap<>();
 	}
 
 	/**
@@ -52,7 +52,7 @@ public class GroupContactSet implements Serializable, Iterable<GroupContact>{
 	 * @param atomContacts
 	 */
 	public GroupContactSet(AtomContactSet atomContacts) {
-		contacts = new HashMap<Pair<ResidueIdentifier>, GroupContact>();
+		contacts = new HashMap<>();
 		atoms2groups(atomContacts);
 	}
 
@@ -69,8 +69,8 @@ public class GroupContactSet implements Serializable, Iterable<GroupContact>{
 			// we skip the self-residue contacts
 			if (iResidue.equals(jResidue)) continue;
 
-			Pair<Group> residuePair = new Pair<Group> (iResidue, jResidue);
-			Pair<ResidueIdentifier> pair = new Pair<ResidueIdentifier>(new ResidueIdentifier(iResidue), new ResidueIdentifier(jResidue));
+			Pair<Group> residuePair = new Pair<> (iResidue, jResidue);
+			Pair<ResidueIdentifier> pair = new Pair<>(new ResidueIdentifier(iResidue), new ResidueIdentifier(jResidue));
 
 			if (!contacts.containsKey(pair)) {
 
@@ -152,7 +152,7 @@ public class GroupContactSet implements Serializable, Iterable<GroupContact>{
 	}
 
 	private Pair<ResidueIdentifier> getResIdPairFromContact(GroupContact groupContact) {
-		return new Pair<ResidueIdentifier>(
+		return new Pair<>(
 				new ResidueIdentifier(groupContact.getPair().getFirst()),
 				new ResidueIdentifier(groupContact.getPair().getSecond()) );
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterface.java
@@ -522,7 +522,7 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 			}
 		}
 
-		return new Pair<List<Group>>(rim1, rim2);
+		return new Pair<>(rim1, rim2);
 	}
 
 	/**
@@ -613,8 +613,8 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 			return 0;
 		}
 
-		Pair<EntityInfo> thisCompounds = new Pair<EntityInfo>(thisChains.getFirst().getEntityInfo(), thisChains.getSecond().getEntityInfo());
-		Pair<EntityInfo> otherCompounds = new Pair<EntityInfo>(otherChains.getFirst().getEntityInfo(), otherChains.getSecond().getEntityInfo());
+		Pair<EntityInfo> thisCompounds = new Pair<>(thisChains.getFirst().getEntityInfo(), thisChains.getSecond().getEntityInfo());
+		Pair<EntityInfo> otherCompounds = new Pair<>(otherChains.getFirst().getEntityInfo(), otherChains.getSecond().getEntityInfo());
 
 		if (checkMolIdMatch(thisCompounds,otherCompounds)) {
 
@@ -706,7 +706,7 @@ public class StructureInterface implements Serializable, Comparable<StructureInt
 			logger.warn("Could not find parents chains, compounds will be null");
 			return null;
 		}
-		return new Pair<EntityInfo>(chains.getFirst().getEntityInfo(), chains.getSecond().getEntityInfo());
+		return new Pair<>(chains.getFirst().getEntityInfo(), chains.getSecond().getEntityInfo());
 	}
 
 	private Structure getParentStructure() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterfaceCluster.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/contact/StructureInterfaceCluster.java
@@ -40,7 +40,7 @@ public class StructureInterfaceCluster implements Serializable {
 
 
 	public StructureInterfaceCluster() {
-		this.members = new ArrayList<StructureInterface>();
+		this.members = new ArrayList<>();
 	}
 
 	public List<StructureInterface> getMembers() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/SerializableCache.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/SerializableCache.java
@@ -117,7 +117,7 @@ public class SerializableCache <K,V>{
 
 		File f = getCacheFile();
 
-		serializedCache = new HashMap<K,V>();
+		serializedCache = new HashMap<>();
 
 		// has never been cached here before
 		if( ! f.exists()) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/ClusterDomains.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/ClusterDomains.java
@@ -228,7 +228,7 @@ public class ClusterDomains {
 		if ( verbose)
 			System.out.println("  +++  combining domains " + Si + " " + Sj);
 
-		List<Domain> newdoms = new ArrayList<Domain>();
+		List<Domain> newdoms = new ArrayList<>();
 
 		//int ndom = domains.size();
 		for(int i=0;i<domains.get(Sj).nseg;i++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/CutDomain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/CutDomain.java
@@ -43,7 +43,7 @@ public class CutDomain {
 
 		ndom = 0;
 
-		domains = new ArrayList<Domain>();
+		domains = new ArrayList<>();
 
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/Domain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/domain/pdp/Domain.java
@@ -48,7 +48,7 @@ public class Domain implements Comparable<Domain>, Serializable{
 	int nseg;
 	double score;
 
-	List<Segment>segments = new ArrayList<Segment>();
+	List<Segment>segments = new ArrayList<>();
 
 	public Domain(){
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodDomain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodDomain.java
@@ -150,7 +150,7 @@ Column 15: Comma-separated value list of non-polymer entities within 4 A of at l
 		this.tGroupName = o.tGroupName;
 		this.fGroupName = o.fGroupName;
 		this.assemblyId = o.assemblyId;
-		this.ligands = new HashSet<String>(o.ligands);
+		this.ligands = new HashSet<>(o.ligands);
 	}
 
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/ecod/EcodInstallation.java
@@ -153,7 +153,7 @@ public class EcodInstallation implements EcodDatabase {
 				return null;
 			}
 			// Deep clone
-			List<EcodDomain> clonedDoms = new ArrayList<EcodDomain>(doms.size());
+			List<EcodDomain> clonedDoms = new ArrayList<>(doms.size());
 			for(EcodDomain d : doms) {
 				clonedDoms.add( new EcodDomain(d) );
 			}
@@ -178,7 +178,7 @@ public class EcodInstallation implements EcodDatabase {
 		Integer hGroup = xhtGroup.length>1 ? Integer.parseInt(xhtGroup[1]) : null;
 		Integer tGroup = xhtGroup.length>2 ? Integer.parseInt(xhtGroup[2]) : null;
 
-		List<EcodDomain> filtered = new ArrayList<EcodDomain>();
+		List<EcodDomain> filtered = new ArrayList<>();
 		for(EcodDomain d: getAllDomains()) {
 			boolean match = true;
 			if(xhtGroup.length>0) {
@@ -485,7 +485,7 @@ public class EcodInstallation implements EcodDatabase {
 			}
 
 			// Leave enough space for all PDBs as of 2015
-			domainMap = new HashMap<PdbId, List<EcodDomain>>((int) (150000/.85),.85f);
+			domainMap = new HashMap<>((int) (150000/.85),.85f);
 
 			// Index with domainMap
 			for(EcodDomain d : allDomains) {
@@ -504,7 +504,7 @@ public class EcodInstallation implements EcodDatabase {
 				if( domainMap.containsKey(pdbId) ) {
 					currDomains = domainMap.get(pdbId);
 				} else {
-					currDomains = new LinkedList<EcodDomain>();
+					currDomains = new LinkedList<>();
 					domainMap.put(pdbId,currDomains);
 				}
 				currDomains.add(d);
@@ -582,7 +582,7 @@ v1.4 - added seqid_range and headers (develop101)
 		private void parse(BufferedReader in) throws IOException {
 			try {
 				// Allocate plenty of space for ECOD as of 2015
-				ArrayList<EcodDomain> domainsList = new ArrayList<EcodDomain>(500000);
+				ArrayList<EcodDomain> domainsList = new ArrayList<>(500000);
 
 				Pattern versionRE = Pattern.compile("^\\s*#.*ECOD\\s*version\\s+(\\S+).*");
 				Pattern commentRE = Pattern.compile("^\\s*#.*");
@@ -705,7 +705,7 @@ v1.4 - added seqid_range and headers (develop101)
 										ligands = Collections.emptySet();
 									} else {
 										String[] ligSplit = ligandStr.split(",");
-										ligands = new LinkedHashSet<String>(ligSplit.length);
+										ligands = new LinkedHashSet<>(ligSplit.length);
 										for(String s : ligSplit) {
 											ligands.add(s.intern());
 										}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/geometry/MomentsOfInertia.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/geometry/MomentsOfInertia.java
@@ -47,7 +47,7 @@ import java.util.List;
 public class MomentsOfInertia {
 
 	private List<Point3d> points = new ArrayList<Point3d>();
-	private List<Double> masses = new ArrayList<Double>();
+	private List<Double> masses = new ArrayList<>();
 
 	private boolean modified = true;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/CAConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/CAConverter.java
@@ -42,7 +42,7 @@ public class CAConverter {
 	 * @since Biojava 4.1.0
 	 */
 	public static List<Chain> getRepresentativeAtomsOnly(List<Chain> chains){
-		List<Chain> newChains = new ArrayList<Chain>();
+		List<Chain> newChains = new ArrayList<>();
 
 		for (Chain chain : chains){
 			Chain newChain = getRepresentativeAtomsOnly(chain);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FastaAFPChainConverter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/FastaAFPChainConverter.java
@@ -85,8 +85,8 @@ public class FastaAFPChainConverter {
 	public static AFPChain cpFastaToAfpChain(File fastaFile, Structure structure, int cpSite) throws IOException, StructureException {
 		InputStream inStream = new FileInputStream(fastaFile);
 		SequenceCreatorInterface<AminoAcidCompound> creator = new CasePreservingProteinSequenceCreator(AminoAcidCompoundSet.getAminoAcidCompoundSet());
-		SequenceHeaderParserInterface<ProteinSequence, AminoAcidCompound> headerParser = new GenericFastaHeaderParser<ProteinSequence, AminoAcidCompound>();
-		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<ProteinSequence, AminoAcidCompound>(inStream, headerParser, creator);
+		SequenceHeaderParserInterface<ProteinSequence, AminoAcidCompound> headerParser = new GenericFastaHeaderParser<>();
+		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<>(inStream, headerParser, creator);
 		LinkedHashMap<String, ProteinSequence> sequences = fastaReader.process();
 		inStream.close();
 		Iterator<ProteinSequence> iter = sequences.values().iterator();
@@ -196,8 +196,8 @@ public class FastaAFPChainConverter {
 		InputStream inStream = new FileInputStream(fastaFile);
 		SequenceCreatorInterface<AminoAcidCompound> creator = new CasePreservingProteinSequenceCreator(
 				AminoAcidCompoundSet.getAminoAcidCompoundSet());
-		SequenceHeaderParserInterface<ProteinSequence, AminoAcidCompound> headerParser = new GenericFastaHeaderParser<ProteinSequence, AminoAcidCompound>();
-		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<ProteinSequence, AminoAcidCompound>(
+		SequenceHeaderParserInterface<ProteinSequence, AminoAcidCompound> headerParser = new GenericFastaHeaderParser<>();
+		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<>(
 				inStream, headerParser, creator);
 		LinkedHashMap<String, ProteinSequence> sequences = fastaReader.process();
 		inStream.close();
@@ -236,8 +236,8 @@ public class FastaAFPChainConverter {
 			throw new IllegalArgumentException("A structure is null");
 		}
 
-		List<ProteinSequence> seqs = new ArrayList<ProteinSequence>();
-		List<String> names = new ArrayList<String>(2);
+		List<ProteinSequence> seqs = new ArrayList<>();
+		List<String> names = new ArrayList<>(2);
 		for (Map.Entry<String, ProteinSequence> entry : sequences.entrySet()) {
 			seqs.add(entry.getValue());
 			names.add(entry.getKey());
@@ -321,7 +321,7 @@ public class FastaAFPChainConverter {
 				sb1.append(a.getBase());
 			}
 			ProteinSequence seq2 = new ProteinSequence(sb2.toString());
-			LinkedHashMap<String, ProteinSequence> map = new LinkedHashMap<String, ProteinSequence>();
+			LinkedHashMap<String, ProteinSequence> map = new LinkedHashMap<>();
 			map.put(structure1.getName(), seq1);
 			map.put(structure2.getName(), seq2);
 			return fastaToAfpChain(map, structure1, structure2);
@@ -349,8 +349,8 @@ public class FastaAFPChainConverter {
 
 		// remove any gap
 		// this includes the ones introduced by the nullifying above
-		List<ResidueNumber> alignedResiduesList1 = new ArrayList<ResidueNumber>();
-		List<ResidueNumber> alignedResiduesList2 = new ArrayList<ResidueNumber>();
+		List<ResidueNumber> alignedResiduesList1 = new ArrayList<>();
+		List<ResidueNumber> alignedResiduesList2 = new ArrayList<>();
 		for (int i = 0; i < residues1.length; i++) {
 			if (residues1[i] != null && residues2[i] != null) {
 				alignedResiduesList1.add(residues1[i]);
@@ -379,7 +379,7 @@ public class FastaAFPChainConverter {
 	 * @param sequence Make sure <em>not</em> to use {@link ProteinSequence#getSequenceAsString()} for this, as it won't preserve upper- and lower-case
 	 */
 	public static List<Object> getAlignedUserCollection(String sequence) {
-		List<Object> aligned = new ArrayList<Object>(sequence.length());
+		List<Object> aligned = new ArrayList<>(sequence.length());
 		for (char c : sequence.toCharArray()) {
 			aligned.add(Character.isUpperCase(c));
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/GroupToSDF.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/GroupToSDF.java
@@ -130,7 +130,7 @@ public class GroupToSDF {
 
 	private static List<Number> getAtomCharges(Group group) {
 		// The list to store the answer
-		List<Number> outArr = new ArrayList<Number>();
+		List<Number> outArr = new ArrayList<>();
 		// Get the atom charge Information
 		for(Atom a: group.getAtoms()){
 			outArr.add(a.getCharge());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/LocalPDBDirectory.java
@@ -174,7 +174,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 	 * @param path Path to the PDB file directory
 	 */
 	public LocalPDBDirectory(String path) {
-		extensions    = new ArrayList<String>();
+		extensions    = new ArrayList<>();
 
 		params = new FileParsingParameters();
 
@@ -677,7 +677,7 @@ public abstract class LocalPDBDirectory implements StructureIOFile {
 		// Search directories:
 		// 1) LOCAL_MMCIF_SPLIT_DIR/<middle>/(pdb)?<pdbId>.<ext>
 		// 2) LOCAL_MMCIF_ALL_DIR/<middle>/(pdb)?<pdbId>.<ext>
-		LinkedList<File> searchdirs = new LinkedList<File>();
+		LinkedList<File> searchdirs = new LinkedList<>();
 		String middle = id.substring(offset, offset+2).toLowerCase();
 
 		File splitdir = new File(splitDirPath, middle);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBBioAssemblyParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBBioAssemblyParser.java
@@ -41,10 +41,10 @@ public class PDBBioAssemblyParser {
 	//private static final Logger logger = LoggerFactory.getLogger(PDBBioAssemblyParser.class);
 
 	private Integer currentBioMolecule = null;
-	private List<String> currentChainIDs = new ArrayList<String>();
+	private List<String> currentChainIDs = new ArrayList<>();
 	private Matrix currentMatrix = null;
 	private double[] shift = null;
-	private Map<Integer,BioAssemblyInfo> transformationMap = new HashMap<Integer, BioAssemblyInfo>();
+	private Map<Integer,BioAssemblyInfo> transformationMap = new HashMap<>();
 	private int modelNumber = 1;
 
 	private List<BiologicalAssemblyTransformation> transformations;
@@ -159,7 +159,7 @@ public class PDBBioAssemblyParser {
 	}
 
 	private void initialize() {
-		transformations = new ArrayList<BiologicalAssemblyTransformation>();
+		transformations = new ArrayList<>();
 		currentMatrix = Matrix.identity(3,3);
 		currentBioMolecule = null;
 		shift = new double[3];

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/PDBFileParser.java
@@ -177,15 +177,15 @@ public class PDBFileParser  {
 	private boolean isLastCompndLine = false;
 	private boolean isLastSourceLine = false;
 	private EntityInfo current_compound;
-	private List<EntityInfo> entities = new ArrayList<EntityInfo>();
-	private HashMap<Integer,List<String>> compoundMolIds2chainIds = new HashMap<Integer, List<String>>();
-	private List<String> compndLines = new ArrayList<String>();
-	private List<String> sourceLines = new ArrayList<String>();
-	private List<String> journalLines = new ArrayList<String>();
-	private List<String> keywordsLines = new ArrayList<String>();
+	private List<EntityInfo> entities = new ArrayList<>();
+	private HashMap<Integer,List<String>> compoundMolIds2chainIds = new HashMap<>();
+	private List<String> compndLines = new ArrayList<>();
+	private List<String> sourceLines = new ArrayList<>();
+	private List<String> journalLines = new ArrayList<>();
+	private List<String> keywordsLines = new ArrayList<>();
 	private List<DBRef> dbrefs;
-	private Map<String, Site> siteMap = new LinkedHashMap<String, Site>();
-	private Map<String, List<ResidueNumber>> siteToResidueMap = new LinkedHashMap<String, List<ResidueNumber>>();
+	private Map<String, Site> siteMap = new LinkedHashMap<>();
+	private Map<String, List<ResidueNumber>> siteToResidueMap = new LinkedHashMap<>();
 
 	private List<SSBondImpl> ssbonds = new ArrayList<>();
 
@@ -207,7 +207,7 @@ public class PDBFileParser  {
 	private float rfreeStandardLine = -1;
 	private float rfreeNoCutoffLine = -1;
 
-	private static  final List<String> compndFieldValues = new ArrayList<String>(
+	private static  final List<String> compndFieldValues = new ArrayList<>(
 			Arrays.asList(
 					"MOL_ID:", "MOLECULE:", "CHAIN:", "SYNONYM:",
 					"EC:", "FRAGMENT:", "ENGINEERED:", "MUTATION:",
@@ -215,14 +215,14 @@ public class PDBFileParser  {
 					));
 
 
-	private static final List<String> ignoreCompndFieldValues = new ArrayList<String>(
+	private static final List<String> ignoreCompndFieldValues = new ArrayList<>(
 			Arrays.asList(
 					"HETEROGEN:","ENGINEEREED:","FRAGMENT,",
 					"MUTANT:","SYNTHETIC:"
 					));
 	// ENGINEEREED in pdb219d
 
-	private static final List<String> sourceFieldValues = new ArrayList<String>(
+	private static final List<String> sourceFieldValues = new ArrayList<>(
 			Arrays.asList("ENGINEERED:", "MOL_ID:", "SYNTHETIC:", "FRAGMENT:",
 					"ORGANISM_SCIENTIFIC:", "ORGANISM_COMMON:",
 					"ORGANISM_TAXID:","STRAIN:",
@@ -274,14 +274,14 @@ public class PDBFileParser  {
 
 		pdbHeader 	  = new PDBHeader();
 		crystallographicInfo = new PDBCrystallographicInfo();
-		connects      = new ArrayList<Map<String,Integer>>() ;
+		connects      = new ArrayList<>() ;
 
 
-		helixList     = new ArrayList<Map<String,String>>();
-		strandList    = new ArrayList<Map<String,String>>();
-		turnList      = new ArrayList<Map<String,String>>();
+		helixList     = new ArrayList<>();
+		strandList    = new ArrayList<>();
+		turnList      = new ArrayList<>();
 		current_compound = null;
-		dbrefs        = new ArrayList<DBRef>();
+		dbrefs        = new ArrayList<>();
 		siteMap = null;
 		dateFormat = new SimpleDateFormat("dd-MMM-yy", Locale.US);
 		atomCount = 0;
@@ -294,7 +294,7 @@ public class PDBFileParser  {
 		loadMaxAtoms = params.getMaxAtoms();
 		atomCAThreshold = params.getAtomCaThreshold();
 
-		linkRecords = new ArrayList<LinkRecord>();
+		linkRecords = new ArrayList<>();
 
 		blankChainIdsPresent = false;
 
@@ -486,7 +486,7 @@ public class PDBFileParser  {
 		//System.out.println(initResName + " " + initChainId + " " + initSeqNum + " " + initICode + " " +
 		//        endResName + " " + endChainId + " " + endSeqNum + " " + endICode);
 
-		Map<String,String> m = new HashMap<String,String>();
+		Map<String,String> m = new HashMap<>();
 
 		m.put("initResName",initResName);
 		m.put("initChainId", initChainId);
@@ -573,7 +573,7 @@ public class PDBFileParser  {
 		//System.out.println(initResName + " " + initChainId + " " + initSeqNum + " " + initICode + " " +
 		//        endResName + " " + endChainId + " " + endSeqNum + " " + endICode);
 
-		Map<String,String> m = new HashMap<String,String>();
+		Map<String,String> m = new HashMap<>();
 
 		m.put("initResName",initResName);
 		m.put("initChainId", initChainId);
@@ -638,7 +638,7 @@ public class PDBFileParser  {
 		//System.out.println(initResName + " " + initChainId + " " + initSeqNum + " " + initICode + " " +
 		//        endResName + " " + endChainId + " " + endSeqNum + " " + endICode);
 
-		Map<String,String> m = new HashMap<String,String>();
+		Map<String,String> m = new HashMap<>();
 
 		m.put("initResName",initResName);
 		m.put("initChainId", initChainId);
@@ -1055,7 +1055,7 @@ public class PDBFileParser  {
 		if ("CHAIN:".equals(field)) {
 			//System.out.println(value);
 			StringTokenizer chainTokens = new StringTokenizer(value, ",");
-			List<String> chains = new ArrayList<String>();
+			List<String> chains = new ArrayList<>();
 
 			while (chainTokens.hasMoreTokens()) {
 				String chainID = chainTokens.nextToken().trim();
@@ -1070,7 +1070,7 @@ public class PDBFileParser  {
 		if ("SYNONYM:".equals(field)) {
 
 			StringTokenizer synonyms = new StringTokenizer(value, ",");
-			List<String> names = new ArrayList<String>();
+			List<String> names = new ArrayList<>();
 
 			while (synonyms.hasMoreTokens()) {
 				names.add(synonyms.nextToken());
@@ -1083,7 +1083,7 @@ public class PDBFileParser  {
 		if ("EC:".equals(field)) {
 
 			StringTokenizer ecNumTokens = new StringTokenizer(value, ",");
-			List<String> ecNums = new ArrayList<String>();
+			List<String> ecNums = new ArrayList<>();
 
 			while (ecNumTokens.hasMoreTokens()) {
 				ecNums.add(ecNumTokens.nextToken());
@@ -2079,7 +2079,7 @@ public class PDBFileParser  {
 
 			//System.out.println(atomserial+ " "+ bond1 +" "+bond2+ " " +bond3+" "+bond4+" "+
 			//		   hyd1+" "+hyd2 +" "+salt1+" "+hyd3+" "+hyd4+" "+salt2);
-			HashMap<String, Integer> cons = new HashMap<String, Integer>();
+			HashMap<String, Integer> cons = new HashMap<>();
 			cons.put("atomserial",atomserial);
 
 			if ( bond1 != null) cons.put("bond1",bond1);
@@ -2383,7 +2383,7 @@ public class PDBFileParser  {
 
 		//if the siteResidues doesn't yet exist, make a new one.
 		if (siteResidues == null || ! siteToResidueMap.containsKey(siteID.trim())){
-			siteResidues = new ArrayList<ResidueNumber>();
+			siteResidues = new ArrayList<>();
 			siteToResidueMap.put(siteID.trim(), siteResidues);
 
 			logger.debug(String.format("New Site made: %s %s", siteID,  siteResidues));
@@ -2600,10 +2600,10 @@ public class PDBFileParser  {
 		startOfMolecule = true;
 		startOfModel = true;
 
-		seqResChains  = new ArrayList<Chain>();
-		siteMap = new LinkedHashMap<String, Site>();
+		seqResChains  = new ArrayList<>();
+		siteMap = new LinkedHashMap<>();
 		pdbHeader     = new PDBHeader();
-		connects      = new ArrayList<Map<String,Integer>>();
+		connects      = new ArrayList<>();
 		previousContinuationField = "";
 		continuationField = "";
 		continuationString = "";
@@ -2621,7 +2621,7 @@ public class PDBFileParser  {
 		lengthCheck = -1;
 		atomCount = 0;
 		atomOverflow = false;
-		linkRecords = new ArrayList<LinkRecord>();
+		linkRecords = new ArrayList<>();
 		siteToResidueMap.clear();
 
 		blankChainIdsPresent = false;
@@ -2812,7 +2812,7 @@ public class PDBFileParser  {
 		}
 		String fulllengthList = fullList.toString();
 		keywords = fulllengthList.split("( )*,( )*");
-		ArrayList<String> lst = new ArrayList<String>(keywords.length);
+		ArrayList<String> lst = new ArrayList<>(keywords.length);
 		for (String keyword : keywords) {
 			if(keyword.length() == 0) {
 				logger.debug("Keyword empty in structure {}", structure.getIdentifier().toString());
@@ -3317,7 +3317,7 @@ public class PDBFileParser  {
 		List<Site> sites = null;
 		//check that there are chains with which to associate the groups
 		if (structure.getChains().isEmpty()) {
-			sites = new ArrayList<Site>(siteMap.values());
+			sites = new ArrayList<>(siteMap.values());
 			logger.info("No chains to link Site Groups with - Sites will not be present in the Structure");
 			return;
 		}
@@ -3360,7 +3360,7 @@ public class PDBFileParser  {
 
 		//System.out.println("SITEMAP: " + siteMap);
 
-		sites = new ArrayList<Site>(siteMap.values());
+		sites = new ArrayList<>(siteMap.values());
 		structure.setSites(sites);
 		//System.out.println("STRUCTURE SITES: " + structure.getSites().size());
 		//            for (Site site : structure.getSites()) {
@@ -3611,7 +3611,7 @@ public class PDBFileParser  {
 	}
 
 	private List<Author> authorBuilder(String authorString) {
-		ArrayList<Author> authorList = new ArrayList<Author>();
+		ArrayList<Author> authorList = new ArrayList<>();
 
 		if ("".equals(authorString)) {
 			return authorList;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/SeqRes2AtomAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/SeqRes2AtomAligner.java
@@ -453,8 +453,8 @@ public class SeqRes2AtomAligner {
 
 	private boolean alignNucleotideGroups(List<Group> seqRes, List<Group> atomRes) {
 
-		Map<Integer,Integer> seqresIndexPosition = new HashMap<Integer, Integer>();
-		Map<Integer,Integer> atomIndexPosition   = new HashMap<Integer, Integer>();
+		Map<Integer,Integer> seqresIndexPosition = new HashMap<>();
+		Map<Integer,Integer> atomIndexPosition   = new HashMap<>();
 
 		String seq1 = getFullAtomSequence(seqRes, seqresIndexPosition, true);
 		//
@@ -573,8 +573,8 @@ public class SeqRes2AtomAligner {
 	 */
 	private boolean alignProteinChains(List<Group> seqRes, List<Group> atomRes) {
 
-		Map<Integer,Integer> seqresIndexPosition = new HashMap<Integer, Integer>();
-		Map<Integer,Integer> atomIndexPosition   = new HashMap<Integer, Integer>();
+		Map<Integer,Integer> seqresIndexPosition = new HashMap<>();
+		Map<Integer,Integer> atomIndexPosition   = new HashMap<>();
 
 		String seq1 = getFullAtomSequence(seqRes, seqresIndexPosition, false);
 		//

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/StructureSequenceMatcher.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/StructureSequenceMatcher.java
@@ -118,7 +118,7 @@ public class StructureSequenceMatcher {
 
 		for(Chain chain : struct.getChains()) {
 			List<Group> groups = chain.getAtomGroups();
-			Map<Integer,Integer> chainIndexPosition = new HashMap<Integer, Integer>();
+			Map<Integer,Integer> chainIndexPosition = new HashMap<>();
 			int prevLen = seqStr.length();
 
 			// get the sequence for this chain
@@ -162,7 +162,7 @@ public class StructureSequenceMatcher {
 	public static ResidueNumber[] matchSequenceToStructure(ProteinSequence seq, Structure struct) {
 
 		//1. Create ProteinSequence for struct while remembering to which group each residue corresponds
-		Map<Integer,Group> atomIndexPosition   = new HashMap<Integer, Group>();
+		Map<Integer,Group> atomIndexPosition   = new HashMap<>();
 
 		ProteinSequence structSeq = getProteinSequenceForStructure(struct,atomIndexPosition);
 
@@ -171,10 +171,10 @@ public class StructureSequenceMatcher {
 		// Identity substitution matrix with +1 for match, -1 for mismatch
 		// TODO
 		SubstitutionMatrix<AminoAcidCompound> matrix =
-			new SimpleSubstitutionMatrix<AminoAcidCompound>(
+			new SimpleSubstitutionMatrix<>(
 					AminoAcidCompoundSet.getAminoAcidCompoundSet(),
 					(short)1, (short)-1 );
-		matrix = new SimpleSubstitutionMatrix<AminoAcidCompound>(
+		matrix = new SimpleSubstitutionMatrix<>(
 				AminoAcidCompoundSet.getAminoAcidCompoundSet(),
 				new InputStreamReader(
 						SimpleSubstitutionMatrix.class.getResourceAsStream("/matrices/blosum100.txt")),

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
@@ -934,7 +934,7 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
 
     @Override
     public void consumeStructKeywords(StructKeywords structKeywords) {
-        ArrayList<String> keywordsList = new ArrayList<String>();
+        ArrayList<String> keywordsList = new ArrayList<>();
 
         StrColumn text = structKeywords.getText();
         if (text.isDefined()) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfUtils.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/mmtf/MmtfUtils.java
@@ -256,8 +256,8 @@ public class MmtfUtils {
 	 * @return the atoms for the input Biojava Group
 	 */
 	public static List<Atom> getAtomsForGroup(Group inputGroup) {
-		Set<Atom> uniqueAtoms = new HashSet<Atom>();
-		List<Atom> theseAtoms = new ArrayList<Atom>();
+		Set<Atom> uniqueAtoms = new HashSet<>();
+		List<Atom> theseAtoms = new ArrayList<>();
 		for(Atom a: inputGroup.getAtoms()){
 			theseAtoms.add(a);
 			uniqueAtoms.add(a);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsChainToUniprotMapping.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsChainToUniprotMapping.java
@@ -156,9 +156,9 @@ public class SiftsChainToUniprotMapping {
 
 	}
 
-	private Map<String, SiftsChainEntry> byChainId = new HashMap<String, SiftsChainEntry>();
+	private Map<String, SiftsChainEntry> byChainId = new HashMap<>();
 
-	private Map<String, SiftsChainEntry> byUniProtId = new HashMap<String, SiftsChainEntry>();
+	private Map<String, SiftsChainEntry> byUniProtId = new HashMap<>();
 
 	private SiftsChainToUniprotMapping() {
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsEntity.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsEntity.java
@@ -46,7 +46,7 @@ public class SiftsEntity implements Serializable{
 	public SiftsEntity(String type, String entityId) {
 		this.type = type;
 		this.entityId = entityId;
-		segments = new ArrayList<SiftsSegment>();
+		segments = new ArrayList<>();
 	}
 
 	public void addSegment(SiftsSegment s) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsSegment.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsSegment.java
@@ -49,7 +49,7 @@ public class SiftsSegment implements Serializable{
 		this.segId = segId;
 		this.start = start;
 		this.end = end;
-		residues = new ArrayList<SiftsResidue>();
+		residues = new ArrayList<>();
 	}
 
 	public String getSegId() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsXMLParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/sifts/SiftsXMLParser.java
@@ -51,7 +51,7 @@ public class SiftsXMLParser {
 
 	static boolean debug = false;
 	public SiftsXMLParser(){
-		entities = new ArrayList<SiftsEntity>();
+		entities = new ArrayList<>();
 	}
 
 	public List<SiftsEntity> getEntities(){
@@ -60,7 +60,7 @@ public class SiftsXMLParser {
 
 
 	public void parseXmlFile(InputStream is){
-		entities = new ArrayList<SiftsEntity>();
+		entities = new ArrayList<>();
 
 		//get the factory
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -269,7 +269,7 @@ public class SiftsXMLParser {
 		}
 
 	private List<String> getTextValues(Element ele, String tagName) {
-		List<String>values = new ArrayList<String>();
+		List<String>values = new ArrayList<>();
 		NodeList nl = ele.getElementsByTagName(tagName);
 		if(nl != null && nl.getLength() > 0) {
 			for ( int i = 0 ;i < nl.getLength() ; i ++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/math/SparseVector.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/math/SparseVector.java
@@ -54,7 +54,7 @@ public class SparseVector implements Serializable{
 	 */
 	public SparseVector(int N) {
 		this.N  = N;
-		this.symbolTable = new SymbolTable<Integer, Double>();
+		this.symbolTable = new SymbolTable<>();
 	}
 
 	/** Setter method (should it be renamed to set?)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/math/SymbolTable.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/math/SymbolTable.java
@@ -69,7 +69,7 @@ public class SymbolTable<Key extends Comparable<Key>, Value> implements Iterable
 	 * Create an empty symbol table.
 	 */
 	public SymbolTable() {
-		st = new TreeMap<Key, Value>();
+		st = new TreeMap<>();
 	}
 
 	/**

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BioAssemblyTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BioAssemblyTools.java
@@ -76,7 +76,7 @@ public class BioAssemblyTools {
 		}
 
 		// expand ranges if present, i.e. 1-60 -> 1, 2, 3, ..., 60
-		List<String> operators = new ArrayList<String>();
+		List<String> operators = new ArrayList<>();
 		for (String component : components) {
 			if (component.contains("-")) {
 				operators.addAll(expandRange(component));
@@ -104,7 +104,7 @@ public class BioAssemblyTools {
 			throw new IllegalArgumentException("Invalid range specification in oper_expression: " + expression);
 		}
 
-		List<String> expandedExpression = new ArrayList<String>(last-first+1);
+		List<String> expandedExpression = new ArrayList<>(last-first+1);
 		for (int i = first; i <= last; i++) {
 			expandedExpression.add(String.valueOf(i));
 		}
@@ -127,7 +127,7 @@ public class BioAssemblyTools {
 		List<String> rightSide = parseSubExpression(subExpressions[1]);
 
 		// form the cartesian product of the two lists
-		CartesianProduct<String> product = new CartesianProduct<String>(leftSide, rightSide);
+		CartesianProduct<String> product = new CartesianProduct<>(leftSide, rightSide);
 		return product.getOrderedPairs();
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyBuilder.java
@@ -184,7 +184,7 @@ public class BiologicalAssemblyBuilder {
 	 * @return
 	 */
 	private List<String> getChainIds(Structure asymUnit) {
-		List<String> chainIds = new ArrayList<String>();
+		List<String> chainIds = new ArrayList<>();
 		for ( Chain c : asymUnit.getChains()){
 			String intChainID = c.getId();
 			chainIds.add(intChainID);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyTransformation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/BiologicalAssemblyTransformation.java
@@ -236,7 +236,7 @@ public class BiologicalAssemblyTransformation implements Cloneable, Comparable<B
 	public static List<BiologicalAssemblyTransformation> fromMultiXML(String xml) throws ParserConfigurationException, SAXException, IOException{
 
 
-		List<BiologicalAssemblyTransformation> transformations = new ArrayList<BiologicalAssemblyTransformation>();
+		List<BiologicalAssemblyTransformation> transformations = new ArrayList<>();
 
 		// read the XML of a string and returns a ModelTransformationmatrix
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/CartesianProduct.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/quaternary/CartesianProduct.java
@@ -60,7 +60,7 @@ public class CartesianProduct<T> {
 	 * @return the list of ordered pairs
 	 */
 	public List<OrderedPair<T>> getOrderedPairs() {
-		List<OrderedPair<T>> pairs = new ArrayList<OrderedPair<T>>(list1.size()*list2.size());
+		List<OrderedPair<T>> pairs = new ArrayList<>(list1.size()*list2.size());
 
 		for (T element1: list1) {
 			for (T element2: list2) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/Astral.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/Astral.java
@@ -101,7 +101,7 @@ public class Astral {
 		}
 	}
 
-	private static Map<String, SoftReference<Astral>> instances = new HashMap<String, SoftReference<Astral>>();
+	private static Map<String, SoftReference<Astral>> instances = new HashMap<>();
 
 	private static final Logger logger = LoggerFactory.getLogger(Astral.class);
 
@@ -203,8 +203,8 @@ public class Astral {
 	 * Parses the FASTA file opened by reader.
 	 */
 	private void init(Reader reader) {
-		names = new TreeSet<String>();
-		failedLines = new LinkedHashMap<Integer,String>();
+		names = new TreeSet<>();
+		failedLines = new LinkedHashMap<>();
 
 		BufferedReader br = null;
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/BerkeleyScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/BerkeleyScopInstallation.java
@@ -45,7 +45,7 @@ public class BerkeleyScopInstallation extends ScopInstallation {
 	 * A map from SCOP version names which the Berkeley server offers as a
 	 * download to an array of equivalent deprecated SCOP version names.
 	 */
-	public static final Map<String,String[]> EQUIVALENT_VERSIONS = new HashMap<String,String[]>();
+	public static final Map<String,String[]> EQUIVALENT_VERSIONS = new HashMap<>();
 
 	static {
 		EQUIVALENT_VERSIONS.put("2.01", new String[] {"1.75A"});

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopDomain.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopDomain.java
@@ -243,7 +243,7 @@ public class ScopDomain implements Serializable, Cloneable, StructureIdentifier 
 	 * Returns the chains this domain is defined over; contains more than 1 element only if this domains is a multi-chain domain.
 	 */
 	public Set<String> getChains() {
-		Set<String> chains = new HashSet<String>();
+		Set<String> chains = new HashSet<>();
 		List<ResidueRange> rrs = ResidueRange.parseMultiple(getRanges());
 		for (ResidueRange rr : rrs) chains.add(rr.getChainName());
 		return chains;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/scop/ScopInstallation.java
@@ -123,12 +123,12 @@ public class ScopInstallation implements LocalScopDatabase {
 		installedCom.set(false);
 
 		scopVersion = DEFAULT_VERSION;
-		mirrors = new ArrayList<ScopMirror>(1);
+		mirrors = new ArrayList<>(1);
 
-		domainMap = new HashMap<String, List<ScopDomain>>();
+		domainMap = new HashMap<>();
 
-		sunidMap  = new HashMap<Integer, ScopDescription>();
-		scopTree  = new TreeMap<Integer, ScopNode>();
+		sunidMap  = new HashMap<>();
+		scopTree  = new TreeMap<>();
 
 	}
 
@@ -189,7 +189,7 @@ public class ScopInstallation implements LocalScopDatabase {
 			throw new ScopIOException(e);
 		}
 
-		List<ScopDescription> matches = new ArrayList<ScopDescription>();
+		List<ScopDescription> matches = new ArrayList<>();
 		for (Integer i : sunidMap.keySet()){
 			ScopDescription sc = sunidMap.get(i);
 			if ( sc.getCategory().equals(category))
@@ -216,7 +216,7 @@ public class ScopInstallation implements LocalScopDatabase {
 			throw new ScopIOException(e);
 		}
 
-		List<ScopDescription> matches = new ArrayList<ScopDescription>();
+		List<ScopDescription> matches = new ArrayList<>();
 		for (Integer i : sunidMap.keySet()){
 			ScopDescription sc = sunidMap.get(i);
 
@@ -238,7 +238,7 @@ public class ScopInstallation implements LocalScopDatabase {
 		ScopNode node = getScopNode(domain.getSunid());
 
 
-		List<ScopNode> tree = new ArrayList<ScopNode>();
+		List<ScopNode> tree = new ArrayList<>();
 		while (node != null){
 
 			//System.out.println("This node: sunid:" + node.getSunid() );
@@ -257,7 +257,7 @@ public class ScopInstallation implements LocalScopDatabase {
 	@Override
 	public List<ScopDomain> filterByDomainName(String query) {
 
-		List<ScopDomain > domains = new ArrayList<ScopDomain>();
+		List<ScopDomain > domains = new ArrayList<>();
 		if (query.length() <5){
 			return domains;
 		}
@@ -292,7 +292,7 @@ public class ScopInstallation implements LocalScopDatabase {
 		}
 
 		query = query.toLowerCase();
-		List<ScopDescription> matches = new ArrayList<ScopDescription>();
+		List<ScopDescription> matches = new ArrayList<>();
 		for (Integer i : sunidMap.keySet()){
 			ScopDescription sc = sunidMap.get(i);
 
@@ -332,7 +332,7 @@ public class ScopInstallation implements LocalScopDatabase {
 
 		List<ScopDomain> doms = domainMap.get(pdbId.toLowerCase());
 
-		List<ScopDomain> retdoms = new ArrayList<ScopDomain>();
+		List<ScopDomain> retdoms = new ArrayList<>();
 
 		if ( doms == null)
 			return retdoms;
@@ -439,7 +439,7 @@ public class ScopInstallation implements LocalScopDatabase {
 			String children = spl[2];
 			String[] childIds = children.split(",");
 
-			List<Integer> chis = new ArrayList<Integer>();
+			List<Integer> chis = new ArrayList<>();
 
 			for ( String id : childIds){
 				if ( "-".equals(id))
@@ -483,7 +483,7 @@ public class ScopInstallation implements LocalScopDatabase {
 
 	private void parseComments(BufferedReader buffer) throws IOException {
 
-		commentsMap = new HashMap<Integer,List<String>>();
+		commentsMap = new HashMap<>();
 
 		int counter = 0;
 		String line;
@@ -495,7 +495,7 @@ public class ScopInstallation implements LocalScopDatabase {
 				commentsMap.put(sunId, new ArrayList<String>(1));
 				continue;
 			}
-			List<String> comments = new ArrayList<String>(parts.length - 1);
+			List<String> comments = new ArrayList<>(parts.length - 1);
 			for (int i = 1; i < parts.length; i++) {
 				String trimmed = parts[i].trim();
 				if( !trimmed.isEmpty() ) {
@@ -611,7 +611,7 @@ public class ScopInstallation implements LocalScopDatabase {
 			if ( domainMap.containsKey(pdbId)){
 				domainList = domainMap.get(pdbId);
 			} else {
-				domainList = new ArrayList<ScopDomain>();
+				domainList = new ArrayList<>();
 				domainMap.put(pdbId,domainList);
 			}
 
@@ -862,7 +862,7 @@ public class ScopInstallation implements LocalScopDatabase {
 			throw new ScopIOException(e);
 		}
 
-		List<ScopDomain> domains = new ArrayList<ScopDomain>();
+		List<ScopDomain> domains = new ArrayList<>();
 
 		for (String pdbId: domainMap.keySet()){
 			for (ScopDomain d : domainMap.get(pdbId)){
@@ -900,7 +900,7 @@ public class ScopInstallation implements LocalScopDatabase {
 		} catch (IOException e) {
 			throw new ScopIOException(e);
 		}
-		if (!commentsMap.containsKey(sunid)) return new ArrayList<String>(1);
+		if (!commentsMap.containsKey(sunid)) return new ArrayList<>(1);
 		return commentsMap.get(sunid);
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/DSSPParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/DSSPParser.java
@@ -124,7 +124,7 @@ public class DSSPParser {
 		String startLine = "  #  RESIDUE AA STRUCTURE BP1 BP2  ACC";
 		String line;
 
-		List<SecStrucState> secstruc = new ArrayList<SecStrucState>();
+		List<SecStrucState> secstruc = new ArrayList<>();
 
 		//Find the first line of the DSSP output
 		while((line = reader.readLine()) != null) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucCalc.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucCalc.java
@@ -104,8 +104,8 @@ public class SecStrucCalc {
 	private AtomContactSet contactSet;
 	private Map<ResidueNumber, Integer> indResMap;
 	public SecStrucCalc(){
-		ladders = new ArrayList<Ladder>();
-		bridges = new ArrayList<BetaBridge>();
+		ladders = new ArrayList<>();
+		bridges = new ArrayList<>();
 	}
 
 
@@ -120,11 +120,11 @@ public class SecStrucCalc {
 	public List<SecStrucState> calculate(Structure s, boolean assign)
 			throws StructureException {
 
-		List<SecStrucState> secstruc = new ArrayList<SecStrucState>();
+		List<SecStrucState> secstruc = new ArrayList<>();
 		for(int i=0; i<s.nrModels(); i++) {
 			// Reinitialise the global vars
-			ladders = new ArrayList<Ladder>();
-			bridges = new ArrayList<BetaBridge>();
+			ladders = new ArrayList<>();
+			bridges = new ArrayList<>();
 			groups = initGroupArray(s, i);
 			// Initialise the contact set for this structure
 			initContactSet();
@@ -424,7 +424,7 @@ public class SecStrucCalc {
 	private void findBridges() {
 		// Get the interator of contacts
 		Iterator<AtomContact> myIter = contactSet.iterator();
-		List<Pair<Integer>> outList = new ArrayList<Pair<Integer>>();
+		List<Pair<Integer>> outList = new ArrayList<>();
 
 		// Now iterate through this
 		while(myIter.hasNext()){
@@ -461,7 +461,7 @@ public class SecStrucCalc {
 				continue;
 			}
 
-			Pair<Integer> thisPair = new Pair<Integer>(i,j);
+			Pair<Integer> thisPair = new Pair<>(i,j);
 			outList.add(thisPair);
 		}
 		//
@@ -705,7 +705,7 @@ public class SecStrucCalc {
 	}
 
 	private static SecStrucGroup[] initGroupArray(Structure s, int modelId) {
-		List<SecStrucGroup> groupList = new ArrayList<SecStrucGroup>();
+		List<SecStrucGroup> groupList = new ArrayList<>();
 		//
 		for ( Chain c : s.getChains(modelId)){
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/secstruc/SecStrucTools.java
@@ -99,7 +99,7 @@ public class SecStrucTools {
 		int count = 0; // counts the number of residues in SSE
 
 		// Create a map for the IDs of the SSE in the structure
-		Map<SecStrucType, Integer> ids = new TreeMap<SecStrucType, Integer>();
+		Map<SecStrucType, Integer> ids = new TreeMap<>();
 		for (SecStrucType t : SecStrucType.values())
 			ids.put(t, 1);
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/axis/HelixAxisAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/axis/HelixAxisAligner.java
@@ -356,7 +356,7 @@ public class HelixAxisAligner extends AxisAligner {
 	 * @return list of orbits ordered by z-depth
 	 */
 	private void calcAlignedOrbits() {
-		Map<Double, List<Integer>> depthMap = new TreeMap<Double, List<Integer>>();
+		Map<Double, List<Integer>> depthMap = new TreeMap<>();
 		double[] depth = getSubunitZDepth();
 		alignedOrbits = calcOrbits();
 
@@ -585,7 +585,7 @@ public class HelixAxisAligner extends AxisAligner {
 	private List<List<Integer>> calcOrbits() {
 		int n = subunits.getSubunitCount();
 
-		List<List<Integer>> orbits = new ArrayList<List<Integer>>();
+		List<List<Integer>> orbits = new ArrayList<>();
 		for (int i = 0; i < n; i++) {
 			orbits.add(Collections.singletonList(i));
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/axis/RotationAxisAligner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/axis/RotationAxisAligner.java
@@ -236,7 +236,7 @@ public class RotationAxisAligner extends AxisAligner{
 	 * @return list of orbits ordered by z-depth
 	 */
 	private void calcAlignedOrbits() {
-		Map<Double, List<Integer>> depthMap = new TreeMap<Double, List<Integer>>();
+		Map<Double, List<Integer>> depthMap = new TreeMap<>();
 		double[] depth = getSubunitZDepth();
 		alignedOrbits = calcOrbits();
 
@@ -539,7 +539,7 @@ public class RotationAxisAligner extends AxisAligner{
 	 *
 	 */
 	private List<List<Integer>> getOrbitsByXYWidth() {
-		Map<Double, List<Integer>> widthMap = new TreeMap<Double, List<Integer>>();
+		Map<Double, List<Integer>> widthMap = new TreeMap<>();
 		double[] width = getSubunitXYWidth();
 		List<List<Integer>> orbits = calcOrbits();
 
@@ -608,14 +608,14 @@ public class RotationAxisAligner extends AxisAligner{
 		int n = subunits.getSubunitCount();
 		int fold = rotationGroup.getRotation(0).getFold();
 
-		List<List<Integer>> orbits = new ArrayList<List<Integer>>();
+		List<List<Integer>> orbits = new ArrayList<>();
 		boolean[] used = new boolean[n];
 		Arrays.fill(used, false);
 
 		for (int i = 0; i < n; i++) {
 			if (! used[i]) {
 				// determine the equivalent subunits
-				List<Integer> orbit = new ArrayList<Integer>(fold);
+				List<Integer> orbit = new ArrayList<>(fold);
 				for (int j = 0; j < fold; j++) {
 					List<Integer> permutation = rotationGroup.getRotation(j).getPermutation();
 					orbit.add(permutation.get(i));
@@ -637,7 +637,7 @@ public class RotationAxisAligner extends AxisAligner{
 //		System.out.println("Permutation0: " + p0);
 //		System.out.println("Permutation1: " + p1);
 
-		List<Integer> inRotationOrder = new ArrayList<Integer>(orbit.size());
+		List<Integer> inRotationOrder = new ArrayList<>(orbit.size());
 		inRotationOrder.add(orbit.get(0));
 		for (int i = 1; i < orbit.size(); i++) {
 			int current = inRotationOrder.get(i-1);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelicalRepeatUnit.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelicalRepeatUnit.java
@@ -30,7 +30,7 @@ public class HelicalRepeatUnit {
 	private QuatSymmetrySubunits subunits = null;
 	private List<Point3d> repeatUnitCenters = new ArrayList<Point3d>();
 	private List<Point3d[]> repeatUnits = new ArrayList<Point3d[]>();
-	private List<List<Integer>> repeatUnitIndices = new ArrayList<List<Integer>>();
+	private List<List<Integer>> repeatUnitIndices = new ArrayList<>();
 	private Map<Integer[], Integer> interactingNeighbors = Collections.emptyMap();
 
 public HelicalRepeatUnit(QuatSymmetrySubunits subunits) {
@@ -74,10 +74,10 @@ private void run() {
 private List<Point3d> calcRepeatUnitCenters() {
 
 	// TODO why do we use models here? it should not matter. Setting to 0 all
-	List<Integer> models = new ArrayList<Integer>(subunits.getSubunitCount());
+	List<Integer> models = new ArrayList<>(subunits.getSubunitCount());
 	for (int s = 0; s <subunits.getSubunitCount(); s++)
 		models.add(0);
-	Set<Integer> uniqueModels = new HashSet<Integer>(Arrays.asList(1));
+	Set<Integer> uniqueModels = new HashSet<>(Arrays.asList(1));
 
 	int modelCount = uniqueModels.size();
 	List<Integer> folds = this.subunits.getFolds();
@@ -90,7 +90,7 @@ private List<Point3d> calcRepeatUnitCenters() {
 	if (maxFold%modelCount == 0 && modelCount > 1 && subunits.getSubunitCount() > 3) {
 //		System.out.println("calcRepeatUnitCenters case 1");
 		for (int i = 0; i < modelCount; i++) {
-			List<Integer> subunitIndices = new ArrayList<Integer>();
+			List<Integer> subunitIndices = new ArrayList<>();
 			Point3d p = new Point3d();
 			int count = 0;
 //			System.out.println("Models: " + models.size());
@@ -113,7 +113,7 @@ private List<Point3d> calcRepeatUnitCenters() {
 		// Case of 3B5U: A14, but seems to form (A2)*7 and symmetry related subunits don't have direct contact
 		List<Integer> sequenceClusterIds = subunits.getClusterIds();
 		for (int i = 0; i < subunits.getSubunitCount(); i++) {
-			List<Integer> subunitIndices = new ArrayList<Integer>(1);
+			List<Integer> subunitIndices = new ArrayList<>(1);
 			if (sequenceClusterIds.get(i) == 0) {
 				repeatCenters.add(new Point3d(centers.get(i)));
 //				System.out.println("Orig Repeat unit: " + centers.get(i));
@@ -135,11 +135,11 @@ private List<Point3d> calcRepeatUnitCenters() {
 private List<Point3d[]> calcRepeatUnits() {
 
 	// TODO why do we use models here? it should not matter. Setting to 0 all
-	List<Integer> models = new ArrayList<Integer>(
+	List<Integer> models = new ArrayList<>(
 			subunits.getSubunitCount());
 	for (int s = 0; s < subunits.getSubunitCount(); s++)
 		models.add(0);
-	Set<Integer> uniqueModels = new HashSet<Integer>(Arrays.asList(1));
+	Set<Integer> uniqueModels = new HashSet<>(Arrays.asList(1));
 
 	int modelCount = uniqueModels.size();
 	List<Integer> folds = this.subunits.getFolds();
@@ -180,7 +180,7 @@ private List<Point3d[]> calcRepeatUnits() {
 }
 
 private Map<Integer[], Integer> findInteractingNeigbors() {
-	Map<Integer[], Integer>  contactMap = new HashMap<Integer[], Integer>();
+	Map<Integer[], Integer>  contactMap = new HashMap<>();
 
 	Map<Integer, List<Integer[]>> distanceMap = findClosestPairs(8);
 	for (List<Integer[]> pairs: distanceMap.values())
@@ -196,9 +196,9 @@ private Map<Integer[], Integer> findInteractingNeigbors() {
 }
 
 private Map<Integer, List<Integer[]>> findClosestPairs(int maxNeighbors) {
-	Map<Integer, List<Integer[]>>  reducedMap = new TreeMap<Integer, List<Integer[]>>();
+	Map<Integer, List<Integer[]>>  reducedMap = new TreeMap<>();
 
-	Map<Integer, List<Integer[]>>  distanceMap = new TreeMap<Integer, List<Integer[]>>();
+	Map<Integer, List<Integer[]>>  distanceMap = new TreeMap<>();
 	int nCenters = repeatUnitCenters.size();
 //	System.out.println("repeatUnitCenters: " + repeatUnitCenters);
 
@@ -212,7 +212,7 @@ private Map<Integer, List<Integer[]>> findClosestPairs(int maxNeighbors) {
 			List<Integer[]> pairs = distanceMap.get(intDist);
 			// save only one representative pair for each distance
 			if (pairs == null) {
-				pairs = new ArrayList<Integer[]>();
+				pairs = new ArrayList<>();
 			}
 			Integer[] pair = new Integer[2];
 			pair[0] = i;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/Helix.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/Helix.java
@@ -161,7 +161,7 @@ public class Helix {
 	}
 
 	public List<List<Integer>> getLayerLines() {
-		List<List<Integer>> layerLines = new ArrayList<List<Integer>>();
+		List<List<Integer>> layerLines = new ArrayList<>();
 
 		createLineSegments(permutation, layerLines);
 
@@ -192,7 +192,7 @@ public class Helix {
 			List<List<Integer>> layerLines) {
 		for (int i = 0; i < permutation.size(); i++) {
 			if (permutation.get(i) != -1 ) {
-				List<Integer> lineSegment = new ArrayList<Integer>();
+				List<Integer> lineSegment = new ArrayList<>();
 				lineSegment.add(i);
 				lineSegment.add(permutation.get(i));
 				layerLines.add(lineSegment);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixExtender.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixExtender.java
@@ -40,7 +40,7 @@ public class HelixExtender {
 		List<List<Integer>> layerLines = helix.getLayerLines();
 
 		// get list of subunit indices to be used for helix extension
-		List<Integer> indices = new ArrayList<Integer>();
+		List<Integer> indices = new ArrayList<>();
 		for (List<Integer> line: layerLines) {
 			if (steps < 0) {
 				indices.add(line.get(0));

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixLayers.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixLayers.java
@@ -29,7 +29,7 @@ import java.util.List;
  * @author Peter
  */
 public class HelixLayers {
-	private List<Helix> helices = new ArrayList<Helix>();
+	private List<Helix> helices = new ArrayList<>();
 	private double symmetryDeviation = 0;
 
 	public int size() {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/HelixSolver.java
@@ -73,7 +73,7 @@ public class HelixSolver {
 		HelicalRepeatUnit unit = new HelicalRepeatUnit(subunits);
 		List<Point3d> repeatUnitCenters = unit.getRepeatUnitCenters();
 		List<Point3d[]> repeatUnits = unit.getRepeatUnits();
-		Set<List<Integer>> permutations = new HashSet<List<Integer>>();
+		Set<List<Integer>> permutations = new HashSet<>();
 
 		double minRise = parameters.getMinimumHelixRise() * fold; // for n-start
 																	// helix,
@@ -129,7 +129,7 @@ public class HelixSolver {
 
 
 			// keep track of which subunits are permuted
-			Set<Integer> permSet = new HashSet<Integer>();
+			Set<Integer> permSet = new HashSet<>();
 			int count = 0;
 			boolean valid = true;
 			for (int i = 0; i < permutation.size(); i++) {
@@ -355,7 +355,7 @@ public class HelixSolver {
 		List<Point3d> centers = subunits.getOriginalCenters();
 		List<Integer> seqClusterId = subunits.getClusterIds();
 
-		List<Integer> permutations = new ArrayList<Integer>(centers.size());
+		List<Integer> permutations = new ArrayList<>(centers.size());
 		double[] dSqs = new double[centers.size()];
 		boolean[] used = new boolean[centers.size()];
 		Arrays.fill(used, false);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/PermutationGroup.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/PermutationGroup.java
@@ -32,7 +32,7 @@ import java.util.Set;
  * @author Peter
  */
 public class PermutationGroup implements Iterable<List<Integer>> {
-	List<List<Integer>> permutations = new ArrayList<List<Integer>>();
+	List<List<Integer>> permutations = new ArrayList<>();
 
 	public void addPermutation(List<Integer> permutation) {
 		if (!permutations.contains(permutation)) {
@@ -60,13 +60,13 @@ public class PermutationGroup implements Iterable<List<Integer>> {
 	 */
 	public void completeGroup() {
 		// Copy initial set to allow permutations to grow
-		List<List<Integer>> gens = new ArrayList<List<Integer>>(permutations);
+		List<List<Integer>> gens = new ArrayList<>(permutations);
 		// Keep HashSet version of permutations for fast lookup.
-		Set<List<Integer>> known = new HashSet<List<Integer>>(permutations);
+		Set<List<Integer>> known = new HashSet<>(permutations);
 		//breadth-first search through the map of all members
-		List<List<Integer>> currentLevel = new ArrayList<List<Integer>>(permutations);
+		List<List<Integer>> currentLevel = new ArrayList<>(permutations);
 		while( currentLevel.size() > 0) {
-			List<List<Integer>> nextLevel = new ArrayList<List<Integer>>();
+			List<List<Integer>> nextLevel = new ArrayList<>();
 			for( List<Integer> p : currentLevel) {
 				for(List<Integer> gen : gens) {
 					List<Integer> y = combine(p,gen);
@@ -93,7 +93,7 @@ public class PermutationGroup implements Iterable<List<Integer>> {
 	}
 
 	public static List<Integer> combine(List<Integer> permutation1, List<Integer> permutation2) {
-		List<Integer> intermediate = new ArrayList<Integer>(permutation1.size());
+		List<Integer> intermediate = new ArrayList<>(permutation1.size());
 		for (int i = 0, n = permutation1.size(); i < n; i++) {
 			intermediate.add(permutation2.get(permutation1.get(i)));
 		}
@@ -101,7 +101,7 @@ public class PermutationGroup implements Iterable<List<Integer>> {
 	}
 
 	public static int getOrder(List<Integer> permutation) {
-		List<Integer> copy = new ArrayList<Integer>(permutation);
+		List<Integer> copy = new ArrayList<>(permutation);
 		for (int i = 0, n = permutation.size(); i < n; i++) {
 			copy = combine(copy, permutation);
 			if (copy.equals(permutation)) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryResults.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetryResults.java
@@ -72,7 +72,7 @@ public class QuatSymmetryResults {
 		this.stoichiometry = stoichiometry;
 		this.clusters = stoichiometry.getClusters();
 
-		subunits = new ArrayList<Subunit>();
+		subunits = new ArrayList<>();
 		for (SubunitCluster c : clusters) {
 			subunits.addAll(c.getSubunits());
 		}
@@ -95,7 +95,7 @@ public class QuatSymmetryResults {
 		this.stoichiometry = stoichiometry;
 		this.clusters = stoichiometry.getClusters();
 
-		subunits = new ArrayList<Subunit>();
+		subunits = new ArrayList<>();
 		for (SubunitCluster c : clusters) {
 			subunits.addAll(c.getSubunits());
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetrySubunits.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/QuatSymmetrySubunits.java
@@ -105,7 +105,7 @@ public class QuatSymmetrySubunits {
 	 */
 	public List<String> getChainIds() {
 
-		List<String> chains = new ArrayList<String>(getSubunitCount());
+		List<String> chains = new ArrayList<>(getSubunitCount());
 
 		// Loop through all subunits in the clusters and fill Lists
 		for (int c = 0; c < clusters.size(); c++) {
@@ -125,7 +125,7 @@ public class QuatSymmetrySubunits {
 	 */
 	public List<Integer> getModelNumbers() {
 
-		List<Integer> models = new ArrayList<Integer>(getSubunitCount());
+		List<Integer> models = new ArrayList<>(getSubunitCount());
 
 		// Loop through all subunits in the clusters and fill Lists
 		for (int c = 0; c < clusters.size(); c++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/RotationGroup.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/RotationGroup.java
@@ -35,7 +35,7 @@ import java.util.List;
  * @author Peter
  */
 public class RotationGroup implements Iterable<Rotation> {
-	private List<Rotation> rotations = new ArrayList<Rotation>();
+	private List<Rotation> rotations = new ArrayList<>();
 	private int principalAxisIndex = 0;
 	private int higherOrderRotationAxis = 0;
 	private int twoFoldsPerpendicular = 0;
@@ -61,7 +61,7 @@ public class RotationGroup implements Iterable<Rotation> {
 
 	public void setC1(int n) {
 		Rotation r = new Rotation();
-		List<Integer> permutation = new ArrayList<Integer>(n);
+		List<Integer> permutation = new ArrayList<>(n);
 		for (int i = 0; i < n; i++) {
 			permutation.add(i);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/RotationSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/RotationSolver.java
@@ -282,7 +282,7 @@ public class RotationSolver implements QuatSymmetrySolver {
 			n = 60;
 		}
 		List<Integer> folds = subunits.getFolds();
-		List<Double> angles = new ArrayList<Double>(folds.size()-1);
+		List<Double> angles = new ArrayList<>(folds.size()-1);
 
 		// note this loop starts at 1, we do ignore 1-fold symmetry, which is the first entry
 		for (int fold: folds) {
@@ -370,7 +370,7 @@ public class RotationSolver implements QuatSymmetrySolver {
 
 	private void setupDistanceBox() {
 		distanceThreshold = calcDistanceThreshold();
-		box = new DistanceBox<Integer>(distanceThreshold);
+		box = new DistanceBox<>(distanceThreshold);
 
 		for (int i = 0; i < originalCoords.length; i++) {
 			box.addPoint(originalCoords[i], i);
@@ -402,7 +402,7 @@ public class RotationSolver implements QuatSymmetrySolver {
 	 * @return A list mapping each subunit to the closest transformed subunit
 	 */
 	private List<Integer> getPermutation() {
-		List<Integer> permutation = new ArrayList<Integer>(transformedCoords.length);
+		List<Integer> permutation = new ArrayList<>(transformedCoords.length);
 		double sum = 0.0f;
 
 		for (Point3d t: transformedCoords) {
@@ -432,7 +432,7 @@ public class RotationSolver implements QuatSymmetrySolver {
 		}
 
 		// check uniqueness of indices
-		Set<Integer> set = new HashSet<Integer>(permutation);
+		Set<Integer> set = new HashSet<>(permutation);
 
 		// if size mismatch, clear permutation (its invalid)
 		if (set.size() != originalCoords.length) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/SystematicSolver.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/core/SystematicSolver.java
@@ -50,7 +50,7 @@ public class SystematicSolver implements QuatSymmetrySolver {
 	private RotationGroup rotations = new RotationGroup();
 	private Vector3d centroid = new Vector3d();
 	private Matrix4d centroidInverse = new Matrix4d();
-	private Set<List<Integer>> hashCodes = new HashSet<List<Integer>>();
+	private Set<List<Integer>> hashCodes = new HashSet<>();
 
 	public SystematicSolver(QuatSymmetrySubunits subunits, QuatSymmetryParameters parameters) {
 		if (subunits.getSubunitCount()== 2) {
@@ -77,7 +77,7 @@ public class SystematicSolver implements QuatSymmetrySolver {
 		// loop over all permutations
 		while (g.hasMore()) {
 			int[] perm = g.getNext();
-			List<Integer> permutation = new ArrayList<Integer>(perm.length);
+			List<Integer> permutation = new ArrayList<>(perm.length);
 			for (int j = 0; j < n; j++) {
 				permutation.add(perm[j]);
 			}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/geometry/DistanceBox.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/geometry/DistanceBox.java
@@ -63,12 +63,12 @@ public class DistanceBox<T> {
 		1 + ( 1 * 10000) + ( 1 * 1000000000L)
 	};
 
-	private List<T> tempBox = new ArrayList<T>(offset.length);
+	private List<T> tempBox = new ArrayList<>(offset.length);
 
 	/** Creates a new instance of DistanceBox */
 	public DistanceBox(double binWidth) {
-		map = new HashMap<Long, List<T>>();
-		layerMap = new HashMap<Long, List<T>>();
+		map = new HashMap<>();
+		layerMap = new HashMap<>();
 		this.inverseBinWidth = 1.0f/binWidth;
 		this.modified = true;
 	}
@@ -82,7 +82,7 @@ public class DistanceBox<T> {
 		List<T> box = map.get(location);
 
 		if (box == null) {
-			box = new ArrayList<T>();
+			box = new ArrayList<>();
 			map.put(location, box);
 		}
 
@@ -127,8 +127,8 @@ public class DistanceBox<T> {
 	}
 
 	public List<T> getIntersection(DistanceBox<T> distanceBox) {
-		List<T> intersection = new ArrayList<T>();
-		HashSet<Long> checkedLocations = new HashSet<Long>();
+		List<T> intersection = new ArrayList<>();
+		HashSet<Long> checkedLocations = new HashSet<>();
 
 		for (Iterator<Long> iter = map.keySet().iterator(); iter.hasNext();) {
 			long location = iter.next();
@@ -171,7 +171,7 @@ public class DistanceBox<T> {
 		} else if (tempBox.size() == 1) {
 			boxTwo = Collections.singletonList(tempBox.get(0));
 		} else {
-			boxTwo = new ArrayList<T>(tempBox);
+			boxTwo = new ArrayList<>(tempBox);
 		}
 		return boxTwo;
 	}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/geometry/Prism.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/geometry/Prism.java
@@ -119,7 +119,7 @@ public class Prism implements Polyhedron {
 
 	@Override
 	public List<int[]> getLineLoops() {
-		List<int[]> list = new ArrayList<int[]>();
+		List<int[]> list = new ArrayList<>();
 		int[] l1 = new int[2*n+2];
 		for (int i = 0; i < n; i++) {
 			l1[i] = i;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymm.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymm.java
@@ -189,7 +189,7 @@ public class CeSymm {
 		CECalculator calculator = new CECalculator(params);
 		Matrix lastMatrix = null;
 
-		List<AFPChain> selfAlignments = new ArrayList<AFPChain>();
+		List<AFPChain> selfAlignments = new ArrayList<>();
 		AFPChain optimalAFP = null;
 
 		// STEP 2: perform the self-alignments of the structure

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymmIterative.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymmIterative.java
@@ -89,7 +89,7 @@ public class CeSymmIterative {
 	public CeSymmIterative(CESymmParameters param) {
 		params = param;
 		alignGraph = new SimpleGraph<Integer, DefaultEdge>(DefaultEdge.class);
-		levels = new ArrayList<CeSymmResult>();
+		levels = new ArrayList<>();
 	}
 
 	/**
@@ -231,7 +231,7 @@ public class CeSymmIterative {
 		ConnectivityInspector<Integer, DefaultEdge> inspector = new ConnectivityInspector<Integer, DefaultEdge>(
 				alignGraph);
 		List<Set<Integer>> comps = inspector.connectedSets();
-		List<ResidueGroup> groups = new ArrayList<ResidueGroup>(comps.size());
+		List<ResidueGroup> groups = new ArrayList<>(comps.size());
 		for (Set<Integer> comp : comps)
 			groups.add(new ResidueGroup(comp));
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymmResult.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/CeSymmResult.java
@@ -106,7 +106,7 @@ public class CeSymmResult {
 		if (!isRefined())
 			return null;
 
-		List<StructureIdentifier> repeats = new ArrayList<StructureIdentifier>(
+		List<StructureIdentifier> repeats = new ArrayList<>(
 				numRepeats);
 
 		PdbId pdbId = structureId.toCanonical().getPdbId();

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/GraphComponentOrderDetector.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/GraphComponentOrderDetector.java
@@ -59,7 +59,7 @@ public class GraphComponentOrderDetector implements OrderDetector {
 		List<Set<Integer>> components = inspector.connectedSets();
 
 		// The order maximizes the residues aligned
-		Map<Integer, Integer> counts = new HashMap<Integer, Integer>();
+		Map<Integer, Integer> counts = new HashMap<>();
 		for (Set<Integer> c : components) {
 			if (counts.containsKey(c.size()))
 				counts.put(c.size(), counts.get(c.size()) + c.size());

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/GraphComponentRefiner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/GraphComponentRefiner.java
@@ -68,7 +68,7 @@ public class GraphComponentRefiner implements SymmetryRefiner {
 		List<Set<Integer>> components = inspector.connectedSets();
 
 		// Filter components with size != order, and transform to ResidueGroups
-		List<ResidueGroup> groups = new ArrayList<ResidueGroup>();
+		List<ResidueGroup> groups = new ArrayList<>();
 		for (Set<Integer> comp : components) {
 			if (comp.size() == order) {
 				ResidueGroup group = new ResidueGroup(comp);
@@ -103,7 +103,7 @@ public class GraphComponentRefiner implements SymmetryRefiner {
 		}
 
 		// The compatibility score is the sum of rows of the matrix
-		List<Integer> rowScores = new ArrayList<Integer>(size);
+		List<Integer> rowScores = new ArrayList<>(size);
 		for (int i = 0; i < size; i++) {
 			GVector row = new GVector(size);
 			matrix.getRow(i, row);
@@ -113,7 +113,7 @@ public class GraphComponentRefiner implements SymmetryRefiner {
 		}
 
 		// Refined multiple alignment Block as a result
-		List<List<Integer>> alignRes = new ArrayList<List<Integer>>(order);
+		List<List<Integer>> alignRes = new ArrayList<>(order);
 		for (int i = 0; i < order; i++)
 			alignRes.add(new ArrayList<Integer>());
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/ResidueGroup.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/ResidueGroup.java
@@ -48,7 +48,7 @@ public class ResidueGroup {
 	 */
 	public ResidueGroup(Set<Integer> component) {
 		// Transform component into sorted List of residues
-		residues = new ArrayList<Integer>(component);
+		residues = new ArrayList<>(component);
 		Collections.sort(residues);
 	}
 

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/SequenceFunctionRefiner.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/SequenceFunctionRefiner.java
@@ -117,8 +117,8 @@ public class SequenceFunctionRefiner implements SymmetryRefiner {
 		//  2. f^K-1(x) is defined
 		//	3. score(f^K-1(x))>0
 
-		TreeSet<Integer> forwardLoops = new TreeSet<Integer>();
-		TreeSet<Integer> backwardLoops = new TreeSet<Integer>();
+		TreeSet<Integer> forwardLoops = new TreeSet<>();
+		TreeSet<Integer> backwardLoops = new TreeSet<>();
 
 
 		List<Integer> eligible = null;
@@ -240,7 +240,7 @@ public class SequenceFunctionRefiner implements SymmetryRefiner {
 
 		// Assume all residues are eligible to start
 		if(eligible == null) {
-			eligible = new LinkedList<Integer>(alignment.keySet());
+			eligible = new LinkedList<>(alignment.keySet());
 		}
 
 		// Precalculate f^K-1(x)
@@ -334,8 +334,8 @@ public class SequenceFunctionRefiner implements SymmetryRefiner {
 	private static Map<Integer, Integer> applyAlignmentAndCheckCycles(Map<Integer, Integer> alignmentMap, int k, List<Integer> eligible) {
 
 		// Convert to lists to establish a fixed order (avoid concurrent modification)
-		List<Integer> preimage = new ArrayList<Integer>(alignmentMap.keySet()); // currently unmodified
-		List<Integer> image = new ArrayList<Integer>(preimage);
+		List<Integer> preimage = new ArrayList<>(alignmentMap.keySet()); // currently unmodified
+		List<Integer> image = new ArrayList<>(preimage);
 
 		for (int n = 1; n <= k; n++) {
 			// apply alignment
@@ -351,7 +351,7 @@ public class SequenceFunctionRefiner implements SymmetryRefiner {
 			}
 		}
 
-		Map<Integer, Integer> imageMap = new HashMap<Integer, Integer>(alignmentMap.size());
+		Map<Integer, Integer> imageMap = new HashMap<>(alignmentMap.size());
 
 		// now populate with actual values
 		for (int i = 0; i < preimage.size(); i++) {
@@ -372,7 +372,7 @@ public class SequenceFunctionRefiner implements SymmetryRefiner {
 	private static Map<Integer, Double> initializeScores(Map<Integer, Integer> alignment,
 			Map<Integer, Double> scores, int k) {
 		if(scores == null) {
-			scores = new HashMap<Integer, Double>(alignment.size());
+			scores = new HashMap<>(alignment.size());
 		} else {
 			scores.clear();
 		}
@@ -444,7 +444,7 @@ public class SequenceFunctionRefiner implements SymmetryRefiner {
 		int repeatLen = afpChain.getOptLength()/order;
 
 		//Extract all the residues considered in the first chain of the alignment
-		List<Integer> alignedRes = new ArrayList<Integer>();
+		List<Integer> alignedRes = new ArrayList<>();
 		for (int su=0; su<afpChain.getBlockNum(); su++){
 			for (int i=0; i<afpChain.getOptLen()[su]; i++){
 				alignedRes.add(afpChain.getOptAln()[su][0][i]);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/SymmOptimizer.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/SymmOptimizer.java
@@ -146,21 +146,21 @@ public class SymmOptimizer {
 					"Seed alignment too short: repeat core length < 1");
 
 		// Initialize the history variables
-		timeHistory = new ArrayList<Long>();
-		lengthHistory = new ArrayList<Integer>();
-		rmsdHistory = new ArrayList<Double>();
-		mcScoreHistory = new ArrayList<Double>();
-		tmScoreHistory = new ArrayList<Double>();
+		timeHistory = new ArrayList<>();
+		lengthHistory = new ArrayList<>();
+		rmsdHistory = new ArrayList<>();
+		mcScoreHistory = new ArrayList<>();
+		tmScoreHistory = new ArrayList<>();
 
 		C = 20 * order;
 
 		// Initialize alignment variables
 		block = msa.getBlock(0).getAlignRes();
-		freePool = new ArrayList<Integer>();
+		freePool = new ArrayList<>();
 		length = block.get(0).size();
 
 		// Store the residues aligned in the block
-		List<Integer> aligned = new ArrayList<Integer>();
+		List<Integer> aligned = new ArrayList<>();
 		for (int su = 0; su < order; su++)
 			aligned.addAll(block.get(su));
 
@@ -196,11 +196,11 @@ public class SymmOptimizer {
 		initialize();
 
 		// Save the optimal alignment
-		List<List<Integer>> optBlock = new ArrayList<List<Integer>>();
-		List<Integer> optFreePool = new ArrayList<Integer>();
+		List<List<Integer>> optBlock = new ArrayList<>();
+		List<Integer> optFreePool = new ArrayList<>();
 		optFreePool.addAll(freePool);
 		for (int k = 0; k < order; k++) {
-			List<Integer> b = new ArrayList<Integer>();
+			List<Integer> b = new ArrayList<>();
 			b.addAll(block.get(k));
 			optBlock.add(b);
 		}
@@ -214,11 +214,11 @@ public class SymmOptimizer {
 		while (i < maxIter && conv < stepsToConverge) {
 
 			// Save the state of the system
-			List<List<Integer>> lastBlock = new ArrayList<List<Integer>>();
-			List<Integer> lastFreePool = new ArrayList<Integer>();
+			List<List<Integer>> lastBlock = new ArrayList<>();
+			List<Integer> lastFreePool = new ArrayList<>();
 			lastFreePool.addAll(freePool);
 			for (int k = 0; k < order; k++) {
-				List<Integer> b = new ArrayList<Integer>();
+				List<Integer> b = new ArrayList<>();
 				b.addAll(block.get(k));
 				lastBlock.add(b);
 			}
@@ -281,11 +281,11 @@ public class SymmOptimizer {
 
 			// Store as the optimal alignment if better
 			if (mcScore > optScore) {
-				optBlock = new ArrayList<List<Integer>>();
-				optFreePool = new ArrayList<Integer>();
+				optBlock = new ArrayList<>();
+				optFreePool = new ArrayList<>();
 				optFreePool.addAll(freePool);
 				for (int k = 0; k < order; k++) {
-					List<Integer> b = new ArrayList<Integer>();
+					List<Integer> b = new ArrayList<>();
 					b.addAll(block.get(k));
 					optBlock.add(b);
 				}
@@ -366,7 +366,7 @@ public class SymmOptimizer {
 	 */
 	private boolean checkGaps() {
 
-		List<Integer> shrinkColumns = new ArrayList<Integer>();
+		List<Integer> shrinkColumns = new ArrayList<>();
 		// Loop for each column
 		for (int res = 0; res < length; res++) {
 			int gapCount = 0;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/SymmetryAxes.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/internal/SymmetryAxes.java
@@ -541,7 +541,7 @@ public class SymmetryAxes {
 	 * @return List of first Repeats of each index, sorted in ascending order
 	 */
 	public List<Integer> getFirstRepeats(int level) {
-		List<Integer> firstRepeats = new ArrayList<Integer>();
+		List<Integer> firstRepeats = new ArrayList<>();
 		int m = getNumRepeats(level+1); //size of the level
 		int d = axes.get(level).getOrder(); //degree of this level
 		int n = m*d; // number of repeats included in each axis

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/misc/ProteinComplexSignature.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/misc/ProteinComplexSignature.java
@@ -29,7 +29,7 @@ public class ProteinComplexSignature {
 	private BlastClustReader blastClust = null;
 	private String pdbId = "";
 	private List<String> chainIds = null;
-	private List<ChainSignature> chainSignatures = new ArrayList<ChainSignature>();
+	private List<ChainSignature> chainSignatures = new ArrayList<>();
 
 
 	public ProteinComplexSignature(String pdbId, List<String> chainIds, BlastClustReader blastClust) {
@@ -75,15 +75,15 @@ public class ProteinComplexSignature {
 	private List<ChainSignature> getChainSignatures() {
 		String alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-		Map<String,Integer> mapCounts = new TreeMap<String,Integer>();
-		Map<String,List<String>> mapChainIds = new TreeMap<String, List<String>>();
+		Map<String,Integer> mapCounts = new TreeMap<>();
+		Map<String,List<String>> mapChainIds = new TreeMap<>();
 
 		for (String chainId: chainIds) {
 			String rep = blastClust.getRepresentativeChain(pdbId, chainId);
 			Integer value = mapCounts.get(rep);
 			if (value == null) {
 				mapCounts.put(rep, 1);
-				List<String> list = new ArrayList<String>();
+				List<String> list = new ArrayList<>();
 				list.add(chainId);
 				mapChainIds.put(rep, list);
 			} else {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/BlastClustReader.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/BlastClustReader.java
@@ -102,7 +102,7 @@ public class BlastClustReader implements Serializable {
 		loadClusters(sequenceIdentity);
 		String pdbIdUpper = pdbId.toUpperCase();
 
-		List<List<String>> matches = new ArrayList<List<String>>();
+		List<List<String>> matches = new ArrayList<>();
 		for (List<String> cluster: clusters) {
 			for (String chainId: cluster) {
 				if (chainId.startsWith(pdbIdUpper)) {
@@ -117,14 +117,14 @@ public class BlastClustReader implements Serializable {
 	public List<List<String>> getChainIdsInEntry(String pdbId) {
 		loadClusters(sequenceIdentity);
 
-		List<List<String>> matches = new ArrayList<List<String>>();
+		List<List<String>> matches = new ArrayList<>();
 		List<String> match = null;
 
 		for (List<String> cluster: clusters) {
 			for (String chainId: cluster) {
 				if (chainId.startsWith(pdbId)) {
 					if (match == null) {
-						match = new ArrayList<String>();
+						match = new ArrayList<>();
 					}
 					match.add(chainId.substring(5));
 				}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/PowerSet.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/PowerSet.java
@@ -52,16 +52,16 @@ public class PowerSet<T> {
 	 * @return the set of power Sets of the original Set
 	 */
 	public Set<Set<T>> powerSet(Set<T> originalSet) {
-		Set<Set<T>> sets = new LinkedHashSet<Set<T>>();
+		Set<Set<T>> sets = new LinkedHashSet<>();
 		if (originalSet.isEmpty()) {
 			sets.add(new LinkedHashSet<T>());
 			return sets;
 		}
-		List<T> list = new ArrayList<T>(originalSet);
+		List<T> list = new ArrayList<>(originalSet);
 		T head = list.get(0);
-		Set<T> rest = new LinkedHashSet<T>(list.subList(1, list.size()));
+		Set<T> rest = new LinkedHashSet<>(list.subList(1, list.size()));
 		for (Set<T> set : powerSet(rest)) {
-			Set<T> newSet = new LinkedHashSet<T>();
+			Set<T> newSet = new LinkedHashSet<>();
 			newSet.add(head);
 			newSet.addAll(set);
 			sets.add(newSet);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/symmetry/utils/SymmetryTools.java
@@ -443,7 +443,7 @@ public class SymmetryTools {
 	public static List<List<Integer>> buildSymmetryGraph(List<AFPChain> afps,
 			Atom[] atoms, boolean undirected) {
 
-		List<List<Integer>> graph = new ArrayList<List<Integer>>();
+		List<List<Integer>> graph = new ArrayList<>();
 
 		for (int n = 0; n < atoms.length; n++) {
 			graph.add(new ArrayList<Integer>());
@@ -512,7 +512,7 @@ public class SymmetryTools {
 		Atom[] atoms = symmetry.getAtoms();
 		Set<Group> allGroups = StructureTools.getAllGroupsFromSubset(atoms, GroupType.HETATM);
 		List<StructureIdentifier> repeatsId = symmetry.getRepeatsID();
-		List<Structure> repeats = new ArrayList<Structure>(order);
+		List<Structure> repeats = new ArrayList<>(order);
 
 		// Create new structure containing the repeat atoms
 		for (int i = 0; i < order; i++) {
@@ -613,7 +613,7 @@ public class SymmetryTools {
 
 		MultipleAlignment repeats = newEnsemble.getMultipleAlignment(0);
 		Block block = repeats.getBlock(0);
-		List<Atom[]> atomArrays = new ArrayList<Atom[]>();
+		List<Atom[]> atomArrays = new ArrayList<>();
 
 		for (Structure s : repSt)
 			atomArrays.add(StructureTools.getRepresentativeAtomArray(s));
@@ -737,7 +737,7 @@ public class SymmetryTools {
 	 */
 	public static List<Group> getGroups(Atom[] rAtoms) {
 
-		List<Group> groups = new ArrayList<Group>(rAtoms.length);
+		List<Group> groups = new ArrayList<>(rAtoms.length);
 
 		for (Atom a : rAtoms) {
 			Group g = a.getGroup();
@@ -774,8 +774,8 @@ public class SymmetryTools {
 			for (int level = 0; level < axes.getNumLevels(); level++) {
 
 				// Calculate the aligned atom arrays to superimpose
-				List<Atom> list1 = new ArrayList<Atom>();
-				List<Atom> list2 = new ArrayList<Atom>();
+				List<Atom> list1 = new ArrayList<>();
+				List<Atom> list2 = new ArrayList<>();
 
 				for (int firstRepeat : axes.getFirstRepeats(level)) {
 
@@ -866,7 +866,7 @@ public class SymmetryTools {
 		else {
 
 			// Get Atoms of all models
-			List<Atom> atomList = new ArrayList<Atom>();
+			List<Atom> atomList = new ArrayList<>();
 			for (int m = 0; m < structure.nrModels(); m++) {
 				for (Chain c : structure.getModel(m))
 					atomList.addAll(Arrays.asList(StructureTools
@@ -888,7 +888,7 @@ public class SymmetryTools {
 	 */
 	public static List<Integer> getValidFolds(List<Integer> stoichiometry) {
 
-		List<Integer> denominators = new ArrayList<Integer>();
+		List<Integer> denominators = new ArrayList<>();
 
 		if (stoichiometry.isEmpty())
 			return denominators;
@@ -896,7 +896,7 @@ public class SymmetryTools {
 		int nChains = Collections.max(stoichiometry);
 
 		// Remove duplicate stoichiometries
-		Set<Integer> nominators = new TreeSet<Integer>(stoichiometry);
+		Set<Integer> nominators = new TreeSet<>(stoichiometry);
 
 		// find common denominators
 		for (int d = 1; d <= nChains; d++) {

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/BravaisLattice.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/BravaisLattice.java
@@ -62,7 +62,7 @@ public enum BravaisLattice {
 	}
 
 	private static HashMap<String,BravaisLattice> initname2bl(){
-		HashMap<String,BravaisLattice> name2bl = new HashMap<String, BravaisLattice>();
+		HashMap<String,BravaisLattice> name2bl = new HashMap<>();
 		for (BravaisLattice bl:BravaisLattice.values()) {
 			name2bl.put(bl.getName(), bl);
 		}

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalCell.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/CrystalCell.java
@@ -489,7 +489,7 @@ public class CrystalCell implements Serializable {
 		Point3d vert7 = new Point3d(1,1,1);
 		transfToOrthonormal(vert7);
 
-		ArrayList<Double> vertDists = new ArrayList<Double>();
+		ArrayList<Double> vertDists = new ArrayList<>();
 		vertDists.add(vert0.distance(vert7));
 		vertDists.add(vert3.distance(vert4));
 		vertDists.add(vert1.distance(vert6));

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/SpaceGroup.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/SpaceGroup.java
@@ -105,7 +105,7 @@ public class SpaceGroup implements Serializable {
 		this.shortSymbol = shortSymbol;
 		this.altShortSymbol = altShortSymbol;
 		transformations = new ArrayList<Matrix4d>(multiplicity);
-		transfAlgebraic = new ArrayList<String>(multiplicity);
+		transfAlgebraic = new ArrayList<>(multiplicity);
 		cellTranslations = new Vector3d[multiplicity/primitiveMultiplicity];
 		this.bravLattice = bravLattice;
 	}
@@ -649,7 +649,7 @@ public class SpaceGroup implements Serializable {
 			transformations = new ArrayList<Matrix4d>(transfAlgebraic.size());
 
 		if ( this.transfAlgebraic == null || this.transfAlgebraic.size() == 0)
-			this.transfAlgebraic = new ArrayList<String>(transfAlgebraic.size());
+			this.transfAlgebraic = new ArrayList<>(transfAlgebraic.size());
 
 		for ( String transf : transfAlgebraic){
 			addTransformation(transf);

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/SymoplibParser.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/SymoplibParser.java
@@ -98,7 +98,7 @@ public class SymoplibParser {
 			System.exit(1);
 		}
 
-		TreeMap<Integer, SpaceGroup> map = new TreeMap<Integer, SpaceGroup>();
+		TreeMap<Integer, SpaceGroup> map = new TreeMap<>();
 
 		try {
 			map = parseSpaceGroupsXML(spaceGroupIS);
@@ -110,7 +110,7 @@ public class SymoplibParser {
 			System.exit(1);
 		}
 
-		name2sgs = new HashMap<String, SpaceGroup>();
+		name2sgs = new HashMap<>();
 
 		for (SpaceGroup sg:map.values()) {
 
@@ -193,8 +193,8 @@ public class SymoplibParser {
 	 * @return
 	 */
 	public static TreeMap<Integer,SpaceGroup> parseSymopLib(InputStream symoplibIS) {
-		TreeMap<Integer, SpaceGroup> map = new TreeMap<Integer, SpaceGroup>();
-		name2sgs = new HashMap<String, SpaceGroup>();
+		TreeMap<Integer, SpaceGroup> map = new TreeMap<>();
+		name2sgs = new HashMap<>();
 		try {
 			BufferedReader br = new BufferedReader(new InputStreamReader(symoplibIS));
 			String line;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/io/SpaceGroupMapAdapter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/io/SpaceGroupMapAdapter.java
@@ -42,7 +42,7 @@ class SpaceGroupMapAdapter extends XmlAdapter<SpaceGroupMapElements[], Map<Integ
 
 	@Override
 	public Map<Integer, SpaceGroup> unmarshal(SpaceGroupMapElements[] arg0) throws Exception {
-		Map<Integer, SpaceGroup> r = new TreeMap<Integer, SpaceGroup>();
+		Map<Integer, SpaceGroup> r = new TreeMap<>();
 		for (SpaceGroupMapElements mapelement : arg0)
 			r.put(mapelement.key, mapelement.value);
 		return r;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/io/SpaceGroupMapRoot.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/io/SpaceGroupMapRoot.java
@@ -43,7 +43,7 @@ public class SpaceGroupMapRoot {
 	private TreeMap<Integer, SpaceGroup> mapProperty;
 
 	public SpaceGroupMapRoot() {
-		mapProperty = new TreeMap<Integer, SpaceGroup>();
+		mapProperty = new TreeMap<>();
 	}
 
 	@XmlJavaTypeAdapter(SpaceGroupMapAdapter.class)

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/io/TransfAlgebraicAdapter.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/io/TransfAlgebraicAdapter.java
@@ -41,7 +41,7 @@ public class TransfAlgebraicAdapter extends XmlAdapter<String[], List<String>>{
 
 	@Override
 	public List<String> unmarshal(String[] arg0) throws Exception {
-		List<String> l = new ArrayList<String>();
+		List<String> l = new ArrayList<>();
 		for (String s : arg0)
 			l.add(s);
 		return l;

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/io/TreeMapSpaceGroupWrapper.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/xtal/io/TreeMapSpaceGroupWrapper.java
@@ -52,7 +52,7 @@ public class TreeMapSpaceGroupWrapper implements Serializable{
 
 
 	public TreeMapSpaceGroupWrapper(){
-		data = new TreeMap<Integer,SpaceGroup>();
+		data = new TreeMap<>();
 	}
 
 	public TreeMap<Integer,SpaceGroup> getData() {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxCC.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxCC.java
@@ -42,9 +42,9 @@ public class CoxCC {
 	static public void process(CoxInfo ci) throws Exception {
 		ArrayList<SurvivalInfo> survivalInfoList = ci.survivalInfoList;
 		//r
-		ArrayList<String> variables = new ArrayList<String>(ci.getCoefficientsList().keySet());
+		ArrayList<String> variables = new ArrayList<>(ci.getCoefficientsList().keySet());
 
-		ArrayList<Integer> strataClass = new ArrayList<Integer>(survivalInfoList.size());
+		ArrayList<Integer> strataClass = new ArrayList<>(survivalInfoList.size());
 		double[] wt = new double[survivalInfoList.size()];
 		for (int i = 0; i < survivalInfoList.size(); i++) {
 			SurvivalInfo si = survivalInfoList.get(i);
@@ -75,7 +75,7 @@ public class CoxCC {
 			rvar = ci.getVariance();
 		}
 		//nj
-		LinkedHashMap<Integer, Double> nj = new LinkedHashMap<Integer, Double>();
+		LinkedHashMap<Integer, Double> nj = new LinkedHashMap<>();
 		Collections.sort(strataClass);
 		for (Integer value : strataClass) {
 			Double count = nj.get(value);
@@ -86,7 +86,7 @@ public class CoxCC {
 			nj.put(value, count);
 		}
 		//Nj
-		LinkedHashMap<Integer, Double> Nj = new LinkedHashMap<Integer, Double>();
+		LinkedHashMap<Integer, Double> Nj = new LinkedHashMap<>();
 		//N = N + Nj[key];
 		double N = 0;
 		for (int i = 0; i < survivalInfoList.size(); i++) {
@@ -106,7 +106,7 @@ public class CoxCC {
 			N = N + value;
 		}
 
-		LinkedHashMap<Integer, Double> k1j = new LinkedHashMap<Integer, Double>();
+		LinkedHashMap<Integer, Double> k1j = new LinkedHashMap<>();
 		for (Integer key : nj.keySet()) {
 			double _nj = (nj.get(key)); //trying to copy what R is doing on precision
 			double _Nj = (Nj.get(key));
@@ -119,7 +119,7 @@ public class CoxCC {
 		for (Integer i : k1j.keySet()) {
 			//          System.out.println("Strata=" + i + " " + k1j.get(i) + " " + Nj.get(i) + " " + nj.get(i));
 			if (nj.get(i) > 1) {
-				LinkedHashMap<String, DescriptiveStatistics> variableStatsMap = new LinkedHashMap<String, DescriptiveStatistics>();
+				LinkedHashMap<String, DescriptiveStatistics> variableStatsMap = new LinkedHashMap<>();
 
 				for (int p = 0; p < survivalInfoList.size(); p++) {
 					SurvivalInfo si = survivalInfoList.get(p);

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxHelper.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxHelper.java
@@ -71,7 +71,7 @@ public class CoxHelper {
 	public static CoxInfo process(WorkSheet worksheet, String timeColumn, String statusColumn, String weightColumn, String strataColumn, String clusterColumn, ArrayList<String> variables, boolean useStrata, boolean useWeights) {
 
 		try {
-			ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<SurvivalInfo>();
+			ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<>();
 
 			int i = 1;
 			for (String row : worksheet.getRows()) {
@@ -152,7 +152,7 @@ public class CoxHelper {
 		try {
 			if (true) {
 				String datafile = "/Users/Scooter/scripps/ngs/DataSets/E2197/misc/ecoglabtransfer/500790/2013.05.10.12.28.58.313/clindasl0228.txt";
-				ArrayList<String> variables = new ArrayList<String>();
+				ArrayList<String> variables = new ArrayList<>();
 				variables.add("nndpos");
 				variables.add("meno");
 //              variables.add("er1");

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxInfo.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxInfo.java
@@ -59,9 +59,9 @@ public class CoxInfo {
 	int numSamples = 0;
 	int numEvents = 0;
 	private LinkedHashMap<String, String> metaDataFilter = null;
-	private LinkedHashMap<String, CoxCoefficient> coefficientsList = new LinkedHashMap<String, CoxCoefficient>();
-	LinkedHashMap<Double, Double> baselineSurvivorFunction = new LinkedHashMap<Double, Double>();
-	ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<SurvivalInfo>();
+	private LinkedHashMap<String, CoxCoefficient> coefficientsList = new LinkedHashMap<>();
+	LinkedHashMap<Double, Double> baselineSurvivorFunction = new LinkedHashMap<>();
+	ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<>();
 	/**
 	 *
 	 */
@@ -184,7 +184,7 @@ public class CoxInfo {
 	 * @return
 	 */
 	public double[][] getVariableResiduals() {
-		ArrayList<String> variables = new ArrayList<String>(coefficientsList.keySet());
+		ArrayList<String> variables = new ArrayList<>(coefficientsList.keySet());
 		double[][] rr = new double[survivalInfoList.size()][variables.size()];
 		int p = 0;
 		for (SurvivalInfo si : this.survivalInfoList) {
@@ -204,7 +204,7 @@ public class CoxInfo {
 	 * @param rr
 	 */
 	public void setVariableResiduals(double[][] rr) {
-		ArrayList<String> variables = new ArrayList<String>(coefficientsList.keySet());
+		ArrayList<String> variables = new ArrayList<>(coefficientsList.keySet());
 
 		int p = 0;
 		for (SurvivalInfo si : this.survivalInfoList) {
@@ -320,7 +320,7 @@ public class CoxInfo {
 
 		//beta
 
-		ArrayList<String> variables = new ArrayList<String>(coefficientsList.keySet());
+		ArrayList<String> variables = new ArrayList<>(coefficientsList.keySet());
 		for (int i = 0; i < variables.size(); i++) {
 			String variable = variables.get(i);
 			CoxCoefficient coe = coefficientsList.get(variable);

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxR.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxR.java
@@ -273,7 +273,7 @@ public class CoxR {
 		ArrayList<String> clusterList = null;
 
 		if(cluster){
-			clusterList = new ArrayList<String>();
+			clusterList = new ArrayList<>();
 		}
 		//copy data over to local arrays to minimuze changing code
 		for (person = 0; person < nused; person++) {
@@ -797,7 +797,7 @@ public class CoxR {
 		double[] infs = Matrix.abs(Matrix.multiply(ci.u, ci.getVariance()));
 //        StdArrayIO.print(infs);
 
-		ArrayList<CoxCoefficient> coxCoefficients = new ArrayList<CoxCoefficient>(ci.getCoefficientsList().values());
+		ArrayList<CoxCoefficient> coxCoefficients = new ArrayList<>(ci.getCoefficientsList().values());
 
 		for (int i = 0; i < infs.length; i++) {
 			double inf = infs[i];
@@ -958,7 +958,7 @@ public class CoxR {
 
 
 				WorkSheet worksheet = WorkSheet.readCSV(is, '\t');
-				ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<SurvivalInfo>();
+				ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<>();
 				int i = 0;
 				for (String row : worksheet.getRows()) {
 					double time = worksheet.getCellDouble(row, "TIME");
@@ -977,7 +977,7 @@ public class CoxR {
 				}
 
 				CoxR cox = new CoxR();
-				ArrayList<String> variables = new ArrayList<String>();
+				ArrayList<String> variables = new ArrayList<>();
 				//               variables.add("AGE");
 
 				variables.add("AGE");

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxScore.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxScore.java
@@ -41,7 +41,7 @@ public class CoxScore {
 		double temp;
 		int n = survivalInfoList.size();
 
-		ArrayList<String> variables = new ArrayList<String>(coxInfo.getCoefficientsList().keySet());
+		ArrayList<String> variables = new ArrayList<>(coxInfo.getCoefficientsList().keySet());
 		int nvar = variables.size();
 
 		double deaths;

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxVariables.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/CoxVariables.java
@@ -55,7 +55,7 @@ public class CoxVariables {
 		String link = geneSet + "_" + cohortName;
 		return link.hashCode();
 	}
-	private LinkedHashMap<String, CoxInfo> coxInfoHashMap = new LinkedHashMap<String, CoxInfo>();
+	private LinkedHashMap<String, CoxInfo> coxInfoHashMap = new LinkedHashMap<>();
 
 	/**
 	 *

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/ResidualsCoxph.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/ResidualsCoxph.java
@@ -124,7 +124,7 @@ public class ResidualsCoxph {
 	 * @return
 	 */
 	private static double[][] rowsum(double[][] rr, ArrayList<String> sets) throws Exception {
-		LinkedHashMap<String, Double> sumMap = new LinkedHashMap<String, Double>();
+		LinkedHashMap<String, Double> sumMap = new LinkedHashMap<>();
 		if (rr.length != sets.size()) {
 			throw new Exception("Cluster value for each sample are not of equal length n=" + rr.length + " cluster length=" + sets.size());
 		}
@@ -144,7 +144,7 @@ public class ResidualsCoxph {
 				sum = new double[sumMap.size()][rr[0].length];
 			}
 
-			ArrayList<String> index = new ArrayList<String>(sumMap.keySet());
+			ArrayList<String> index = new ArrayList<>(sumMap.keySet());
 			//sorting does seem to make a difference in test cases at the .0000000001
 	   //     ArrayList<Integer> in = new ArrayList<Integer>();
 	   //     for (String s : index) {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/StrataInfo.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/StrataInfo.java
@@ -31,19 +31,19 @@ import java.util.LinkedHashMap;
  */
 public class StrataInfo {
 
-	private ArrayList<Double> time = new ArrayList<Double>();
-	private ArrayList<Integer> status = new ArrayList<Integer>();
-	private ArrayList<Double> nevent = new ArrayList<Double>();
-	private ArrayList<Double> ncens = new ArrayList<Double>();
-	private ArrayList<Double> nrisk = new ArrayList<Double>();
-	private ArrayList<Double> weight = new ArrayList<Double>();
-	private ArrayList<Double> surv = new ArrayList<Double>();
-	private ArrayList<Double> varhaz = new ArrayList<Double>();
-	private ArrayList<Double> stderr = new ArrayList<Double>();
-	private ArrayList<Double> stdlow = new ArrayList<Double>();
-	private ArrayList<Double> upper = new ArrayList<Double>();
-	private ArrayList<Double> lower = new ArrayList<Double>();
-	private LinkedHashMap<Double, Integer> ndead = new LinkedHashMap<Double, Integer>();
+	private ArrayList<Double> time = new ArrayList<>();
+	private ArrayList<Integer> status = new ArrayList<>();
+	private ArrayList<Double> nevent = new ArrayList<>();
+	private ArrayList<Double> ncens = new ArrayList<>();
+	private ArrayList<Double> nrisk = new ArrayList<>();
+	private ArrayList<Double> weight = new ArrayList<>();
+	private ArrayList<Double> surv = new ArrayList<>();
+	private ArrayList<Double> varhaz = new ArrayList<>();
+	private ArrayList<Double> stderr = new ArrayList<>();
+	private ArrayList<Double> stdlow = new ArrayList<>();
+	private ArrayList<Double> upper = new ArrayList<>();
+	private ArrayList<Double> lower = new ArrayList<>();
+	private LinkedHashMap<Double, Integer> ndead = new LinkedHashMap<>();
 	DecimalFormat df = new DecimalFormat("#.######");
 	DecimalFormat dfe = new DecimalFormat("0.000000E0");
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvFitInfo.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvFitInfo.java
@@ -29,8 +29,8 @@ import java.util.LinkedHashMap;
  */
 public class SurvFitInfo {
 
-	private LinkedHashMap<String, StrataInfo> strataInfoHashMap = new LinkedHashMap<String, StrataInfo>();
-	private LinkedHashMap<String, StrataInfo> unweightedStrataInfoHashMap = new LinkedHashMap<String, StrataInfo>();
+	private LinkedHashMap<String, StrataInfo> strataInfoHashMap = new LinkedHashMap<>();
+	private LinkedHashMap<String, StrataInfo> unweightedStrataInfoHashMap = new LinkedHashMap<>();
 	private boolean weighted = false;
 
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvivalInfo.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvivalInfo.java
@@ -45,12 +45,12 @@ public class SurvivalInfo implements Comparable<SurvivalInfo> {
 	private double residual = 0.0;
 	private String clusterValue = "";
 
-	LinkedHashMap<String,Double> residualVariableMap = new LinkedHashMap<String,Double>();
+	LinkedHashMap<String,Double> residualVariableMap = new LinkedHashMap<>();
 
-	LinkedHashMap<String, Double> data = new LinkedHashMap<String, Double>();
+	LinkedHashMap<String, Double> data = new LinkedHashMap<>();
 	//    LinkedHashMap<String, Double> discreteData = new LinkedHashMap<String, Double>();
-	LinkedHashMap<String, String> unknownDataType = new LinkedHashMap<String, String>();
-	LinkedHashMap<String, String> originalMetaData = new LinkedHashMap<String,String>();
+	LinkedHashMap<String, String> unknownDataType = new LinkedHashMap<>();
+	LinkedHashMap<String, String> originalMetaData = new LinkedHashMap<>();
 
 	/**
 	 *
@@ -177,7 +177,7 @@ public class SurvivalInfo implements Comparable<SurvivalInfo> {
 	 * @return
 	 */
 	public ArrayList<String> getGroupCategories(String groupName) {
-		ArrayList<String> groupNameList = new ArrayList<String>();
+		ArrayList<String> groupNameList = new ArrayList<>();
 		for (String key : data.keySet()) {
 			if (key.startsWith(groupName + "_")) {
 				groupNameList.add(key);
@@ -199,7 +199,7 @@ public class SurvivalInfo implements Comparable<SurvivalInfo> {
 	 * @return
 	 */
 	public ArrayList<String> getDataVariables(){
-		ArrayList<String> v = new ArrayList<String>();
+		ArrayList<String> v = new ArrayList<>();
 		v.addAll(data.keySet());
 		v.addAll(unknownDataType.keySet());
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvivalInfoHelper.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/SurvivalInfoHelper.java
@@ -86,13 +86,13 @@ public class SurvivalInfoHelper {
 	public static void categorizeData(ArrayList<SurvivalInfo> DataT) {
 
 		//Go through and get all variable value pairs
-		LinkedHashMap<String, LinkedHashMap<String, Double>> valueMap = new LinkedHashMap<String, LinkedHashMap<String, Double>>();
+		LinkedHashMap<String, LinkedHashMap<String, Double>> valueMap = new LinkedHashMap<>();
 		for (SurvivalInfo si : DataT) {
 
 			for (String key : si.unknownDataType.keySet()) {
 				LinkedHashMap<String, Double> map = valueMap.get(key);
 				if (map == null) {
-					map = new LinkedHashMap<String, Double>();
+					map = new LinkedHashMap<>();
 					valueMap.put(key, map);
 				}
 				map.put(si.unknownDataType.get(key), null);
@@ -102,7 +102,7 @@ public class SurvivalInfoHelper {
 		for (String variable : valueMap.keySet()) {
 			LinkedHashMap<String, Double> values = valueMap.get(variable);
 			if (isCategorical(values)) {
-				ArrayList<String> categories = new ArrayList<String>(values.keySet());
+				ArrayList<String> categories = new ArrayList<>(values.keySet());
 				Collections.sort(categories); //go ahead and put in alphabetical order
 				if (categories.size() == 2) {
 					for (String value : values.keySet()) {
@@ -147,7 +147,7 @@ public class SurvivalInfoHelper {
 	 * @return
 	 */
 	public static ArrayList<String> addInteraction(String variable1, String variable2, ArrayList<SurvivalInfo> survivalInfoList) {
-		ArrayList<String> variables = new ArrayList<String>();
+		ArrayList<String> variables = new ArrayList<>();
 		variables.add(variable1);
 		variables.add(variable2);
 		variables.add(variable1 + ":" + variable2);
@@ -170,7 +170,7 @@ public class SurvivalInfoHelper {
 	 * @throws Exception
 	 */
 	public static void groupByRange(double[] range, String variable, String groupName, ArrayList<SurvivalInfo> survivalInfoList) throws Exception {
-		ArrayList<String> labels = new ArrayList<String>();
+		ArrayList<String> labels = new ArrayList<>();
 		for (int i = 0; i < range.length; i++) {
 			String label = "";
 			if (i == 0) {
@@ -184,7 +184,7 @@ public class SurvivalInfoHelper {
 			}
 			labels.add(label);
 		}
-		ArrayList<String> validLabels = new ArrayList<String>();
+		ArrayList<String> validLabels = new ArrayList<>();
 
 		//need to find the categories so we can set 1 and 0 and not include ranges with no values
 		for (SurvivalInfo si : survivalInfoList) {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/stats/AgScore.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/cox/stats/AgScore.java
@@ -45,7 +45,7 @@ public class AgScore {
 		//double temp;
 		int n = survivalInfoList.size();
 
-		ArrayList<String> variables = new ArrayList<String>(coxInfo.getCoefficientsList().keySet());
+		ArrayList<String> variables = new ArrayList<>(coxInfo.getCoefficientsList().keySet());
 		int nvar = variables.size();
 
 

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/data/WorkSheet.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/data/WorkSheet.java
@@ -31,10 +31,10 @@ import java.util.*;
  */
 public class WorkSheet {
 
-	private LinkedHashMap<String, HeaderInfo> columnLookup = new LinkedHashMap<String, HeaderInfo>();
-	private LinkedHashMap<String, HeaderInfo> rowLookup = new LinkedHashMap<String, HeaderInfo>();
+	private LinkedHashMap<String, HeaderInfo> columnLookup = new LinkedHashMap<>();
+	private LinkedHashMap<String, HeaderInfo> rowLookup = new LinkedHashMap<>();
 	private CompactCharSequence[][] data = new CompactCharSequence[1][1];
-	HashMap<String, String> dataGrid = new HashMap<String, String>();
+	HashMap<String, String> dataGrid = new HashMap<>();
 	private String indexColumnName = "";
 
 	/**
@@ -233,14 +233,14 @@ public class WorkSheet {
 
 		data = values;
 	}
-	private LinkedHashMap<String, String> metaDataColumnsHashMap = new LinkedHashMap<String, String>();
+	private LinkedHashMap<String, String> metaDataColumnsHashMap = new LinkedHashMap<>();
 
 	/**
 	 *
 	 * @return
 	 */
 	public ArrayList<String> getMetaDataColumns() {
-		ArrayList<String> metaColumns = new ArrayList<String>();
+		ArrayList<String> metaColumns = new ArrayList<>();
 		for (String key : metaDataColumnsHashMap.keySet()) {
 			HeaderInfo hi = columnLookup.get(key);
 			if (!hi.isHide()) {
@@ -255,7 +255,7 @@ public class WorkSheet {
 	 * @return
 	 */
 	public ArrayList<String> getMetaDataRows() {
-		ArrayList<String> metaRows = new ArrayList<String>();
+		ArrayList<String> metaRows = new ArrayList<>();
 		for (String key : metaDataRowsHashMap.keySet()) {
 			HeaderInfo hi = rowLookup.get(key);
 			if (!hi.isHide()) {
@@ -270,7 +270,7 @@ public class WorkSheet {
 	 * @return
 	 */
 	public ArrayList<String> getDataColumns() {
-		ArrayList<String> dataColumns = new ArrayList<String>();
+		ArrayList<String> dataColumns = new ArrayList<>();
 		ArrayList<String> columns = this.getColumns();
 		for (String column : columns) {
 			if (!metaDataColumnsHashMap.containsKey(column)) {
@@ -292,7 +292,7 @@ public class WorkSheet {
 		doubleValues.clear();
 
 		for (String column : columns) { //shuffle all values in the column
-			ArrayList<Integer> rowIndex = new ArrayList<Integer>();
+			ArrayList<Integer> rowIndex = new ArrayList<>();
 			for (int i = 0; i < rows.size(); i++) {
 				rowIndex.add(i);
 			}
@@ -311,7 +311,7 @@ public class WorkSheet {
 		}
 
 		for (String row : rows) {
-			ArrayList<Integer> columnIndex = new ArrayList<Integer>();
+			ArrayList<Integer> columnIndex = new ArrayList<>();
 			for (int i = 0; i < columns.size(); i++) {
 				columnIndex.add(i);
 			}
@@ -344,7 +344,7 @@ public class WorkSheet {
 		doubleValues.clear();
 		ArrayList<String> rows = this.getDataRows();
 		for (String column : columns) { //shuffle all values in the column
-			ArrayList<Integer> rowIndex = new ArrayList<Integer>();
+			ArrayList<Integer> rowIndex = new ArrayList<>();
 			for (int i = 0; i < rows.size(); i++) {
 				rowIndex.add(i);
 			}
@@ -375,7 +375,7 @@ public class WorkSheet {
 		doubleValues.clear();
 		ArrayList<String> columns = this.getColumns();
 		for (String row : rows) {
-			ArrayList<Integer> columnIndex = new ArrayList<Integer>();
+			ArrayList<Integer> columnIndex = new ArrayList<>();
 			for (int i = 0; i < columns.size(); i++) {
 				columnIndex.add(i);
 			}
@@ -521,7 +521,7 @@ public class WorkSheet {
 			return true;
 		}
 	}
-	private LinkedHashMap<String, String> metaDataRowsHashMap = new LinkedHashMap<String, String>();
+	private LinkedHashMap<String, String> metaDataRowsHashMap = new LinkedHashMap<>();
 
 	/**
 	 *
@@ -646,7 +646,7 @@ public class WorkSheet {
 	 * @param defaultValue
 	 */
 	public void addColumn(String column, String defaultValue) {
-		ArrayList<String> columns = new ArrayList<String>();
+		ArrayList<String> columns = new ArrayList<>();
 		columns.add(column);
 		addColumns(columns, defaultValue);
 	}
@@ -694,7 +694,7 @@ public class WorkSheet {
 	 * @param defaultValue
 	 */
 	public void addRow(String row, String defaultValue) {
-		ArrayList<String> rows = new ArrayList<String>();
+		ArrayList<String> rows = new ArrayList<>();
 		rows.add(row);
 		addRows(rows, defaultValue);
 	}
@@ -808,7 +808,7 @@ public class WorkSheet {
 		}
 	}
 	//When we do gene signatures we ask for the same data value often. This method took up 50% of the time.
-	HashMap<String, Double> doubleValues = new HashMap<String, Double>();
+	HashMap<String, Double> doubleValues = new HashMap<>();
 	boolean cacheDoubleValues = false;
 
 	/**
@@ -909,7 +909,7 @@ public class WorkSheet {
 	 * @param changeValue
 	 */
 	public void changeRowHeader(ChangeValue changeValue) {
-		ArrayList<String> rows = new ArrayList<String>(rowLookup.keySet());
+		ArrayList<String> rows = new ArrayList<>(rowLookup.keySet());
 		for (String row : rows) {
 			String newRow = changeValue.change(row);
 			HeaderInfo value = rowLookup.get(row);
@@ -923,7 +923,7 @@ public class WorkSheet {
 	 * @param changeValue
 	 */
 	public void changeColumnHeader(ChangeValue changeValue) {
-		ArrayList<String> columns = new ArrayList<String>(columnLookup.keySet());
+		ArrayList<String> columns = new ArrayList<>(columnLookup.keySet());
 		for (String col : columns) {
 			String newCol = changeValue.change(col);
 			HeaderInfo value = columnLookup.get(col);
@@ -1030,8 +1030,8 @@ public class WorkSheet {
 	 * @return
 	 */
 	public ArrayList<String> getRandomDataColumns(int number, ArrayList<String> columns) {
-		ArrayList<String> randomColumns = new ArrayList<String>();
-		HashMap<String, String> picked = new HashMap<String, String>();
+		ArrayList<String> randomColumns = new ArrayList<>();
+		HashMap<String, String> picked = new HashMap<>();
 		while (picked.size() < number) {
 			double v = Math.random();
 			int index = (int) (v * columns.size());
@@ -1051,7 +1051,7 @@ public class WorkSheet {
 	 * @return
 	 */
 	public ArrayList<String> getAllColumns() {
-		ArrayList<String> columns = new ArrayList<String>();
+		ArrayList<String> columns = new ArrayList<>();
 		for (String col : columnLookup.keySet()) {
 			columns.add(col);
 		}
@@ -1064,7 +1064,7 @@ public class WorkSheet {
 	 * @return
 	 */
 	public ArrayList<String> getColumns() {
-		ArrayList<String> columns = new ArrayList<String>();
+		ArrayList<String> columns = new ArrayList<>();
 		for (String col : columnLookup.keySet()) {
 			HeaderInfo hi = columnLookup.get(col);
 			if (!hi.isHide()) {
@@ -1082,8 +1082,8 @@ public class WorkSheet {
 	 * @throws Exception
 	 */
 	public ArrayList<String> getDiscreteColumnValues(String column) throws Exception {
-		HashMap<String, String> hashMapValues = new HashMap<String, String>();
-		ArrayList<String> values = new ArrayList<String>();
+		HashMap<String, String> hashMapValues = new HashMap<>();
+		ArrayList<String> values = new ArrayList<>();
 		ArrayList<String> rows = getDataRows();
 		for (String row : rows) {
 			String value = getCell(row, column);
@@ -1103,8 +1103,8 @@ public class WorkSheet {
 	 * @throws Exception
 	 */
 	public ArrayList<String> getDiscreteRowValues(String row) throws Exception {
-		HashMap<String, String> hashMapValues = new HashMap<String, String>();
-		ArrayList<String> values = new ArrayList<String>();
+		HashMap<String, String> hashMapValues = new HashMap<>();
+		ArrayList<String> values = new ArrayList<>();
 		for (String column : getColumns()) {
 			String value = getCell(row, column);
 			if (!hashMapValues.containsKey(value)) {
@@ -1121,7 +1121,7 @@ public class WorkSheet {
 	 * @return
 	 */
 	public ArrayList<String> getAllRows() {
-		ArrayList<String> rows = new ArrayList<String>();
+		ArrayList<String> rows = new ArrayList<>();
 		for (String row : rowLookup.keySet()) {
 			rows.add(row);
 		}
@@ -1135,7 +1135,7 @@ public class WorkSheet {
 	 * @return
 	 */
 	public ArrayList<String> getRows() {
-		ArrayList<String> rows = new ArrayList<String>();
+		ArrayList<String> rows = new ArrayList<>();
 		for (String row : rowLookup.keySet()) {
 			HeaderInfo hi = rowLookup.get(row);
 			if (!hi.isHide()) {
@@ -1151,7 +1151,7 @@ public class WorkSheet {
 	 * @return
 	 */
 	public ArrayList<String> getDataRows() {
-		ArrayList<String> rows = new ArrayList<String>();
+		ArrayList<String> rows = new ArrayList<>();
 		for (String row : rowLookup.keySet()) {
 			if (this.isMetaDataRow(row)) {
 				continue;
@@ -1262,7 +1262,7 @@ public class WorkSheet {
 		BufferedReader br = new BufferedReader(new InputStreamReader(is));
 
 
-		ArrayList<CompactCharSequence[]> rows = new ArrayList<CompactCharSequence[]>();
+		ArrayList<CompactCharSequence[]> rows = new ArrayList<>();
 
 		String line = br.readLine();
 		int numcolumns = -1;
@@ -1309,7 +1309,7 @@ public class WorkSheet {
 	static String[][] getAllValues(String fileName, char delimiter) throws Exception {
 		FileReader reader = new FileReader(fileName);
 		BufferedReader br = new BufferedReader(reader);
-		ArrayList<String[]> rows = new ArrayList<String[]>();
+		ArrayList<String[]> rows = new ArrayList<>();
 
 		String line = br.readLine();
 		int numcolumns = -1;
@@ -1388,7 +1388,7 @@ public class WorkSheet {
 			}
 		}
 
-		ArrayList<String> joinedColumns = new ArrayList<String>();
+		ArrayList<String> joinedColumns = new ArrayList<>();
 		joinedColumns.addAll(w1DataColumns);
 		joinedColumns.addAll(w2DataColumns);
 		if (!joinedColumns.contains("META_DATA") && (w1MetaDataColumns.size() > 0 || w2MetaDataColumns.size() > 0)) {
@@ -1406,9 +1406,9 @@ public class WorkSheet {
 		}
 		ArrayList<String> w1Rows = w1.getRows();
 		ArrayList<String> w2Rows = w2.getRows();
-		ArrayList<String> rows = new ArrayList<String>();
+		ArrayList<String> rows = new ArrayList<>();
 
-		HashSet<String> w1Key = new HashSet<String>(w1Rows);
+		HashSet<String> w1Key = new HashSet<>(w1Rows);
 		for (String key : w2Rows) {
 			if (w1Key.contains(key)) {
 				rows.add(key);

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/ExpressionFigure.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/ExpressionFigure.java
@@ -41,7 +41,7 @@ public class ExpressionFigure extends JPanel {
 
 	private static final long serialVersionUID = 1L;
 
-	ArrayList<String> title = new ArrayList<String>();
+	ArrayList<String> title = new ArrayList<>();
 	/**
 	 *
 	 */
@@ -70,8 +70,8 @@ public class ExpressionFigure extends JPanel {
 	FontMetrics fm;
 	KMFigureInfo kmfi = new KMFigureInfo();
 //    LinkedHashMap<String, ArrayList<CensorStatus>> survivalData = new LinkedHashMap<String, ArrayList<CensorStatus>>();
-	ArrayList<String> lineInfoList = new ArrayList<String>();
-	ArrayList<SurvivalInfo> siList = new ArrayList<SurvivalInfo>();
+	ArrayList<String> lineInfoList = new ArrayList<>();
+	ArrayList<SurvivalInfo> siList = new ArrayList<>();
 	String variable = "";
 	private String fileName = "";
 
@@ -120,7 +120,7 @@ public class ExpressionFigure extends JPanel {
 	 * @param variable
 	 */
 	public void setSurvivalInfo(ArrayList<String> title, ArrayList<SurvivalInfo> _siList, String variable) {
-		this.siList = new ArrayList<SurvivalInfo>();
+		this.siList = new ArrayList<>();
 		this.title = title;
 		this.variable = variable;
 
@@ -372,13 +372,13 @@ public class ExpressionFigure extends JPanel {
 			application.setSize(500, 400);         // window is 500 pixels wide, 400 high
 			application.setVisible(true);
 
-			ArrayList<String> titles = new ArrayList<String>();
+			ArrayList<String> titles = new ArrayList<>();
 			titles.add("Line 1");
 			titles.add("line 2");
 
-			ArrayList<String> figureInfo = new ArrayList<String>();
+			ArrayList<String> figureInfo = new ArrayList<>();
 
-			ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<SurvivalInfo>();
+			ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<>();
 
 			for (int i = 0; i < 600; i++) {
 				double r = Math.random();

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/KMFigureInfo.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/KMFigureInfo.java
@@ -87,7 +87,7 @@ public class KMFigureInfo {
 	 *
 	 */
 	public Color[] legendColor = {Color.RED, Color.BLUE, Color.GREEN, Color.CYAN, Color.ORANGE, Color.YELLOW, Color.MAGENTA, Color.PINK};
-	public ArrayList<Double> xAxisLabels = new ArrayList<Double>();//new ArrayList<Double>(Arrays.asList(0.0, 5.0, 10.0, 15.0, 20.0));
+	public ArrayList<Double> xAxisLabels = new ArrayList<>();//new ArrayList<Double>(Arrays.asList(0.0, 5.0, 10.0, 15.0, 20.0));
 	public String xAxisLegend = "";
 	public String yAxisLegend = "";
 	public Color getColor(int index) {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/KaplanMeierFigure.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/KaplanMeierFigure.java
@@ -42,7 +42,7 @@ public class KaplanMeierFigure extends JPanel {
 
 	private static final long serialVersionUID = 1L;
 
-	ArrayList<String> title = new ArrayList<String>();
+	ArrayList<String> title = new ArrayList<>();
 	/**
 	 *
 	 */
@@ -69,12 +69,12 @@ public class KaplanMeierFigure extends JPanel {
 	double maxPercentage = 1.0;
 	FontMetrics fm;
 	KMFigureInfo kmfi = new KMFigureInfo();
-	LinkedHashMap<String, ArrayList<CensorStatus>> survivalData = new LinkedHashMap<String, ArrayList<CensorStatus>>();
-	ArrayList<String> lineInfoList = new ArrayList<String>();
+	LinkedHashMap<String, ArrayList<CensorStatus>> survivalData = new LinkedHashMap<>();
+	ArrayList<String> lineInfoList = new ArrayList<>();
 	SurvFitInfo sfi = new SurvFitInfo();
 	private String fileName = "";
-	private ArrayList<Double> xAxisTimeValues = new ArrayList<Double>();
-	private ArrayList<Integer> xAxisTimeCoordinates = new ArrayList<Integer>();
+	private ArrayList<Double> xAxisTimeValues = new ArrayList<>();
+	private ArrayList<Integer> xAxisTimeCoordinates = new ArrayList<>();
 
 	/**
 	 *
@@ -91,7 +91,7 @@ public class KaplanMeierFigure extends JPanel {
 	 * @return
 	 */
 	public ArrayList<String> getGroups() {
-		return new ArrayList<String>(survivalData.keySet());
+		return new ArrayList<>(survivalData.keySet());
 	}
 
 	/**
@@ -160,7 +160,7 @@ public class KaplanMeierFigure extends JPanel {
 	 * @throws Exception
 	 */
 	public void setCoxInfo(ArrayList<String> title, CoxInfo ci, String strataVariable, LinkedHashMap<String, String> legendMap, Boolean useWeighted) throws Exception {
-		LinkedHashMap<String, ArrayList<CensorStatus>> survivalData = new LinkedHashMap<String, ArrayList<CensorStatus>>();
+		LinkedHashMap<String, ArrayList<CensorStatus>> survivalData = new LinkedHashMap<>();
 		ArrayList<SurvivalInfo> siList = ci.getSurvivalInfoList();
 		int n = 0;
 		int event = 0;
@@ -173,7 +173,7 @@ public class KaplanMeierFigure extends JPanel {
 			}
 			ArrayList<CensorStatus> censorStatusList = survivalData.get(legend);
 			if (censorStatusList == null) {
-				censorStatusList = new ArrayList<CensorStatus>();
+				censorStatusList = new ArrayList<>();
 				survivalData.put(legend, censorStatusList);
 			}
 			CensorStatus cs = new CensorStatus(strata, si.getTime(), si.getStatus() + "");
@@ -195,7 +195,7 @@ public class KaplanMeierFigure extends JPanel {
 //        System.out.println("setCoxInfo=" + cc.pvalue + " " + title);
 
 
-		ArrayList<String> lines = new ArrayList<String>();
+		ArrayList<String> lines = new ArrayList<>();
 		lines.add(line1);
 		lines.add(line2);
 		lines.add(line3);
@@ -303,7 +303,7 @@ public class KaplanMeierFigure extends JPanel {
 		this.title = title;
 		this.survivalData = survivalData;
 		Double mTime = null;
-		ArrayList<String> labels = new ArrayList<String>(survivalData.keySet());
+		ArrayList<String> labels = new ArrayList<>(survivalData.keySet());
 		Collections.sort(labels);
 		for (String legend : labels) {
 			ArrayList<CensorStatus> censorStatusList = survivalData.get(legend);
@@ -394,7 +394,7 @@ public class KaplanMeierFigure extends JPanel {
 
 
 		int colorIndex = 0;
-		ArrayList<String> labels = new ArrayList<String>(sfi.getStrataInfoHashMap().keySet());
+		ArrayList<String> labels = new ArrayList<>(sfi.getStrataInfoHashMap().keySet());
 		Collections.sort(labels);
 
 		LinkedHashMap<String, StrataInfo> strataInfoHashMap = sfi.getStrataInfoHashMap();
@@ -763,7 +763,7 @@ public class KaplanMeierFigure extends JPanel {
 		try {
 
 			KaplanMeierFigure kaplanMeierFigure = new KaplanMeierFigure();
-			LinkedHashMap<String, ArrayList<CensorStatus>> survivalDataHashMap = new LinkedHashMap<String, ArrayList<CensorStatus>>();
+			LinkedHashMap<String, ArrayList<CensorStatus>> survivalDataHashMap = new LinkedHashMap<>();
 
 //            if (false) { //http://sph.bu.edu/otlt/MPH-Modules/BS/BS704_Survival/
 //                ArrayList<CensorStatus> graph1 = new ArrayList<CensorStatus>();
@@ -801,7 +801,7 @@ public class KaplanMeierFigure extends JPanel {
 
 
 
-				ArrayList<CensorStatus> graph1 = new ArrayList<CensorStatus>();
+				ArrayList<CensorStatus> graph1 = new ArrayList<>();
 				graph1.add(new CensorStatus("A", 1.0, "1"));
 				graph1.add(new CensorStatus("A", 1.0, "1"));
 				graph1.add(new CensorStatus("A", 1.0, "1"));
@@ -841,7 +841,7 @@ public class KaplanMeierFigure extends JPanel {
 
 				survivalDataHashMap.put("Label 1", graph1);
 
-				ArrayList<CensorStatus> graph2 = new ArrayList<CensorStatus>();
+				ArrayList<CensorStatus> graph2 = new ArrayList<>();
 				graph2.add(new CensorStatus("A", 1.0, "1"));
 				graph2.add(new CensorStatus("A", 1.0, "1"));
 				graph2.add(new CensorStatus("A", 1.0, "0"));
@@ -882,7 +882,7 @@ public class KaplanMeierFigure extends JPanel {
 				survivalDataHashMap.put("Label 2", graph2);
 			}
 
-			ArrayList<String> figureInfo = new ArrayList<String>();
+			ArrayList<String> figureInfo = new ArrayList<>();
 			//DecimalFormat dfe = new DecimalFormat("0.00E0");
 			//DecimalFormat df = new DecimalFormat("0.00");
 
@@ -896,7 +896,7 @@ public class KaplanMeierFigure extends JPanel {
 			application.setSize(500, 400);         // window is 500 pixels wide, 400 high
 			application.setVisible(true);
 
-			ArrayList<String> titles = new ArrayList<String>();
+			ArrayList<String> titles = new ArrayList<>();
 			titles.add("Line 1");
 			titles.add("Line 2");
 			kaplanMeierFigure.setSurvivalData(titles, survivalDataHashMap, true);

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/NumbersAtRiskPanel.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/NumbersAtRiskPanel.java
@@ -69,7 +69,7 @@ public class NumbersAtRiskPanel extends JPanel {
 		g2.setStroke(kmfi.kmStroke);
 		SurvFitInfo sfi = kmf.getSurvivalFitInfo();
 
-		LinkedHashMap<String, StrataInfo> sfiHashMap = new LinkedHashMap<String, StrataInfo>();
+		LinkedHashMap<String, StrataInfo> sfiHashMap = new LinkedHashMap<>();
 		if(sfi.isWeighted()){
 			sfiHashMap = sfi.getUnweightedStrataInfoHashMap();
 		}else{
@@ -94,7 +94,7 @@ public class NumbersAtRiskPanel extends JPanel {
 		ArrayList<Double> xaxisTimeValues = kmf.getxAxisTimeValues();
 		ArrayList<Integer> xAxisTimeCoordinates = kmf.getxAxisTimeCoordinates();
 
-		ArrayList<String> labels = new ArrayList<String>(sfiHashMap.keySet());
+		ArrayList<String> labels = new ArrayList<>(sfiHashMap.keySet());
 		Collections.sort(labels);
 
 		for (String group : labels) {

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/SurvFitKM.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/figure/SurvFitKM.java
@@ -122,7 +122,7 @@ public class SurvFitKM {
 	 * @throws Exception
 	 */
 	public SurvFitInfo process(LinkedHashMap<String, ArrayList<CensorStatus>> survivalData, boolean useWeights) throws Exception {
-		ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<SurvivalInfo>();
+		ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<>();
 		int i = 0;
 		for (String strata : survivalData.keySet()) {
 			ArrayList<CensorStatus> csList = survivalData.get(strata);
@@ -154,7 +154,7 @@ public class SurvFitKM {
 	 */
 	public SurvFitInfo process(String datafile, String timeColumn, String statusColumn, String weightColumn, String variableColumn, boolean useWeights) throws Exception {
 		WorkSheet worksheet = WorkSheet.readCSV(datafile, '\t');
-		ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<SurvivalInfo>();
+		ArrayList<SurvivalInfo> survivalInfoList = new ArrayList<>();
 
 		int i = 1;
 		for (String row : worksheet.getRows()) {
@@ -223,8 +223,8 @@ public class SurvFitKM {
 		int n = dataT.size();
 
 
-		LinkedHashMap<String, Integer> levels = new LinkedHashMap<String, Integer>();
-		LinkedHashMap<String, ArrayList<SurvivalInfo>> strataHashMap = new LinkedHashMap<String, ArrayList<SurvivalInfo>>();
+		LinkedHashMap<String, Integer> levels = new LinkedHashMap<>();
+		LinkedHashMap<String, ArrayList<SurvivalInfo>> strataHashMap = new LinkedHashMap<>();
 
 		for (int i = 0; i < n; i++) {
 			SurvivalInfo si = dataT.get(i);
@@ -237,7 +237,7 @@ public class SurvFitKM {
 			levels.put(value, count);
 			ArrayList<SurvivalInfo> strataList = strataHashMap.get(value);
 			if (strataList == null) {
-				strataList = new ArrayList<SurvivalInfo>();
+				strataList = new ArrayList<>();
 				strataHashMap.put(value, strataList);
 			}
 			strataList.add(si);
@@ -246,7 +246,7 @@ public class SurvFitKM {
 
 		//int nstrat = levels.size();
 
-		LinkedHashMap<String, StrataInfo> strataInfoHashMap = new LinkedHashMap<String, StrataInfo>();
+		LinkedHashMap<String, StrataInfo> strataInfoHashMap = new LinkedHashMap<>();
 
 		for (String strata : strataHashMap.keySet()) {
 
@@ -379,8 +379,8 @@ public class SurvFitKM {
 
 		}
 
-		ArrayList<Boolean> events = new ArrayList<Boolean>();
-		ArrayList<Double> nrisk = new ArrayList<Double>();
+		ArrayList<Boolean> events = new ArrayList<>();
+		ArrayList<Double> nrisk = new ArrayList<>();
 		for (StrataInfo strataInfo : strataInfoHashMap.values()) {
 			boolean firsttime = true;
 			for (int j = 0; j < strataInfo.getNevent().size(); j++) {
@@ -395,19 +395,19 @@ public class SurvFitKM {
 			}
 
 		}
-		ArrayList<Integer> zz = new ArrayList<Integer>();
+		ArrayList<Integer> zz = new ArrayList<>();
 		for (int i = 0; i < events.size(); i++) {
 			if (events.get(i)) {
 				zz.add(i + 1);
 			}
 		}
 		zz.add(events.size() + 1);
-		ArrayList<Integer> diffzz = new ArrayList<Integer>();
+		ArrayList<Integer> diffzz = new ArrayList<>();
 		for (int i = 0; i < zz.size() - 1; i++) {
 			diffzz.add(zz.get(i + 1) - zz.get(i));
 		}
 		//System.out.println(diffzz);
-		ArrayList<Double> nlag = new ArrayList<Double>();
+		ArrayList<Double> nlag = new ArrayList<>();
 		for (int j = 0; j < nrisk.size(); j++) {
 			int count = diffzz.get(j);
 			for (int c = 0; c < count; c++) {
@@ -542,12 +542,12 @@ public class SurvFitKM {
 				application.setSize(500, 400);         // window is 500 pixels wide, 400 high
 				application.setVisible(true);
 
-				ArrayList<String> titles = new ArrayList<String>();
+				ArrayList<String> titles = new ArrayList<>();
 				titles.add("Line 1");
 				titles.add("line 2");
 				kaplanMeierFigure.setSurvivalData(titles, si, null);
 
-				ArrayList<String> figureInfo = new ArrayList<String>();
+				ArrayList<String> figureInfo = new ArrayList<>();
 				//   figureInfo.add("HR=2.1 95% CI(1.8-2.5)");
 				//   figureInfo.add("p-value=.001");
 				kaplanMeierFigure.setFigureLineInfo(figureInfo);

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/metadata/ClinicalMetaDataOutcome.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/metadata/ClinicalMetaDataOutcome.java
@@ -66,7 +66,7 @@ public class ClinicalMetaDataOutcome {
 	public static void main(String[] args) {
 
 		try {
-			LinkedHashMap<String, String> censorMap = new LinkedHashMap<String, String>();
+			LinkedHashMap<String, String> censorMap = new LinkedHashMap<>();
 			censorMap.put("a", "0");
 			censorMap.put("d", "1");
 			censorMap.put("d-d.s.", "1");
@@ -74,7 +74,7 @@ public class ClinicalMetaDataOutcome {
 			String timeColumn = "TIME";
 			String sensorMapColumn = "last_follow_up_status"; // "survstat3";
 			double timeScale = 1.0;
-			ArrayList<MetaDataInfo> metaDataInfoList = new ArrayList<MetaDataInfo>();
+			ArrayList<MetaDataInfo> metaDataInfoList = new ArrayList<>();
 			metaDataInfoList.add(new MetaDataInfo("age_at_diagnosis", true, new MeanQuantizer()));
 			metaDataInfoList.add(new MetaDataInfo("size", true, new MeanQuantizer()));
 			metaDataInfoList.add(new MetaDataInfo("lymph_nodes_positive", true, new MeanQuantizer()));

--- a/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/metadata/MetaDataInfo.java
+++ b/biojava-survival/src/main/java/org/biojava/nbio/survival/kaplanmeier/metadata/MetaDataInfo.java
@@ -42,7 +42,7 @@ public class MetaDataInfo {
 	 *
 	 */
 	public DiscreteQuantizerInterface discreteQuantizer = null;
-	ArrayList<String> discreteValues = new ArrayList<String>();
+	ArrayList<String> discreteValues = new ArrayList<>();
 
 	/**
 	 *

--- a/biojava-ws/src/main/java/demo/HmmerDemo.java
+++ b/biojava-ws/src/main/java/demo/HmmerDemo.java
@@ -86,7 +86,7 @@ public class HmmerDemo {
 	private static ProteinSequence getUniprot(String uniProtID) throws Exception {
 
 		AminoAcidCompoundSet set = AminoAcidCompoundSet.getAminoAcidCompoundSet();
-		UniprotProxySequenceReader<AminoAcidCompound> uniprotSequence = new UniprotProxySequenceReader<AminoAcidCompound>(uniProtID,set);
+		UniprotProxySequenceReader<AminoAcidCompound> uniprotSequence = new UniprotProxySequenceReader<>(uniProtID,set);
 
 		ProteinSequence seq = new ProteinSequence(uniprotSequence);
 

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/alignment/qblast/NCBIQBlastAlignmentProperties.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/alignment/qblast/NCBIQBlastAlignmentProperties.java
@@ -45,7 +45,7 @@ import static org.biojava.nbio.ws.alignment.qblast.BlastAlignmentParameterEnum.*
 public class NCBIQBlastAlignmentProperties implements RemotePairwiseAlignmentProperties {
 	private static final long serialVersionUID = 7158270364392309841L;
 
-	private Map<BlastAlignmentParameterEnum, String> param = new HashMap<BlastAlignmentParameterEnum, String>();
+	private Map<BlastAlignmentParameterEnum, String> param = new HashMap<>();
 
 	/**
 	 * This method forwards to {@link #getAlignmentOption(BlastAlignmentParameterEnum)}. Consider using it instead.
@@ -69,7 +69,7 @@ public class NCBIQBlastAlignmentProperties implements RemotePairwiseAlignmentPro
 	 */
 	@Override
 	public Set<String> getAlignmentOptions() {
-		Set<String> result = new HashSet<String>();
+		Set<String> result = new HashSet<>();
 		for (BlastAlignmentParameterEnum parameter : param.keySet()) {
 			result.add(parameter.name());
 		}

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/alignment/qblast/NCBIQBlastOutputProperties.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/alignment/qblast/NCBIQBlastOutputProperties.java
@@ -41,7 +41,7 @@ import static org.biojava.nbio.ws.alignment.qblast.BlastOutputParameterEnum.*;
 public class NCBIQBlastOutputProperties implements RemotePairwiseAlignmentOutputProperties {
 	private static final long serialVersionUID = -9202060390925345163L;
 
-	private Map<BlastOutputParameterEnum, String> param = new HashMap<BlastOutputParameterEnum, String>();
+	private Map<BlastOutputParameterEnum, String> param = new HashMap<>();
 
 	/**
 	 * This constructor builds the parameters for the output of the GET command sent to the QBlast service with default
@@ -96,7 +96,7 @@ public class NCBIQBlastOutputProperties implements RemotePairwiseAlignmentOutput
 	 */
 	@Override
 	public Set<String> getOutputOptions() {
-		Set<String> result = new HashSet<String>();
+		Set<String> result = new HashSet<>();
 		for (BlastOutputParameterEnum parameter : param.keySet()) {
 			result.add(parameter.name());
 		}

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/alignment/qblast/NCBIQBlastService.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/alignment/qblast/NCBIQBlastService.java
@@ -72,7 +72,7 @@ public class NCBIQBlastService implements RemotePairwiseAlignmentService {
 	private String email = DEFAULT_EMAIL;
 	private String tool = DEFAULT_TOOL;
 
-	private Map<String, BlastJob> jobs = new HashMap<String, BlastJob>();
+	private Map<String, BlastJob> jobs = new HashMap<>();
 
 	/** Constructs a service object that targets the public NCBI BLAST network
 	 * service.
@@ -164,7 +164,7 @@ public class NCBIQBlastService implements RemotePairwiseAlignmentService {
 	 */
 	@Override
 	public String sendAlignmentRequest(String query, RemotePairwiseAlignmentProperties alignmentProperties) throws Exception {
-		Map<String, String> params = new HashMap<String, String>();
+		Map<String, String> params = new HashMap<>();
 		for (String key : alignmentProperties.getAlignmentOptions()) {
 			params.put(key, alignmentProperties.getAlignmentOption(key));
 		}
@@ -318,7 +318,7 @@ public class NCBIQBlastService implements RemotePairwiseAlignmentService {
 	 */
 	@Override
 	public InputStream getAlignmentResults(String id, RemotePairwiseAlignmentOutputProperties outputProperties) throws Exception {
-		Map<String, String> params = new HashMap<String, String>();
+		Map<String, String> params = new HashMap<>();
 		for (String key : outputProperties.getOutputOptions()) {
 			params.put(key, outputProperties.getOutputOption(key));
 		}

--- a/biojava-ws/src/main/java/org/biojava/nbio/ws/hmmer/RemoteHmmerScan.java
+++ b/biojava-ws/src/main/java/org/biojava/nbio/ws/hmmer/RemoteHmmerScan.java
@@ -134,7 +134,7 @@ public class RemoteHmmerScan implements HmmerScan {
 
 		// process the response and build up a container for the data.
 
-		SortedSet<HmmerResult> results = new TreeSet<HmmerResult>();
+		SortedSet<HmmerResult> results = new TreeSet<>();
 		try {
 			JSONObject json =  JSONObject.fromObject(result.toString());
 
@@ -170,7 +170,7 @@ public class RemoteHmmerScan implements HmmerScan {
 
 				JSONArray hmmdomains = hit.getJSONArray("domains");
 
-				SortedSet<HmmerDomain> domains = new TreeSet<HmmerDomain>();
+				SortedSet<HmmerDomain> domains = new TreeSet<>();
 				for ( int j= 0 ; j < hmmdomains.size() ; j++){
 					JSONObject d = hmmdomains.getJSONObject(j);
 					Integer is_included = getInteger(d.get("is_included"));


### PR DESCRIPTION
Java uses angular brackets (< and >) to provide a specific type (the "type argument") to a generic type. For instance, List is a generic type, so a list containing strings can be declared with List<String>.

Indepth, our Java code remediation solution, has detected and corrected 1103 violations of this type in the current version of the Biojava project. Manually, this correction would have taken more than 2 days.

We suggest that you correct this to improve the quality and maintainability of the code.