### PR TITLE
Run integration tests nightly rather than on every pull request

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,54 @@
+name: Nightly Integration Tests
+
+# The integration tests reach out to CATH, ECOD, RCSB, EBI, UniProt and others.
+# That makes them valuable - they are how we find out that an upstream service
+# has changed a URL, a format or a redirect - but it also makes them unsuitable
+# as a gate on pull requests, because an outage anywhere blocks every
+# contributor. Running them on a schedule keeps the coverage while decoupling it
+# from people's ability to merge.
+on:
+  schedule:
+    # 03:17 UTC daily. Off the hour deliberately: scheduled jobs that ask for
+    # exactly midnight queue behind everybody else's.
+    - cron: '17 3 * * *'
+  # Also runnable by hand, e.g. to confirm an upstream service is back.
+  workflow_dispatch:
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  integrationtest:
+    runs-on: ubuntu-latest
+    # These tests download large files from servers we do not control; the
+    # default 6 hour limit is far more than they need and far more than we want
+    # to spend if one of them hangs.
+    timeout-minutes: 90
+    strategy:
+      matrix:
+        # One JDK only. The point of this run is to exercise the network paths,
+        # not the language level, which the pull request build already covers
+        # across 11, 17 and 21.
+        java: [21]
+      fail-fast: false
+    name: Integration tests, JDK ${{ matrix.java }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'oracle'
+          java-version: ${{ matrix.java }}
+      - name: Build and run integration tests
+        run: mvn verify --no-transfer-progress
+      - name: Upload surefire reports
+        # Kept on failure so an upstream break can be diagnosed after the fact:
+        # GitHub expires run logs after 90 days, and these reports carry the
+        # stack traces that say which service misbehaved.
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: surefire-reports
+          path: '**/target/surefire-reports/**'
+          retention-days: 30

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,8 +30,14 @@ jobs:
         with:
           distribution: 'oracle'
           java-version: ${{ matrix.java }}
-      - name: Build, test and integration test
-        run: mvn verify --no-transfer-progress
+      - name: Build and test (no integration tests)
+        # Integration tests are excluded here and run nightly instead, see
+        # nightly.yml. They depend on CATH, ECOD, RCSB, EBI and others being up
+        # and responsive, so running them on every pull request means a third
+        # party having a bad day blocks contributors, and a real regression
+        # cannot be told apart from the resulting noise. Master Build already
+        # excludes them for the same reason.
+        run: mvn verify -pl '!biojava-integrationtest' --no-transfer-progress
 
   # Note that 11 is not available in openjdk. So we need to do it with the Zulu distribution (see https://github.com/actions/setup-java)
   # When we drop 11, it will be safe to drop the copy-pasted workflow excerpt below
@@ -54,5 +60,11 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
-      - name: Build, test and integration test
-        run: mvn verify --no-transfer-progress
+      - name: Build and test (no integration tests)
+        # Integration tests are excluded here and run nightly instead, see
+        # nightly.yml. They depend on CATH, ECOD, RCSB, EBI and others being up
+        # and responsive, so running them on every pull request means a third
+        # party having a bad day blocks contributors, and a real regression
+        # cannot be told apart from the resulting noise. Master Build already
+        # excludes them for the same reason.
+        run: mvn verify -pl '!biojava-integrationtest' --no-transfer-progress


### PR DESCRIPTION
Addresses the structural half of #1135.

The integration tests reach CATH, ECOD, RCSB, EBI and others. That is what makes them worth having — they are how we learn that an upstream service changed a URL, a format or a redirect. It is also what makes them a poor gate on pull requests, because any of those services having a bad day blocks every contributor, and a real regression then cannot be distinguished from the surrounding noise.

That is not hypothetical. Every `PR Build` since 2025-12-19 has failed, on all five matrix jobs, whatever the pull request contained — a one-line dependency bump (#1132) fails exactly as a feature branch does. Two integration tests account for it: `CathDomainTest`, because `download.cathdb.info` began redirecting http to https (#1138), and `EcodInstallationTest.testVersion`, because ECOD redesigned its distribution format (#1139).

`Master Build` already excludes the module with `-pl '!biojava-integrationtest'`. This applies the same exclusion to pull requests and adds a scheduled workflow that runs the full suite nightly, so the coverage is kept but is no longer in anybody's way. An upstream break still gets caught, within a day, by a run whose failure means what it says.

### Both failures are now fixed, which changes the argument for this PR

#1133 fixes CATH and #1141 fixes ECOD, so with those merged `PR Build` should be green **with** the integration tests still running. The emergency case for this PR is therefore gone, and I would rather say so than let it merge on momentum.

What is left is the stronger argument, and it is the one worth weighing:

- **Both breaks were upstream changes, and both took months to notice.** ECOD changed its file format at v294.1. The signal we got was `EcodInstallationTest.testVersion:285 Values should be different. Actual: latest`, on somebody else's unrelated pull request, competing for attention with a second failure and with eight months of identical red checks. It named neither ECOD nor the format. A nightly run would have reported it the following morning, alone, against a tree nobody had just changed.
- **Meanwhile the cost is paid by everyone.** `ecod.latest.domains.txt` is 657 MB, pulled once per matrix job, five times per pull request. That is not why the test failed — see #1139 — but it is real, and it buys coverage that a one-second offline test now provides better (#1141 adds fixtures pinning every ECOD file layout the project has ever read).

So the trade is not "keep the build green" any more. It is: should a pull request's check depend on five third-party services being up and fast, when the thing those services actually tell us arrives more usefully as a nightly failure?

### The nightly job

- **One JDK (21).** The pull request build already covers 11, 17 and 21; the point of this run is the network paths, not the language level.
- **90 minute timeout.** These downloads are large and GitHub's six hour default is not a useful ceiling if something hangs.
- **Surefire reports kept 30 days on failure.** GitHub expires run logs after 90 days, and those reports carry the stack traces identifying which service misbehaved — exactly what was missing when diagnosing the current breakage, where the logs for the older failures had already expired.
- **`workflow_dispatch`**, so it can be run by hand to confirm a service is back.

### What this gives up

Plainly: a pull request that breaks an integration test is not caught until that night. For changes touching the download or parsing paths, that is a real regression window. If that trade is unacceptable — and now that both tests are fixed it is a much more open question than when I opened this — the coherent response is to close this PR. I would rather that than have it merged by default.
