### PR TITLE
Fix scop flaky tests

### DIFF
--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/TestAtomCache.java
@@ -31,6 +31,8 @@ import org.biojava.nbio.structure.io.LocalPDBDirectory.FetchBehavior;
 import org.biojava.nbio.structure.io.LocalPDBDirectory.ObsoleteBehavior;
 import org.biojava.nbio.structure.io.PDBFileReader;
 import org.biojava.nbio.structure.io.StructureFiletype;
+import org.biojava.nbio.structure.scop.ScopFactory;
+import org.biojava.nbio.structure.test.util.ScopTestHelper;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,6 +51,9 @@ public class TestAtomCache {
 	@Before
 	public void setUp() throws IOException {
 		cache = new AtomCache();
+
+		// Bundled mock SCOP so domain IDs resolve without downloading classification files
+		ScopTestHelper.installMockScop(ScopFactory.LATEST_VERSION);
 
 		// Delete files which were cached in previous tests
 		String[] uncacheIDs = new String[] {

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/align/util/AtomCacheTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/align/util/AtomCacheTest.java
@@ -65,6 +65,7 @@ import org.biojava.nbio.structure.io.StructureFiletype;
 import org.biojava.nbio.structure.scop.ScopDatabase;
 import org.biojava.nbio.structure.scop.ScopFactory;
 import org.biojava.nbio.structure.test.util.GlobalsHelper;
+import org.biojava.nbio.structure.test.util.ScopTestHelper;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -83,15 +84,15 @@ public class AtomCacheTest {
 	private AtomCache cache;
 
 	@Before
-	public void setUp() {
+	public void setUp() throws IOException {
 		GlobalsHelper.pushState();
 
 		cache = new AtomCache();
 		cache.setObsoleteBehavior(ObsoleteBehavior.FETCH_OBSOLETE);
 		StructureIO.setAtomCache(cache);
 
-		// Use a fixed SCOP version for stability
-		ScopFactory.setScopDatabase(ScopFactory.LATEST_VERSION);
+		// Use a fixed SCOP version with bundled mock classification (no network)
+		ScopTestHelper.installMockScop(ScopFactory.LATEST_VERSION);
 	}
 
 	@After
@@ -172,7 +173,8 @@ public class AtomCacheTest {
 	 */
 	@Test
 	public void testGetStructureForChainlessDomains() throws IOException, StructureException {
-		ScopDatabase scop = ScopFactory.getSCOP(ScopFactory.VERSION_1_71); // Uses the range '1-135' without a chain
+		// Uses the range '1-135' without a chain; mock SCOP 1.71 avoids network download
+		ScopDatabase scop = ScopTestHelper.createMockScop(ScopFactory.VERSION_1_71);
 		Structure structure = cache.getStructureForDomain("d1hcy_1",scop);
 
 		//System.out.println(cache.getStructure("1hcy"));

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/test/util/ScopTestHelper.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/test/util/ScopTestHelper.java
@@ -1,0 +1,83 @@
+/*
+ *                    BioJava development code
+ *
+ * This code may be freely distributed and modified under the
+ * terms of the GNU Lesser General Public Licence.  This should
+ * be distributed with the code.  If you do not have a copy,
+ * see:
+ *
+ *      http://www.gnu.org/copyleft/lesser.html
+ *
+ * Copyright for this code is held jointly by the individual
+ * authors.  These should be listed in @author doc comments.
+ *
+ * For more information on the BioJava project and its aims,
+ * or to join the biojava-l mailing list, visit the home page
+ * at:
+ *
+ *      http://www.biojava.org/
+ *
+ */
+package org.biojava.nbio.structure.test.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import org.biojava.nbio.structure.scop.ScopFactory;
+import org.biojava.nbio.structure.scop.ScopInstallation;
+
+/**
+ * Installs small mock SCOP classification files from test resources so unit tests
+ * do not depend on downloading from scop.berkeley.edu.
+ */
+public final class ScopTestHelper {
+
+	private static final String RESOURCE_PREFIX = "scop/" + ScopInstallation.claFileName;
+
+	private ScopTestHelper() {
+	}
+
+	/**
+	 * Creates a {@link ScopInstallation} backed by a temp cache containing the mock
+	 * {@code dir.cla.scop.txt_&lt;version&gt;} resource, and registers it with {@link ScopFactory}.
+	 *
+	 * @param version SCOP/SCOPe version, e.g. {@link ScopFactory#LATEST_VERSION}
+	 * @return the installed database
+	 */
+	public static ScopInstallation installMockScop(String version) throws IOException {
+		ScopInstallation scop = createMockScop(version);
+		ScopFactory.setScopDatabase(scop);
+		return scop;
+	}
+
+	/**
+	 * Creates a {@link ScopInstallation} that reads a bundled mock classification file
+	 * instead of downloading from the network.
+	 *
+	 * @param version SCOP/SCOPe version, e.g. {@link ScopFactory#VERSION_1_71}
+	 * @return a SCOP database pointing at a temp cache with the mock file
+	 */
+	public static ScopInstallation createMockScop(String version) throws IOException {
+		String resourceName = RESOURCE_PREFIX + version;
+		InputStream in = ScopTestHelper.class.getClassLoader().getResourceAsStream(resourceName);
+		if (in == null) {
+			throw new IOException("Missing mock SCOP resource on classpath: " + resourceName);
+		}
+
+		Path cacheDir = Files.createTempDirectory("biojava-scop-mock-");
+		cacheDir.toFile().deleteOnExit();
+
+		Path claFile = cacheDir.resolve(ScopInstallation.claFileName + version);
+		try (InputStream stream = in) {
+			Files.copy(stream, claFile, StandardCopyOption.REPLACE_EXISTING);
+		}
+		claFile.toFile().deleteOnExit();
+
+		ScopInstallation scop = new ScopInstallation(cacheDir.toAbsolutePath().toString());
+		scop.setScopVersion(version);
+		return scop;
+	}
+}

--- a/biojava-structure/src/test/resources/scop/dir.cla.scop.txt_1.71
+++ b/biojava-structure/src/test/resources/scop/dir.cla.scop.txt_1.71
@@ -1,0 +1,2 @@
+# Mock SCOP 1.71 classification lines for unit tests (subset of dir.cla.scop.1.71.txt)
+d1hcy_1	1hcy	1-135	a.85.1.1	18495	cl=46456,cf=48049,sf=48050,fa=48051,dm=48052,sp=48054,px=18495

--- a/biojava-structure/src/test/resources/scop/dir.cla.scop.txt_2.08
+++ b/biojava-structure/src/test/resources/scop/dir.cla.scop.txt_2.08
@@ -1,0 +1,5 @@
+# Mock SCOPe 2.08 classification lines for unit tests (subset of dir.cla.scope.2.08-stable.txt)
+d1i3o.1	1i3o	A:,B:	c.17.1.1	61603	cl=51349,cf=52128,sf=52129,fa=52130,dm=52131,sp=52132,px=61603
+d2gs2a_	2gs2	A:	d.144.1.7	135574	cl=53931,cf=56111,sf=56112,fa=88854,dm=82795,sp=82796,px=135574
+d3bzy.1	3bzy	A:246-262,B:263-345	d.367.1.1	155799	cl=53931,cf=160543,sf=160544,fa=160545,dm=160546,sp=160547,px=155799
+d1i3oe_	1i3o	E:	g.52.1.1	61605	cl=56992,cf=57923,sf=57924,fa=57925,dm=57928,sp=57929,px=61605


### PR DESCRIPTION
1 Stop SCOP-dependent unit tests from downloading classification files from scop.berkeley.edu, which currently returns an HTML error page and causes ScopIOException failures in CI.
2 Add small mock SCOP .cla resources (versions 2.08 and 1.71) containing only the domains used by the failing tests.
3 Introduce ScopTestHelper to install those mocks into a temporary cache and register them via ScopFactory.
4 Update AtomCacheTest and TestAtomCache to use the mock SCOP data.