### PR TITLE
Fix issue s1319 Declarations should use Java collection interfaces on  biojava-core

### DIFF
--- a/biojava-alignment/src/test/java/org/biojava/nbio/alignment/TestDNAAlignment.java
+++ b/biojava-alignment/src/test/java/org/biojava/nbio/alignment/TestDNAAlignment.java
@@ -43,6 +43,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class TestDNAAlignment {
 
@@ -75,7 +76,7 @@ public class TestDNAAlignment {
 	private static List<DNASequence> getDNAFASTAFile() throws Exception {
 
 		InputStream inStream = TestDNAAlignment.class.getResourceAsStream(String.format("/dna-fasta.txt"));
-		LinkedHashMap<String, DNASequence> fastas = FastaReaderHelper.readFastaDNASequence(inStream);
+		Map<String, DNASequence> fastas = FastaReaderHelper.readFastaDNASequence(inStream);
 
 		List<DNASequence> sequences = new ArrayList<DNASequence>();
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Result.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/Result.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.NoSuchElementException;
 
 import org.biojava.nbio.core.sequence.template.Sequence;
+import java.util.Map;
 
 /**
  * This class models a search result.
@@ -46,7 +47,7 @@ public abstract class Result implements Iterable<Hit>{
 	private String reference;
 	private String dbFile;
 
-	private HashMap<String,String> programSpecificParameters;
+	private Map<String, String> programSpecificParameters;
 
 	private int iterationNumber;
 	private String queryID;
@@ -56,7 +57,7 @@ public abstract class Result implements Iterable<Hit>{
 	private List<Hit> hits;
 	private int hitCounter = -1;
 
-	public Result(String program, String version, String reference, String dbFile, HashMap<String, String> programSpecificParameters, int iterationNumber, String queryID, String queryDef, int queryLength, List<Hit> hits, Sequence querySequence) {
+	public Result(String program, String version, String reference, String dbFile, Map<String, String> programSpecificParameters, int iterationNumber, String queryID, String queryDef, int queryLength, List<Hit> hits, Sequence querySequence) {
 		this.program = program;
 		this.version = version;
 		this.reference = reference;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/SearchIO.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/SearchIO.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.NoSuchElementException;
+import java.util.Map;
 
 /**
  * Designed by Paolo Pavan.
@@ -39,7 +40,7 @@ import java.util.NoSuchElementException;
  */
 
 public class SearchIO implements Iterable<Result>{
-	static private HashMap<String,ResultFactory> extensionFactoryAssociation;
+	static private Map<String, ResultFactory> extensionFactoryAssociation;
 
 	final private ResultFactory factory;
 	final private File file;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastResult.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastResult.java
@@ -25,6 +25,7 @@ import org.biojava.nbio.core.search.io.Result;
 import java.util.HashMap;
 import java.util.List;
 import org.biojava.nbio.core.sequence.template.Sequence;
+import java.util.Map;
 
 /**
  * This class models a Blast/Blast plus result.
@@ -39,7 +40,7 @@ import org.biojava.nbio.core.sequence.template.Sequence;
  *
  */
 public class BlastResult extends Result{
-	public BlastResult(String program, String version, String reference, String dbFile, HashMap<String, String> programSpecificParameters, int iterationNumber, String queryID, String queryDef, int queryLength, List<Hit> hits, Sequence querySequence) {
+	public BlastResult(String program, String version, String reference, String dbFile, Map<String, String> programSpecificParameters, int iterationNumber, String queryID, String queryDef, int queryLength, List<Hit> hits, Sequence querySequence) {
 		super(program, version, reference, dbFile, programSpecificParameters, iterationNumber, queryID, queryDef, queryLength, hits, querySequence);
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastResultBuilder.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastResultBuilder.java
@@ -24,6 +24,7 @@ import org.biojava.nbio.core.search.io.Hit;
 import java.util.HashMap;
 import java.util.List;
 import org.biojava.nbio.core.sequence.template.Sequence;
+import java.util.Map;
 
 /**
  * Designed by Paolo Pavan.
@@ -39,7 +40,7 @@ public class BlastResultBuilder {
 	private String version;
 	private String reference;
 	private String dbFile;
-	private HashMap<String, String> programSpecificParameters;
+	private Map<String, String> programSpecificParameters;
 	private int iterationNumber;
 	private String queryID;
 	private String queryDef;
@@ -70,7 +71,7 @@ public class BlastResultBuilder {
 		return this;
 	}
 
-	public BlastResultBuilder setProgramSpecificParameters(HashMap<String, String> programSpecificParameters) {
+	public BlastResultBuilder setProgramSpecificParameters(Map<String, String> programSpecificParameters) {
 		this.programSpecificParameters = programSpecificParameters;
 		return this;
 	}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastTabularParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastTabularParser.java
@@ -37,6 +37,7 @@ import org.biojava.nbio.core.search.io.ResultFactory;
 import org.biojava.nbio.core.sequence.template.Sequence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.Map;
 
 /**
  * Designed by Paolo Pavan.
@@ -71,7 +72,7 @@ public class BlastTabularParser implements ResultFactory {
 
 	// data imported private:
 	int queryIdNumber = 0;
-	HashMap<String,String> queryIdMapping = new HashMap<>();
+	Map<String, String> queryIdMapping = new HashMap<>();
 	String programName=null, queryName = null, databaseFile = null;
 	private String queryId      ;
 	private String subjectId    ;

--- a/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastXMLParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/search/io/blast/BlastXMLParser.java
@@ -90,9 +90,9 @@ public class BlastXMLParser implements ResultFactory {
 		// create mappings between sequences and blast id
 		mapIds();
 
-		ArrayList<Result> resultsCollection;
-		ArrayList<Hit> hitsCollection;
-		ArrayList<Hsp> hspsCollection;
+		List<Result> resultsCollection;
+		List<Hit> hitsCollection;
+		List<Hsp> hspsCollection;
 
 		try {
 			// select top level elements
@@ -102,7 +102,7 @@ public class BlastXMLParser implements ResultFactory {
 			String dbFile = XMLHelper.selectSingleElement(blastDoc.getDocumentElement(),"BlastOutput_db").getTextContent();
 
 			logger.info("Query for hits in "+ targetFile);
-			ArrayList<Element> IterationsList = XMLHelper.selectElements(blastDoc.getDocumentElement(), "BlastOutput_iterations/Iteration[Iteration_hits]");
+			List<Element> IterationsList = XMLHelper.selectElements(blastDoc.getDocumentElement(), "BlastOutput_iterations/Iteration[Iteration_hits]");
 			logger.info(IterationsList.size() + " results");
 
 			resultsCollection = new ArrayList<>();
@@ -129,7 +129,7 @@ public class BlastXMLParser implements ResultFactory {
 
 
 				Element iterationHitsElement = XMLHelper.selectSingleElement(element, "Iteration_hits");
-				ArrayList<Element> hitList = XMLHelper.selectElements(iterationHitsElement, "Hit");
+				List<Element> hitList = XMLHelper.selectElements(iterationHitsElement, "Hit");
 
 				hitsCollection = new ArrayList<>();
 				for (Element hitElement : hitList) {
@@ -146,7 +146,7 @@ public class BlastXMLParser implements ResultFactory {
 					));
 
 					Element hithspsElement = XMLHelper.selectSingleElement(hitElement, "Hit_hsps");
-					ArrayList<Element> hspList = XMLHelper.selectElements(hithspsElement, "Hsp");
+					List<Element> hspList = XMLHelper.selectElements(hithspsElement, "Hsp");
 
 					hspsCollection = new ArrayList<>();
 					for (Element hspElement : hspList) {
@@ -195,7 +195,7 @@ public class BlastXMLParser implements ResultFactory {
 
 	@Override
 	public List<String> getFileExtensions(){
-		ArrayList<String> extensions = new ArrayList<>(1);
+		List<String> extensions = new ArrayList<>(1);
 		extensions.add("blastxml");
 		return extensions;
 	}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ChromosomeSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ChromosomeSequence.java
@@ -29,6 +29,7 @@ import org.biojava.nbio.core.sequence.template.CompoundSet;
 import org.biojava.nbio.core.sequence.template.SequenceReader;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * A ChromosomeSequence is a DNASequence but keeps track of geneSequences
@@ -37,7 +38,7 @@ import java.util.LinkedHashMap;
 public class ChromosomeSequence extends DNASequence {
 
 	private int chromosomeNumber;
-	private LinkedHashMap<String, GeneSequence> geneSequenceHashMap = new LinkedHashMap<>();
+	private Map<String, GeneSequence> geneSequenceHashMap = new LinkedHashMap<>();
 
 	/**
 	 * Empty constructor used by tools that need a proper Bean that allows the actual
@@ -106,7 +107,7 @@ public class ChromosomeSequence extends DNASequence {
 	 * @return
 	 */
 
-	public LinkedHashMap<String, GeneSequence> getGeneSequences() {
+	public Map<String, GeneSequence> getGeneSequences() {
 		return geneSequenceHashMap;
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/GeneSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/GeneSequence.java
@@ -32,6 +32,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.List;
 
 /**
  *
@@ -41,11 +43,11 @@ public class GeneSequence extends DNASequence {
 
 	private final static Logger logger = LoggerFactory.getLogger(GeneSequence.class);
 
-	private final LinkedHashMap<String, TranscriptSequence> transcriptSequenceHashMap = new LinkedHashMap<>();
-	private final LinkedHashMap<String, IntronSequence> intronSequenceHashMap = new LinkedHashMap<>();
-	private final LinkedHashMap<String, ExonSequence> exonSequenceHashMap = new LinkedHashMap<>();
-	private final ArrayList<IntronSequence> intronSequenceList = new ArrayList<>();
-	private final ArrayList<ExonSequence> exonSequenceList = new ArrayList<>();
+	private final Map<String, TranscriptSequence> transcriptSequenceHashMap = new LinkedHashMap<>();
+	private final Map<String, IntronSequence> intronSequenceHashMap = new LinkedHashMap<>();
+	private final Map<String, ExonSequence> exonSequenceHashMap = new LinkedHashMap<>();
+	private final List<IntronSequence> intronSequenceList = new ArrayList<>();
+	private final List<ExonSequence> exonSequenceList = new ArrayList<>();
 	boolean intronAdded = false; // need to deal with the problem that typically introns are not added when validating the list and adding in introns as the regions not included in exons
 	private Strand strand = Strand.UNDEFINED;
 	private ChromosomeSequence chromosomeSequence;
@@ -179,7 +181,7 @@ public class GeneSequence extends DNASequence {
 	 * Get the collection of transcription sequences assigned to this gene
 	 * @return transcripts
 	 */
-	public LinkedHashMap<String, TranscriptSequence> getTranscripts() {
+	public Map<String, TranscriptSequence> getTranscripts() {
 		return transcriptSequenceHashMap;
 	}
 
@@ -294,7 +296,7 @@ public class GeneSequence extends DNASequence {
 	 * Get the exons as an ArrayList. Modifying this list will not modify the underlying collection
 	 * @return exons
 	 */
-	public ArrayList<ExonSequence> getExonSequences() {
+	public List<ExonSequence> getExonSequences() {
 		return new ArrayList<>(exonSequenceList);
 	}
 
@@ -302,7 +304,7 @@ public class GeneSequence extends DNASequence {
 	 * Get the introns as an ArrayList. Modifying this list will not modify the underlying collection
 	 * @return introns
 	 */
-	public ArrayList<IntronSequence> getIntronSequences() {
+	public List<IntronSequence> getIntronSequences() {
 		return  new ArrayList<>(intronSequenceList);
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ProteinSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/ProteinSequence.java
@@ -42,6 +42,7 @@ import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
 import org.biojava.nbio.core.sequence.features.Qualifier;
+import java.util.Map;
 
 /**
  * The representation of a ProteinSequence
@@ -163,7 +164,7 @@ public class ProteinSequence extends AbstractSequence<AminoAcidCompound> {
 				= new FastaReader<>(is,
 						new PlainFastaHeaderParser<DNASequence, NucleotideCompound>(),
 						new DNASequenceCreator(AmbiguityDNACompoundSet.getDNACompoundSet()));
-		LinkedHashMap<String, DNASequence> seq = parentReader.process();
+		Map<String, DNASequence> seq = parentReader.process();
 
 		DNASequence parentSeq = null;
 		if (seq.size() == 1) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/TranscriptSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/TranscriptSequence.java
@@ -31,6 +31,8 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * This is the sequence if you want to go from a gene sequence to a protein sequence. Need to start with a
@@ -41,8 +43,8 @@ public class TranscriptSequence extends DNASequence {
 
 	private final static Logger logger = LoggerFactory.getLogger(TranscriptSequence.class);
 
-	private final ArrayList<CDSSequence> cdsSequenceList = new ArrayList<>();
-	private final LinkedHashMap<String, CDSSequence> cdsSequenceHashMap = new LinkedHashMap<>();
+	private final List<CDSSequence> cdsSequenceList = new ArrayList<>();
+	private final Map<String, CDSSequence> cdsSequenceHashMap = new LinkedHashMap<>();
 	private StartCodonSequence startCodonSequence = null;
 	private StopCodonSequence stopCodonSequence = null;
 	private GeneSequence parentGeneSequence = null;
@@ -110,7 +112,7 @@ public class TranscriptSequence extends DNASequence {
 	 * Get the CDS sequences that have been added to the TranscriptSequences
 	 * @return
 	 */
-	public LinkedHashMap<String, CDSSequence> getCDSSequences() {
+	public Map<String, CDSSequence> getCDSSequences() {
 		return cdsSequenceHashMap;
 	}
 
@@ -152,8 +154,8 @@ public class TranscriptSequence extends DNASequence {
 	 *
 	 * @return
 	 */
-	public ArrayList<ProteinSequence> getProteinCDSSequences() {
-		ArrayList<ProteinSequence> proteinSequenceList = new ArrayList<>();
+	public List<ProteinSequence> getProteinCDSSequences() {
+		List<ProteinSequence> proteinSequenceList = new ArrayList<>();
 		for (int i = 0; i < cdsSequenceList.size(); i++) {
 			CDSSequence cdsSequence = cdsSequenceList.get(i);
 			String codingSequence = cdsSequence.getCodingSequence();

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/DBReferenceInfo.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/features/DBReferenceInfo.java
@@ -25,6 +25,7 @@ package org.biojava.nbio.core.sequence.features;
 import org.biojava.nbio.core.sequence.loader.UniprotProxySequenceReader;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * If you have a uniprot ID then it is possible to get a collection
@@ -37,7 +38,7 @@ import java.util.LinkedHashMap;
  * @author Paolo Pavan
  */
 public class DBReferenceInfo extends Qualifier {
-	private LinkedHashMap<String, String> properties = new LinkedHashMap<>();
+	private Map<String, String> properties = new LinkedHashMap<>();
 	private String database = "";
 	private String id = "";
 
@@ -66,14 +67,14 @@ public class DBReferenceInfo extends Qualifier {
 	 * Get the properties
 	 * @return the properties
 	 */
-	public LinkedHashMap<String, String> getProperties() {
+	public Map<String, String> getProperties() {
 		return properties;
 	}
 
 	/**
 	 * @param properties the properties to set
 	 */
-	public void setProperties(LinkedHashMap<String, String> properties) {
+	public void setProperties(Map<String, String> properties) {
 		this.properties = properties;
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaReaderHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaReaderHelper.java
@@ -35,6 +35,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *
@@ -51,7 +52,7 @@ public class FastaReaderHelper {
 	 * @return
 	 * @throws IOException
 	 */
-	public static LinkedHashMap<String, DNASequence> readFastaDNASequence(File file, boolean lazySequenceLoad) throws IOException {
+	public static Map<String, DNASequence> readFastaDNASequence(File file, boolean lazySequenceLoad) throws IOException {
 		if (!lazySequenceLoad) {
 			return readFastaDNASequence(file);
 		}
@@ -79,7 +80,7 @@ public class FastaReaderHelper {
 	 * @return
 	 * @throws IOException
 	 */
-	public static LinkedHashMap<String, RNASequence> readFastaRNASequence(File file, boolean lazySequenceLoad) throws IOException {
+	public static Map<String, RNASequence> readFastaRNASequence(File file, boolean lazySequenceLoad) throws IOException {
 		if (!lazySequenceLoad) {
 			return readFastaRNASequence(file);
 		}
@@ -106,10 +107,10 @@ public class FastaReaderHelper {
 	 * @return
 	 * @throws IOException
 	 */
-	public static LinkedHashMap<String, ProteinSequence> readFastaProteinSequence(
+	public static Map<String, ProteinSequence> readFastaProteinSequence(
 			File file) throws IOException {
 		FileInputStream inStream = new FileInputStream(file);
-		LinkedHashMap<String, ProteinSequence> proteinSequences = readFastaProteinSequence(inStream);
+		Map<String, ProteinSequence> proteinSequences = readFastaProteinSequence(inStream);
 		inStream.close();
 		return proteinSequences;
 	}
@@ -122,7 +123,7 @@ public class FastaReaderHelper {
 	 * @return
 	 * @throws IOException
 	 */
-	public static LinkedHashMap<String, ProteinSequence> readFastaProteinSequence(
+	public static Map<String, ProteinSequence> readFastaProteinSequence(
 			InputStream inStream) throws IOException {
 		FastaReader<ProteinSequence, AminoAcidCompound> fastaReader = new FastaReader<>(
 				inStream,
@@ -137,7 +138,7 @@ public class FastaReaderHelper {
 	 * @return
 	 * @throws IOException
 	 */
-	public static LinkedHashMap<String, DNASequence> readFastaDNASequence(
+	public static Map<String, DNASequence> readFastaDNASequence(
 			InputStream inStream) throws IOException {
 		FastaReader<DNASequence, NucleotideCompound> fastaReader = new FastaReader<>(
 				inStream,
@@ -152,10 +153,10 @@ public class FastaReaderHelper {
 	 * @return
 	 * @throws IOException
 	 */
-	public static LinkedHashMap<String, DNASequence> readFastaDNASequence(
+	public static Map<String, DNASequence> readFastaDNASequence(
 			File file) throws IOException {
 		FileInputStream inStream = new FileInputStream(file);
-		LinkedHashMap<String, DNASequence> dnaSequences = readFastaDNASequence(inStream);
+		Map<String, DNASequence> dnaSequences = readFastaDNASequence(inStream);
 		inStream.close();
 		return dnaSequences;
 	}
@@ -166,7 +167,7 @@ public class FastaReaderHelper {
 	 * @return
 	 * @throws IOException
 	 */
-	public static LinkedHashMap<String, RNASequence> readFastaRNASequence(
+	public static Map<String, RNASequence> readFastaRNASequence(
 			InputStream inStream) throws IOException {
 		FastaReader<RNASequence, NucleotideCompound> fastaReader = new FastaReader<>(
 				inStream,
@@ -181,10 +182,10 @@ public class FastaReaderHelper {
 	 * @return
 	 * @throws IOException
 	 */
-	public static LinkedHashMap<String, RNASequence> readFastaRNASequence(
+	public static Map<String, RNASequence> readFastaRNASequence(
 			File file) throws IOException {
 		FileInputStream inStream = new FileInputStream(file);
-		LinkedHashMap<String, RNASequence> rnaSequences = readFastaRNASequence(inStream);
+		Map<String, RNASequence> rnaSequences = readFastaRNASequence(inStream);
 		inStream.close();
 		return rnaSequences;
 	}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaStreamer.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/FastaStreamer.java
@@ -36,7 +36,7 @@ public class FastaStreamer {
 	private int batchSize = 1_000;
 	private SequenceHeaderParserInterface<ProteinSequence, AminoAcidCompound> headerParser;
 	private SequenceCreatorInterface<AminoAcidCompound> sequenceCreator;
-	private LinkedHashMap<String, ProteinSequence> chunk = new LinkedHashMap<>();
+	private Map<String, ProteinSequence> chunk = new LinkedHashMap<>();
 	private Iterator<Map.Entry<String, ProteinSequence>> iterator = Collections.emptyIterator();
 	private boolean closed = false;
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReaderHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankReaderHelper.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *
@@ -55,7 +56,7 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, DNASequence> readGenbankDNASequence(File file, boolean lazySequenceLoad) throws Exception {
+	public static Map<String, DNASequence> readGenbankDNASequence(File file, boolean lazySequenceLoad) throws Exception {
 		if (!lazySequenceLoad) {
 			return readGenbankDNASequence(file);
 		}
@@ -83,7 +84,7 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, ProteinSequence> readGenbankProteinSequence(File file, boolean lazySequenceLoad) throws Exception {
+	public static Map<String, ProteinSequence> readGenbankProteinSequence(File file, boolean lazySequenceLoad) throws Exception {
 		if (!lazySequenceLoad) {
 			return readGenbankProteinSequence(file);
 		}
@@ -111,7 +112,7 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, RNASequence> readGenbankRNASequence(File file, boolean lazySequenceLoad) throws Exception {
+	public static Map<String, RNASequence> readGenbankRNASequence(File file, boolean lazySequenceLoad) throws Exception {
 		if (!lazySequenceLoad) {
 			return readGenbankRNASequence(file);
 		}
@@ -138,10 +139,10 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, ProteinSequence> readGenbankProteinSequence(
+	public static Map<String, ProteinSequence> readGenbankProteinSequence(
 			File file) throws Exception {
 		FileInputStream inStream = new FileInputStream(file);
-		LinkedHashMap<String, ProteinSequence> proteinSequences = readGenbankProteinSequence(inStream);
+		Map<String, ProteinSequence> proteinSequences = readGenbankProteinSequence(inStream);
 		inStream.close();
 		return proteinSequences;
 	}
@@ -154,7 +155,7 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, ProteinSequence> readGenbankProteinSequence(
+	public static Map<String, ProteinSequence> readGenbankProteinSequence(
 			InputStream inStream) throws Exception {
 		GenbankReader<ProteinSequence, AminoAcidCompound> GenbankReader = new GenbankReader<>(
 				inStream,
@@ -169,7 +170,7 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, DNASequence> readGenbankDNASequence(
+	public static Map<String, DNASequence> readGenbankDNASequence(
 			InputStream inStream) throws Exception {
 		GenbankReader<DNASequence, NucleotideCompound> GenbankReader = new GenbankReader<>(
 				inStream,
@@ -184,10 +185,10 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, DNASequence> readGenbankDNASequence(
+	public static Map<String, DNASequence> readGenbankDNASequence(
 			File file) throws Exception {
 		FileInputStream inStream = new FileInputStream(file);
-		LinkedHashMap<String, DNASequence> dnaSequences = readGenbankDNASequence(inStream);
+		Map<String, DNASequence> dnaSequences = readGenbankDNASequence(inStream);
 		inStream.close();
 		return dnaSequences;
 	}
@@ -197,7 +198,7 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, RNASequence> readGenbankRNASequence(
+	public static Map<String, RNASequence> readGenbankRNASequence(
 			InputStream inStream) throws Exception {
 		GenbankReader<RNASequence, NucleotideCompound> GenbankReader = new GenbankReader<>(
 				inStream,
@@ -212,10 +213,10 @@ public class GenbankReaderHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	public static LinkedHashMap<String, RNASequence> readGenbankRNASequence(
+	public static Map<String, RNASequence> readGenbankRNASequence(
 			File file) throws Exception {
 		FileInputStream inStream = new FileInputStream(file);
-		LinkedHashMap<String, RNASequence> rnaSequences = readGenbankRNASequence(inStream);
+		Map<String, RNASequence> rnaSequences = readGenbankRNASequence(inStream);
 		inStream.close();
 		return rnaSequences;
 	}

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenbankSequenceParser.java
@@ -217,7 +217,7 @@ public class GenbankSequenceParser<S extends AbstractSequence<C>, C extends Comp
 						xref.setNeedsQuotes(needsQuotes);
 						gbFeature.addQualifier(key, xref);
 
-						ArrayList<DBReferenceInfo> listDBEntry = new ArrayList<>();
+						List<DBReferenceInfo> listDBEntry = new ArrayList<>();
 						listDBEntry.add(xref);
 						mapDB.put(key, listDBEntry);
 					} else {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericFastaHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericFastaHeaderParser.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The default fasta header parser where some headers are well defined based on the source
@@ -71,7 +72,7 @@ public class GenericFastaHeaderParser<S extends AbstractSequence<C>, C extends C
 	 */
 	private String[] getHeaderValues(String header) {
 		String[] data = new String[0];
-		ArrayList<String> values = new ArrayList<>();
+		List<String> values = new ArrayList<>();
 		StringBuffer sb = new StringBuffer();
 		//commented out 1/11/2012 to resolve an issue where headers do contain a length= at the end that are not recognized
 		//if(header.indexOf("length=") != -1){

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderFormat.java
@@ -76,7 +76,7 @@ public class GenericGenbankHeaderFormat<S extends AbstractSequence<C>, C extends
 			text = "";
 		}
 		int max_len = MAX_WIDTH - HEADER_WIDTH;
-		ArrayList<String> lines = _split_multi_line(text, max_len);
+		List<String> lines = _split_multi_line(text, max_len);
 		String output = _write_single_line(tag, lines.get(0));
 		for (int i = 1; i < lines.size(); i++) {
 			output += _write_single_line("", lines.get(i));
@@ -254,7 +254,7 @@ public class GenericGenbankHeaderFormat<S extends AbstractSequence<C>, C extends
 	 * @param sequence
 	 */
 	private String _write_comment(S sequence) {
-		ArrayList<String> comments = sequence.getNotesList();
+		List<String> comments = sequence.getNotesList();
 		String output = _write_multi_line("COMMENT", comments.remove(0));
 		for (String comment : comments) {
 			output += _write_multi_line("", comment);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericGenbankHeaderParser.java
@@ -67,7 +67,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 
 	private boolean versionSeen;
 
-	private ArrayList<String> comments = new ArrayList<>();
+	private List<String> comments = new ArrayList<>();
 
 	/**
 	 * Publications by the authors of the sequence that discuss the data reported in
@@ -134,7 +134,7 @@ public class GenericGenbankHeaderParser<S extends AbstractSequence<C>, C extends
 		return version;
 	}
 
-	public ArrayList<String> getComments() {
+	public List<String> getComments() {
 		return comments;
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/io/GenericInsdcHeaderFormat.java
@@ -208,7 +208,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 				
 				StringBuilder sb = new StringBuilder();
 				Formatter formatter = new Formatter(sb, Locale.US);
-				ArrayList<String> locations = new ArrayList<>();
+				List<String> locations = new ArrayList<>();
 				for(Location l  : feature.getLocations().getSubLocations()) {	
 					locations.add(_insdc_location_string_ignoring_strand_and_subfeatures((AbstractLocation) l, record_length));					
 				}
@@ -223,7 +223,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 				//This covers typical forward strand features, and also an evil mixed strand:
 				StringBuilder sb = new StringBuilder();
 				Formatter formatter = new Formatter(sb,Locale.US);
-				ArrayList<String> locations = new ArrayList<>();
+				List<String> locations = new ArrayList<>();
 				for(Location l  : feature.getLocations().getSubLocations()) {	
 					locations.add(_insdc_location_string_ignoring_strand_and_subfeatures((AbstractLocation) l, record_length));					
 				}
@@ -248,7 +248,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 			}
 			StringBuilder sb = new StringBuilder();
 			Formatter formatter = new Formatter(sb,Locale.US);
-			ArrayList<String> locations = new ArrayList<>();
+			List<String> locations = new ArrayList<>();
 			for(FeatureInterface<AbstractSequence<C>, C> f  : feature.getChildrenFeatures()) {
 				locations.add(_insdc_location_string_ignoring_strand_and_subfeatures(f.getLocations(), record_length));
 			}
@@ -261,7 +261,7 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 		//This covers typical forward strand features, and also an evil mixed strand:
 		StringBuilder sb = new StringBuilder();
 		Formatter formatter = new Formatter(sb,Locale.US);
-		ArrayList<String> locations = new ArrayList<>();
+		List<String> locations = new ArrayList<>();
 		for(FeatureInterface<AbstractSequence<C>, C> f  : feature.getChildrenFeatures()) {
 			locations.add(_insdc_location_string_ignoring_strand_and_subfeatures(f.getLocations(), record_length));
 		}
@@ -404,16 +404,16 @@ public class GenericInsdcHeaderFormat<S extends AbstractSequence<C>, C extends C
 	 * @param text
 	 * @param max_len
 	 */
-	protected ArrayList<String> _split_multi_line(String text, int max_len) {
+	protected List<String> _split_multi_line(String text, int max_len) {
 		// TODO Auto-generated method stub
-		ArrayList<String> output = new ArrayList<>();
+		List<String> output = new ArrayList<>();
 		text = text.trim();
 		if(text.length() <= max_len) {
 			output.add(text);
 			return output;
 		}
 
-		ArrayList<String> words = new ArrayList<>();
+		List<String> words = new ArrayList<>();
 		Collections.addAll(words, text.split("\\s+"));
 		while(!words.isEmpty()) {
 			text = words.remove(0);

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/StringProxySequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/StringProxySequenceReader.java
@@ -83,7 +83,7 @@ public class StringProxySequenceReader<C extends Compound> implements ProxySeque
 		}
 	}
 
-	public void setContents(String sequence, ArrayList features) throws CompoundNotFoundException{
+	public void setContents(String sequence, List features) throws CompoundNotFoundException{
 		setContents(sequence);
 	}
 

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/UniprotProxySequenceReader.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/loader/UniprotProxySequenceReader.java
@@ -340,14 +340,14 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @return
 	 * @throws XPathExpressionException
 	 */
-	public ArrayList<AccessionID> getAccessions() throws XPathExpressionException {
-		ArrayList<AccessionID> accessionList = new ArrayList<>();
+	public List<AccessionID> getAccessions() throws XPathExpressionException {
+		List<AccessionID> accessionList = new ArrayList<>();
 		if (uniprotDoc == null) {
 			return accessionList;
 		}
 		Element uniprotElement = uniprotDoc.getDocumentElement();
 		Element entryElement = XMLHelper.selectSingleElement(uniprotElement, "entry");
-		ArrayList<Element> keyWordElementList = XMLHelper.selectElements(entryElement, "accession");
+		List<Element> keyWordElementList = XMLHelper.selectElements(entryElement, "accession");
 		for (Element element : keyWordElementList) {
 			AccessionID accessionID = new AccessionID(element.getTextContent(), DataSource.UNIPROT);
 			accessionList.add(accessionID);
@@ -363,7 +363,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @return
 	 * @throws XPathExpressionException
 	 */
-	public ArrayList<String> getAliases() throws XPathExpressionException {
+	public List<String> getAliases() throws XPathExpressionException {
 
 		return getProteinAliases();
 	}
@@ -372,8 +372,8 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @return
 	 * @throws XPathExpressionException
 	 */
-	public ArrayList<String> getProteinAliases() throws XPathExpressionException {
-		ArrayList<String> aliasList = new ArrayList<>();
+	public List<String> getProteinAliases() throws XPathExpressionException {
+		List<String> aliasList = new ArrayList<>();
 		if (uniprotDoc == null) {
 			return aliasList;
 		}
@@ -381,7 +381,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 		Element entryElement = XMLHelper.selectSingleElement(uniprotElement, "entry");
 		Element proteinElement = XMLHelper.selectSingleElement(entryElement, "protein");
 		
-		ArrayList<Element> keyWordElementList;
+		List<Element> keyWordElementList;
 		getProteinAliasesFromNameGroup(aliasList, proteinElement);
 		
 		keyWordElementList = XMLHelper.selectElements(proteinElement, "component");
@@ -439,9 +439,9 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @param proteinElement
 	 * @throws XPathExpressionException
 	 */
-	private void getProteinAliasesFromNameGroup(ArrayList<String> aliasList, Element proteinElement)
+	private void getProteinAliasesFromNameGroup(List<String> aliasList, Element proteinElement)
 			throws XPathExpressionException {
-		ArrayList<Element> keyWordElementList = XMLHelper.selectElements(proteinElement, "alternativeName");
+		List<Element> keyWordElementList = XMLHelper.selectElements(proteinElement, "alternativeName");
 		for (Element element : keyWordElementList) {
 			getProteinAliasesFromElement(aliasList, element);
 		}
@@ -457,7 +457,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @param element
 	 * @throws XPathExpressionException
 	 */
-	private void getProteinAliasesFromElement(ArrayList<String> aliasList, Element element)
+	private void getProteinAliasesFromElement(List<String> aliasList, Element element)
 			throws XPathExpressionException {
 		Element fullNameElement = XMLHelper.selectSingleElement(element, "fullName");
 		aliasList.add(fullNameElement.getTextContent());
@@ -475,16 +475,16 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @return
 	 * @throws XPathExpressionException
 	 */
-	public ArrayList<String> getGeneAliases() throws XPathExpressionException {
-		ArrayList<String> aliasList = new ArrayList<>();
+	public List<String> getGeneAliases() throws XPathExpressionException {
+		List<String> aliasList = new ArrayList<>();
 		if (uniprotDoc == null) {
 			return aliasList;
 		}
 		Element uniprotElement = uniprotDoc.getDocumentElement();
 		Element entryElement = XMLHelper.selectSingleElement(uniprotElement, "entry");
-		ArrayList<Element> proteinElements = XMLHelper.selectElements(entryElement, "gene");
+		List<Element> proteinElements = XMLHelper.selectElements(entryElement, "gene");
 		for(Element proteinElement : proteinElements) {
-			ArrayList<Element> keyWordElementList = XMLHelper.selectElements(proteinElement, "name");
+			List<Element> keyWordElementList = XMLHelper.selectElements(proteinElement, "name");
 			for (Element element : keyWordElementList) {
 				aliasList.add(element.getTextContent());
 			}
@@ -774,8 +774,8 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 	 * @return
 	 */
 	@Override
-	public ArrayList<String> getKeyWords() {
-		ArrayList<String> keyWordsList = new ArrayList<>();
+	public List<String> getKeyWords() {
+		List<String> keyWordsList = new ArrayList<>();
 		if (uniprotDoc == null) {
 			return keyWordsList;
 		}
@@ -783,7 +783,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 			Element uniprotElement = uniprotDoc.getDocumentElement();
 
 			Element entryElement = XMLHelper.selectSingleElement(uniprotElement, "entry");
-			ArrayList<Element> keyWordElementList = XMLHelper.selectElements(entryElement, "keyword");
+			List<Element> keyWordElementList = XMLHelper.selectElements(entryElement, "keyword");
 			for (Element element : keyWordElementList) {
 				keyWordsList.add(element.getTextContent());
 			}
@@ -809,7 +809,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 		try {
 			Element uniprotElement = uniprotDoc.getDocumentElement();
 			Element entryElement = XMLHelper.selectSingleElement(uniprotElement, "entry");
-			ArrayList<Element> dbreferenceElementList = XMLHelper.selectElements(entryElement, "dbReference");
+			List<Element> dbreferenceElementList = XMLHelper.selectElements(entryElement, "dbReference");
 			for (Element element : dbreferenceElementList) {
 				String type = element.getAttribute("type");
 				String id = element.getAttribute("id");
@@ -819,7 +819,7 @@ public class UniprotProxySequenceReader<C extends Compound> implements ProxySequ
 					databaseReferencesHashMap.put(type, idlist);
 				}
 				DBReferenceInfo dbreferenceInfo = new DBReferenceInfo(type, id);
-				ArrayList<Element> propertyElementList = XMLHelper.selectElements(element, "property");
+				List<Element> propertyElementList = XMLHelper.selectElements(element, "property");
 				for (Element propertyElement : propertyElementList) {
 					String propertyType = propertyElement.getAttribute("type");
 					String propertyValue = propertyElement.getAttribute("value");

--- a/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractSequence.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/sequence/template/AbstractSequence.java
@@ -65,14 +65,14 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	private Integer bioEnd = null;
 	private AbstractSequence<?> parentSequence = null;
 	private String source = null;
-	private ArrayList<String> notesList = new ArrayList<>();
+	private List<String> notesList = new ArrayList<>();
 	private Double sequenceScore = null;
 	private FeaturesKeyWordInterface featuresKeyWord = null;
 	private DatabaseReferenceInterface databaseReferences = null;
 	private FeatureRetriever featureRetriever = null;
-	private ArrayList<FeatureInterface<AbstractSequence<C>, C>> features =
+	private List<FeatureInterface<AbstractSequence<C>, C>> features =
 			new ArrayList<>();
-	private LinkedHashMap<String, ArrayList<FeatureInterface<AbstractSequence<C>, C>>> groupedFeatures =
+	private Map<String, List<FeatureInterface<AbstractSequence<C>, C>>> groupedFeatures =
 			new LinkedHashMap<>();
 	private List<String> comments = new ArrayList<>();
 	private List<AbstractReference> references;
@@ -139,7 +139,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 			}
 			// success of next statement guaranteed because source is a compulsory field
 			//DBReferenceInfo dbQualifier = (DBReferenceInfo)ff.get("source").get(0).getQualifiers().get("db_xref");
-			ArrayList<DBReferenceInfo> dbQualifiers = (ArrayList)ff.get("source").get(0).getQualifiers().get("db_xref");
+			List<DBReferenceInfo> dbQualifiers = (ArrayList)ff.get("source").get(0).getQualifiers().get("db_xref");
 			DBReferenceInfo dbQualifier = dbQualifiers.get(0);
 
 			if (dbQualifier != null) this.setTaxonomy(new TaxonomyID(dbQualifier.getDatabase()+":"+dbQualifier.getId(), DataSource.UNKNOWN));
@@ -303,14 +303,14 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	/**
 	 * @return the notesList
 	 */
-	public ArrayList<String> getNotesList() {
+	public List<String> getNotesList() {
 		return notesList;
 	}
 
 	/**
 	 * @param notesList the notesList to set
 	 */
-	public void setNotesList(ArrayList<String> notesList) {
+	public void setNotesList(List<String> notesList) {
 		this.notesList = notesList;
 	}
 
@@ -353,7 +353,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	 * @return
 	 */
 	public List<FeatureInterface<AbstractSequence<C>, C>> getFeatures(String featureType, int bioSequencePosition) {
-		ArrayList<FeatureInterface<AbstractSequence<C>, C>> featureHits =
+		List<FeatureInterface<AbstractSequence<C>, C>> featureHits =
 				new ArrayList<>();
 		List<FeatureInterface<AbstractSequence<C>, C>> features = getFeaturesByType(featureType);
 		if (features != null) {
@@ -372,7 +372,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	 * @return
 	 */
 	public List<FeatureInterface<AbstractSequence<C>, C>> getFeatures(int bioSequencePosition) {
-		ArrayList<FeatureInterface<AbstractSequence<C>, C>> featureHits =
+		List<FeatureInterface<AbstractSequence<C>, C>> featureHits =
 				new ArrayList<>();
 		if (features != null) {
 			for (FeatureInterface<AbstractSequence<C>, C> feature : features) {
@@ -414,7 +414,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	 */
 	public void addFeature(FeatureInterface<AbstractSequence<C>, C> feature) {
 		features.add(feature);
-		ArrayList<FeatureInterface<AbstractSequence<C>, C>> featureList = groupedFeatures.get(feature.getType());
+		List<FeatureInterface<AbstractSequence<C>, C>> featureList = groupedFeatures.get(feature.getType());
 		if (featureList == null) {
 			featureList = new ArrayList<>();
 			groupedFeatures.put(feature.getType(), featureList);
@@ -430,7 +430,7 @@ public abstract class AbstractSequence<C extends Compound> implements Sequence<C
 	 */
 	public void removeFeature(FeatureInterface<AbstractSequence<C>, C> feature) {
 		features.remove(feature);
-		ArrayList<FeatureInterface<AbstractSequence<C>, C>> featureList = groupedFeatures.get(feature.getType());
+		List<FeatureInterface<AbstractSequence<C>, C>> featureList = groupedFeatures.get(feature.getType());
 		if (featureList != null) {
 			featureList.remove(feature);
 			if (featureList.isEmpty()) {

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/SingleLinkageClusterer.java
@@ -87,7 +87,7 @@ public class SingleLinkageClusterer {
 
 	//private Set<Integer> toSkip;
 
-	private ArrayList<Integer> indicesToCheck;
+	private List<Integer> indicesToCheck;
 
 
 	/**

--- a/biojava-core/src/main/java/org/biojava/nbio/core/util/XMLHelper.java
+++ b/biojava-core/src/main/java/org/biojava/nbio/core/util/XMLHelper.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 
 import static org.biojava.nbio.core.sequence.io.util.IOUtils.close;
 import static org.biojava.nbio.core.sequence.io.util.IOUtils.openFile;
+import java.util.List;
 
 /**
  * Helper methods to simplify boilerplate XML parsing code for  {@code}org.w3c.dom{@code} XML objects
@@ -206,8 +207,8 @@ public class XMLHelper {
 	 * @return A possibly empty but non-null {@code}ArrayList{@code}
 	 * @throws XPathExpressionException
 	 */
-	public static ArrayList<Element> selectElements(Element element, String xpathExpression) throws XPathExpressionException {
-		ArrayList<Element> resultVector = new ArrayList<>();
+	public static List<Element> selectElements(Element element, String xpathExpression) throws XPathExpressionException {
+		List<Element> resultVector = new ArrayList<>();
 		if (element == null) {
 			return resultVector;
 		}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/GeneSequenceTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/GeneSequenceTest.java
@@ -129,7 +129,7 @@ class GeneSequenceTest {
         geneSequence.addExon(new AccessionID("a"), 20, 50);
         geneSequence.addExon(new AccessionID("b"), 80, 100);
         geneSequence.addIntronsUsingExons();
-        ArrayList<IntronSequence> introns  =  geneSequence.getIntronSequences();
+        List<IntronSequence> introns  =  geneSequence.getIntronSequences();
         assertEquals(1, introns.size());
         introns.remove(0);
         assertEquals(1, geneSequence.getIntronSequences().size());

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankCookbookTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankCookbookTest.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *
@@ -90,12 +91,12 @@ public class GenbankCookbookTest {
 		//File protFile = new File("src/test/resources/BondFeature.gb");
 		ClasspathResource protResource = new ClasspathResource("BondFeature.gb");
 
-		LinkedHashMap<String, DNASequence> dnaSequences = GenbankReaderHelper.readGenbankDNASequence(dnaResource.getInputStream());
+		Map<String, DNASequence> dnaSequences = GenbankReaderHelper.readGenbankDNASequence(dnaResource.getInputStream());
 		for (DNASequence sequence : dnaSequences.values()) {
 			logger.debug("DNA Sequence: {}", sequence.getSequenceAsString());
 		}
 
-		LinkedHashMap<String, ProteinSequence> protSequences = GenbankReaderHelper.readGenbankProteinSequence(protResource.getInputStream());
+		Map<String, ProteinSequence> protSequences = GenbankReaderHelper.readGenbankProteinSequence(protResource.getInputStream());
 		for (ProteinSequence sequence : protSequences.values()) {
 			logger.debug("Protein Sequence: {}", sequence.getSequenceAsString());
 		}

--- a/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/sequence/io/GenbankWriterTest.java
@@ -63,7 +63,7 @@ public class GenbankWriterTest {
 
 		InputStream inStream = GenbankWriterTest.class.getResourceAsStream("/NM_000266.gb");
 		//File dnaFile = new File("src/test/resources/NM_000266.gb");
-		LinkedHashMap<String, DNASequence> dnaSequences = GenbankReaderHelper.readGenbankDNASequence( inStream );
+		Map<String, DNASequence> dnaSequences = GenbankReaderHelper.readGenbankDNASequence( inStream );
 		ByteArrayOutputStream fragwriter = new ByteArrayOutputStream();
 		ArrayList<DNASequence> seqs = new ArrayList<DNASequence>();
 		for(DNASequence seq : dnaSequences.values()) {

--- a/biojava-core/src/test/java/org/biojava/nbio/core/util/XMLHelperTest.java
+++ b/biojava-core/src/test/java/org/biojava/nbio/core/util/XMLHelperTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.List;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -148,7 +149,7 @@ class XMLHelperTest {
         @Test
         void selectMultipleElementsWithXPath()
                 throws  XPathExpressionException {
-            ArrayList<Element> selected = XMLHelper.selectElements(root, "/root/list/a");
+            List<Element> selected = XMLHelper.selectElements(root, "/root/list/a");
             assertEquals(2, selected.size());
         }
 
@@ -157,7 +158,7 @@ class XMLHelperTest {
                 throws  XPathExpressionException {
             Element a1  = (Element) doc.getElementsByTagName("a").item(0);
             
-            ArrayList<Element> selected = XMLHelper.selectElements(a1, "/root");
+            List<Element> selected = XMLHelper.selectElements(a1, "/root");
             assertEquals(1, selected.size());
             assertEquals("root", selected.get(0).getTagName());
         }

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/GeneFeatureHelper.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/GeneFeatureHelper.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *
@@ -43,7 +44,7 @@ public class GeneFeatureHelper {
 
 	static public LinkedHashMap<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromUpperCaseExonFastaFile(File fastaSequenceFile, File uppercaseFastaFile, boolean throwExceptionGeneNotFound) throws Exception {
 		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = new LinkedHashMap<>();
-		LinkedHashMap<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
+		Map<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
 		for (String accession : dnaSequenceList.keySet()) {
 			DNASequence contigSequence = dnaSequenceList.get(accession);
 			ChromosomeSequence chromsomeSequence = new ChromosomeSequence(contigSequence.getSequenceAsString());
@@ -52,7 +53,7 @@ public class GeneFeatureHelper {
 		}
 
 
-		LinkedHashMap<String, DNASequence> geneSequenceList = FastaReaderHelper.readFastaDNASequence(uppercaseFastaFile);
+		Map<String, DNASequence> geneSequenceList = FastaReaderHelper.readFastaDNASequence(uppercaseFastaFile);
 		for (DNASequence dnaSequence : geneSequenceList.values()) {
 			String geneSequence = dnaSequence.getSequenceAsString();
 			String lcGeneSequence = geneSequence.toLowerCase();
@@ -162,7 +163,7 @@ public class GeneFeatureHelper {
 	 * @throws Exception
 	 */
 	static public void outputFastaSequenceLengthGFF3(File fastaSequenceFile, File gffFile) throws Exception {
-		LinkedHashMap<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
+		Map<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
 		String fileName = fastaSequenceFile.getName();
 		FileWriter fw = new FileWriter(gffFile);
 		String newLine = System.getProperty("line.separator");
@@ -182,9 +183,9 @@ public class GeneFeatureHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	static public LinkedHashMap<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromGeneIDGFF2(File fastaSequenceFile, File gffFile) throws Exception {
-		LinkedHashMap<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.getChromosomeSequenceFromDNASequence(dnaSequenceList);
+	static public Map<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromGeneIDGFF2(File fastaSequenceFile, File gffFile) throws Exception {
+		Map<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
+		Map<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.getChromosomeSequenceFromDNASequence(dnaSequenceList);
 		FeatureList listGenes = GeneIDGFF2Reader.read(gffFile.getAbsolutePath());
 		addGeneIDGFF2GeneFeatures(chromosomeSequenceList, listGenes);
 		return chromosomeSequenceList;
@@ -197,7 +198,7 @@ public class GeneFeatureHelper {
 	 * @param listGenes
 	 * @throws Exception
 	 */
-	static public void addGeneIDGFF2GeneFeatures(LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList, FeatureList listGenes) throws Exception {
+	static public void addGeneIDGFF2GeneFeatures(Map<String, ChromosomeSequence> chromosomeSequenceList, FeatureList listGenes) throws Exception {
 		Collection<String> geneIds = listGenes.attributeValues("gene_id");
 		for (String geneid : geneIds) {
 			FeatureList gene = listGenes.selectByAttribute("gene_id", geneid);
@@ -313,7 +314,7 @@ public class GeneFeatureHelper {
 
 	}
 
-	static public LinkedHashMap<String, ChromosomeSequence> getChromosomeSequenceFromDNASequence(LinkedHashMap<String, DNASequence> dnaSequenceList) {
+	static public Map<String, ChromosomeSequence> getChromosomeSequenceFromDNASequence(Map<String, DNASequence> dnaSequenceList) {
 		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = new LinkedHashMap<>();
 		for (String key : dnaSequenceList.keySet()) {
 			DNASequence dnaSequence = dnaSequenceList.get(key);
@@ -334,9 +335,9 @@ public class GeneFeatureHelper {
 	 * @return
 	 * @throws Exception
 	 */
-	static public LinkedHashMap<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromGmodGFF3(File fastaSequenceFile, File gffFile,boolean lazyloadsequences) throws Exception {
-		LinkedHashMap<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile,lazyloadsequences);
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.getChromosomeSequenceFromDNASequence(dnaSequenceList);
+	static public Map<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromGmodGFF3(File fastaSequenceFile, File gffFile,boolean lazyloadsequences) throws Exception {
+		Map<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile,lazyloadsequences);
+		Map<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.getChromosomeSequenceFromDNASequence(dnaSequenceList);
 		FeatureList listGenes = GFF3Reader.read(gffFile.getAbsolutePath());
 		addGmodGFF3GeneFeatures(chromosomeSequenceList, listGenes);
 		return chromosomeSequenceList;
@@ -348,7 +349,7 @@ public class GeneFeatureHelper {
 	 * @param listGenes
 	 * @throws Exception
 	 */
-	static public void addGmodGFF3GeneFeatures(LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList, FeatureList listGenes) throws Exception {
+	static public void addGmodGFF3GeneFeatures(Map<String, ChromosomeSequence> chromosomeSequenceList, FeatureList listGenes) throws Exception {
 
 
 		// key off mRNA as being a known feature that may or may not have a parent gene
@@ -532,15 +533,15 @@ public class GeneFeatureHelper {
 
 	}
 
-	static public LinkedHashMap<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromGlimmerGFF3(File fastaSequenceFile, File gffFile) throws Exception {
-		LinkedHashMap<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.getChromosomeSequenceFromDNASequence(dnaSequenceList);
+	static public Map<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromGlimmerGFF3(File fastaSequenceFile, File gffFile) throws Exception {
+		Map<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
+		Map<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.getChromosomeSequenceFromDNASequence(dnaSequenceList);
 		FeatureList listGenes = GFF3Reader.read(gffFile.getAbsolutePath());
 		addGlimmerGFF3GeneFeatures(chromosomeSequenceList, listGenes);
 		return chromosomeSequenceList;
 	}
 
-	static public void addGlimmerGFF3GeneFeatures(LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList, FeatureList listGenes) throws Exception {
+	static public void addGlimmerGFF3GeneFeatures(Map<String, ChromosomeSequence> chromosomeSequenceList, FeatureList listGenes) throws Exception {
 		FeatureList mRNAFeatures = listGenes.selectByType("mRNA");
 		for (FeatureI f : mRNAFeatures) {
 			Feature mRNAFeature = (Feature) f;
@@ -677,15 +678,15 @@ public class GeneFeatureHelper {
 
 	}
 
-	static public LinkedHashMap<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromGeneMarkGTF(File fastaSequenceFile, File gffFile) throws Exception {
-		LinkedHashMap<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.getChromosomeSequenceFromDNASequence(dnaSequenceList);
+	static public Map<String, ChromosomeSequence> loadFastaAddGeneFeaturesFromGeneMarkGTF(File fastaSequenceFile, File gffFile) throws Exception {
+		Map<String, DNASequence> dnaSequenceList = FastaReaderHelper.readFastaDNASequence(fastaSequenceFile);
+		Map<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper.getChromosomeSequenceFromDNASequence(dnaSequenceList);
 		FeatureList listGenes = GeneMarkGTFReader.read(gffFile.getAbsolutePath());
 		addGeneMarkGTFGeneFeatures(chromosomeSequenceList, listGenes);
 		return chromosomeSequenceList;
 	}
 
-	static public void addGeneMarkGTFGeneFeatures(LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList, FeatureList listGenes) throws Exception {
+	static public void addGeneMarkGTFGeneFeatures(Map<String, ChromosomeSequence> chromosomeSequenceList, FeatureList listGenes) throws Exception {
 		Collection<String> geneIds = listGenes.attributeValues("gene_id");
 		for (String geneid : geneIds) {
 			//       if(geneid.equals("45_g")){

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/homology/GFF3FromUniprotBlastHits.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/homology/GFF3FromUniprotBlastHits.java
@@ -87,7 +87,7 @@ public class GFF3FromUniprotBlastHits {
 
 
 					String predictedProteinSequence = transcriptSequence.getProteinSequence().getSequenceAsString();
-					ArrayList<ProteinSequence> cdsProteinList = transcriptSequence.getProteinCDSSequences();
+					List<ProteinSequence> cdsProteinList = transcriptSequence.getProteinCDSSequences();
 
 					ArrayList<CDSSequence> cdsSequenceList = new ArrayList<>(transcriptSequence.getCDSSequences().values());
 					String testSequence = "";
@@ -228,7 +228,7 @@ public class GFF3FromUniprotBlastHits {
 										for (DBReferenceInfo note : goList) {
 											notes = notes + " " + note.getId();
 											geneSequence.addNote(note.getId()); // add note/keyword which can be output in fasta header if needed
-											LinkedHashMap<String, String> properties = note.getProperties();
+											Map<String, String> properties = note.getProperties();
 											for (String propertytype : properties.keySet()) {
 												if ("evidence".equals(propertytype)) {
 													continue;
@@ -292,7 +292,7 @@ public class GFF3FromUniprotBlastHits {
 		*/
 
 			try {
-				LinkedHashMap<String, ChromosomeSequence> dnaSequenceHashMap = GeneFeatureHelper.loadFastaAddGeneFeaturesFromGlimmerGFF3(new File("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/454Scaffolds-16.fna"), new File("/Users/Scooter/scripps/dyadic/GlimmerHMM/c1_glimmerhmm-16.gff"));
+				Map<String, ChromosomeSequence> dnaSequenceHashMap = GeneFeatureHelper.loadFastaAddGeneFeaturesFromGlimmerGFF3(new File("/Users/Scooter/scripps/dyadic/analysis/454Scaffolds/454Scaffolds-16.fna"), new File("/Users/Scooter/scripps/dyadic/GlimmerHMM/c1_glimmerhmm-16.gff"));
 				LinkedHashMap<String, GeneSequence> geneSequenceList = GeneFeatureHelper.getGeneSequences(dnaSequenceHashMap.values());
 				FileOutputStream fo = new FileOutputStream("/Users/Scooter/scripps/dyadic/outputGlimmer/genemark_uniprot_match-16.gff3");
 				LinkedHashMap<String, ArrayList<String>> blasthits = BlastHomologyHits.getMatches(new File("/Users/Scooter/scripps/dyadic/blastresults/c1_glimmer_in_uniprot.xml"), 1E-10);

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/geneid/GeneIDXMLReader.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/geneid/GeneIDXMLReader.java
@@ -33,6 +33,7 @@ import org.w3c.dom.Element;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 /**
  *
@@ -52,7 +53,7 @@ public class GeneIDXMLReader {
 
 	public LinkedHashMap<String, ProteinSequence> getProteinSequences() throws Exception {
 		LinkedHashMap<String, ProteinSequence> proteinSequenceList = new LinkedHashMap<>();
-		ArrayList<Element> elementList = XMLHelper.selectElements(geneidDoc.getDocumentElement(), "prediction/gene/protein");
+		List<Element> elementList = XMLHelper.selectElements(geneidDoc.getDocumentElement(), "prediction/gene/protein");
 		logger.info("{} hits", elementList.size());
 
 		for (Element proteinElement : elementList) {
@@ -69,7 +70,7 @@ public class GeneIDXMLReader {
 
 	public LinkedHashMap<String, DNASequence> getDNACodingSequences() throws Exception {
 		LinkedHashMap<String, DNASequence> dnaSequenceList = new LinkedHashMap<>();
-		ArrayList<Element> elementList = XMLHelper.selectElements(geneidDoc.getDocumentElement(), "prediction/gene/cDNA");
+		List<Element> elementList = XMLHelper.selectElements(geneidDoc.getDocumentElement(), "prediction/gene/cDNA");
 		logger.info("{} hits", elementList.size());
 
 		for (Element dnaElement : elementList) {

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Writer.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/parsers/gff/GFF3Writer.java
@@ -26,6 +26,8 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -39,7 +41,7 @@ public class GFF3Writer {
 	 * @param chromosomeSequenceList
 	 * @throws Exception
 	 */
-	public void write(OutputStream outputStream, LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList) throws Exception {
+	public void write(OutputStream outputStream, Map<String, ChromosomeSequence> chromosomeSequenceList) throws Exception {
 
 		outputStream.write("##gff-version 3\n".getBytes());
 		for (String key : chromosomeSequenceList.keySet()) {
@@ -117,7 +119,7 @@ public class GFF3Writer {
 
 	}
 
-	private String getGFF3Note(ArrayList<String> notesList) {
+	private String getGFF3Note(List<String> notesList) {
 		String notes = "";
 
 		if (notesList.size() > 0) {

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/query/BlastXMLQuery.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/query/BlastXMLQuery.java
@@ -29,6 +29,7 @@ import org.w3c.dom.Element;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 /**
  *
@@ -49,19 +50,19 @@ public class BlastXMLQuery {
 	public LinkedHashMap<String, ArrayList<String>> getHitsQueryDef(double maxEScore) throws Exception {
 		LinkedHashMap<String, ArrayList<String>> hitsHashMap = new LinkedHashMap<>();
 		logger.info("Query for hits");
-		ArrayList<Element> elementList = XMLHelper.selectElements(blastDoc.getDocumentElement(), "BlastOutput_iterations/Iteration[Iteration_hits]");
+		List<Element> elementList = XMLHelper.selectElements(blastDoc.getDocumentElement(), "BlastOutput_iterations/Iteration[Iteration_hits]");
 		logger.info("{} hits", elementList.size());
 
 		for (Element element : elementList) {
 			Element iterationquerydefElement = XMLHelper.selectSingleElement(element, "Iteration_query-def");
 			String querydef = iterationquerydefElement.getTextContent();
 			Element iterationHitsElement = XMLHelper.selectSingleElement(element, "Iteration_hits");
-			ArrayList<Element> hitList = XMLHelper.selectElements(iterationHitsElement, "Hit");
+			List<Element> hitList = XMLHelper.selectElements(iterationHitsElement, "Hit");
 			for (Element hitElement : hitList) {
 				Element hitaccessionElement = XMLHelper.selectSingleElement(hitElement, "Hit_accession");
 				String hitaccession = hitaccessionElement.getTextContent();
 				Element hithspsElement = XMLHelper.selectSingleElement(hitElement, "Hit_hsps");
-				ArrayList<Element> hspList = XMLHelper.selectElements(hithspsElement, "Hsp");
+				List<Element> hspList = XMLHelper.selectElements(hithspsElement, "Hsp");
 				for (Element hspElement : hspList) {
 					Element evalueElement = XMLHelper.selectSingleElement(hspElement, "Hsp_evalue");
 					String value = evalueElement.getTextContent();

--- a/biojava-genome/src/main/java/org/biojava/nbio/genome/util/SplitFasta.java
+++ b/biojava-genome/src/main/java/org/biojava/nbio/genome/util/SplitFasta.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 
 /**
@@ -44,7 +45,7 @@ public class SplitFasta {
 		if(!outputDirectory.exists())
 			outputDirectory.mkdirs();
 
-		LinkedHashMap<String,DNASequence> dnaSequenceHashMap = FastaReaderHelper.readFastaDNASequence(fastaFileName);
+		Map<String,DNASequence> dnaSequenceHashMap = FastaReaderHelper.readFastaDNASequence(fastaFileName);
 		for(DNASequence dnaSequence : dnaSequenceHashMap.values()){
 			String fileName = outputDirectory.getAbsolutePath() + File.separatorChar;
 			if(uniqueid.length() > 0){

--- a/biojava-genome/src/test/java/org/biojava/nbio/genome/GeneFeatureHelperTest.java
+++ b/biojava-genome/src/test/java/org/biojava/nbio/genome/GeneFeatureHelperTest.java
@@ -39,6 +39,7 @@ import java.io.FileOutputStream;
 import java.nio.file.Files;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *
@@ -112,7 +113,7 @@ public class GeneFeatureHelperTest {
 
 	@Test
 	public void testAddGFF3Note() throws Exception {
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper
+		Map<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper
 				.loadFastaAddGeneFeaturesFromGmodGFF3(new File("src/test/resources/volvox_all.fna"), new File(
 						"src/test/resources/volvox.gff3"), false);
 		ChromosomeSequence ctgASequence = chromosomeSequenceList.get("ctgA");
@@ -128,10 +129,10 @@ public class GeneFeatureHelperTest {
 	 */
 	@Test
 	public void testGetProteinSequences() throws Exception {
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper
+		Map<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper
 				.loadFastaAddGeneFeaturesFromGmodGFF3(new File("src/test/resources/volvox_all.fna"), new File(
 						"src/test/resources/volvox.gff3"), false);
-		LinkedHashMap<String, ProteinSequence> proteinSequenceList = GeneFeatureHelper
+		Map<String, ProteinSequence> proteinSequenceList = GeneFeatureHelper
 				.getProteinSequences(chromosomeSequenceList.values());
 		// for(ProteinSequence proteinSequence : proteinSequenceList.values()){
 		// logger.info("Output={}", proteinSequence.getSequenceAsString());
@@ -149,10 +150,10 @@ public class GeneFeatureHelperTest {
 	@Test
 	public void testGetGeneSequences() throws Exception {
 		// logger.info("getGeneSequences");
-		LinkedHashMap<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper
+		Map<String, ChromosomeSequence> chromosomeSequenceList = GeneFeatureHelper
 				.loadFastaAddGeneFeaturesFromGmodGFF3(new File("src/test/resources/volvox_all.fna"), new File(
 						"src/test/resources/volvox.gff3"), true);
-		LinkedHashMap<String, GeneSequence> geneSequenceHashMap = GeneFeatureHelper
+		Map<String, GeneSequence> geneSequenceHashMap = GeneFeatureHelper
 				.getGeneSequences(chromosomeSequenceList.values());
 		Collection<GeneSequence> geneSequences = geneSequenceHashMap.values();
 


### PR DESCRIPTION
This PR is an experiment to fix the rule Sonar s1319 "Declarations should use Java collection interfaces such as 'List' rather than specific implementation classes such as 'LinkedList'".

It's a bit complicated on the Biojava project because the Sonar rule raises a few false positives and the project makes extensive use of interface implementations and sometimes methods that are implementation-specific. But after a few manual adjustments to standardise the modifications in the dependent modules, the tests pass with the exception of the TestCrystallographicMetadata.test1zna:92 test in the biojava-integrationtest module. I'm not convinced that the error stems from these modifications, but I'll let you be the judge.

Below is a link to the sonar page describing the problem https://rules.sonarsource.com/java/tag/bad-practice/RSPEC-1319/.

Indepth has fixed 102 issues that would have taken about 2 days to correct manually.