### PR TITLE
Bugfix: parsing of mmCIF files with empty database_PDB_rev.date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 BioJava Changelog
 -----------------
 
+BioJava 7.2.6
+==============================
+### Fixed
+* Parsing of PDBx/mmCIF with empty database_PDB_rev.date
+
 BioJava 7.2.5
 ==============================
 ### Fixed

--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/CifStructureConsumerImpl.java
@@ -630,7 +630,8 @@ public class CifStructureConsumerImpl implements CifStructureConsumer {
                 modDate = relDate;
             } else {
                 String dbrev = databasePDBrev.getDate().get(rowIndex);
-                modDate = convert(LocalDate.parse(dbrev, DATE_FORMAT));
+                if (dbrev != null && !dbrev.isBlank())
+                    modDate = convert(LocalDate.parse(dbrev, DATE_FORMAT));
             }
             pdbHeader.setModDate(modDate);
         }


### PR DESCRIPTION
Files with a block like the following were failing parse with a DateTimeParseException:
```
#
_database_PDB_rev.num             .
_database_PDB_rev.date            ?
_database_PDB_rev.date_original   2026-07-14
_database_PDB_rev.status          ?
_database_PDB_rev.replaces        ?
_database_PDB_rev.mod_type        ?
#
```