### PR TITLE
Bump the development version to 7.3.0-SNAPSHOT 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,55 @@
 BioJava Changelog
 -----------------
 
+BioJava 7.3.0
+==============================
+### Added
+* Fetching, caching and display of electron density and cryo-EM maps #1134
+* Checksum verification (MD5, SHA-1, SHA-256) in `FileDownloadUtils`, replacing the previous
+  stub. Downloads from `files.wwpdb.org` and `files.rcsb.org` are checksummed from their `ETag`
+  without a second request #1133
+* `HttpStatusException`, so callers can tell "not there" from a transport failure #1133
+* `FileDownloadUtils.downloadFileWithValidation()`, which downloads and validates over a single
+  connection #1133
+* `LocalPDBDirectory.getMiddleHash(String)`, computing the two-character directory from the
+  right so that it is correct for both short and extended PDB IDs #1133
+* Support for the ECOD distribution format introduced at v294.1 #1141 #1139
+
+### Performance
+* Contact calculation is about 1.5x faster: squared distances compared against a squared cutoff,
+  primitive arrays in `GridCell` instead of boxed lists, and a pre-sized `AtomContactSet` #1147
+* ASA calculation is about 1.2-1.3x faster, by the same replacement of objects with flat
+  primitive arrays in the hot loops #1148
+* `EcodInstallation.getVersion()` reads the file header instead of parsing every domain. The
+  current release is 653 MB and holds nearly three million records #1141
+
+### Fixed
+* CATH downloads use https and check the response before caching it. The previous http URL began
+  redirecting, and the redirect body was cached as classification data #1133 #1138
+* CATH parsing no longer throws `ArrayIndexOutOfBoundsException` on blank or truncated lines, and
+  cached files are validated before being used #1145
+* Chemical component downloads reject redirects and error responses rather than caching them #1133
+* Redirects that `HttpURLConnection` does not follow by itself - 307, 308, and any that change
+  http to https - are now followed #1151 #1149
+* `FileDownloadUtils`: the `hash` argument was ignored by one overload; downloads could be
+  silently truncated; temporary files leaked on failure; `validateFile` threw on a file with no
+  parent directory and on an empty `.size` sidecar #1133
+* mmCIF writer emits the entry identifier as a data item, so `getPdbId()` survives a
+  write-then-read round trip #1144 #1143
+* The ECOD read lock is left balanced when a download fails, so the original error is no longer
+  replaced by `IllegalMonitorStateException` #1150
+* Resolution parsing warns only when the values actually differ
+
+### Changed
+* `createValidationFiles()` now defaults to `ETagPolicy.USE_IF_HEX_DIGEST`, so existing callers
+  begin recording checksums where the server offers one #1133
+* Integration tests run nightly rather than on every pull request #1137 #1135
+* Tests migrated to JUnit 5 #1125 #1126 #1038
+* Library upgrades #1130 #1132
+
+### Removed
+* The `junit-addons` test dependency, no longer needed after the JUnit 5 migration #1126
+
 BioJava 7.2.6
 ==============================
 ### Fixed

--- a/biojava-aa-prop/pom.xml
+++ b/biojava-aa-prop/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>biojava-aa-prop</artifactId>
@@ -70,12 +70,12 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-core</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-structure</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 		</dependency>
 
 		<!-- logging dependencies (managed by parent pom, don't set versions or scopes here) -->

--- a/biojava-alignment/pom.xml
+++ b/biojava-alignment/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>biojava-alignment</artifactId>
 	<name>biojava-alignment</name>
@@ -47,7 +47,7 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-core</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/biojava-core/pom.xml
+++ b/biojava-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>biojava-core</artifactId>

--- a/biojava-genome/pom.xml
+++ b/biojava-genome/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>biojava-genome</artifactId>
@@ -73,13 +73,13 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-core</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-alignment</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<!-- logging dependencies (managed by parent pom, don't set versions or scopes here) -->

--- a/biojava-integrationtest/pom.xml
+++ b/biojava-integrationtest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>biojava</artifactId>
     <groupId>org.biojava</groupId>
-    <version>7.2.7-SNAPSHOT</version>
+    <version>7.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>biojava-integrationtest</artifactId>
   <packaging>jar</packaging>
@@ -40,7 +40,7 @@
     <dependency>
     	<groupId>org.biojava</groupId>
     	<artifactId>biojava-structure</artifactId>
-    	<version>7.2.7-SNAPSHOT</version>
+    	<version>7.3.0-SNAPSHOT</version>
     </dependency>
 		<!-- logging dependencies (managed by parent pom, don't set versions or scopes here) -->
 		<dependency>

--- a/biojava-modfinder/pom.xml
+++ b/biojava-modfinder/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>biojava-modfinder</artifactId>
 	<name>biojava-modfinder</name>
@@ -31,7 +31,7 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-structure</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/biojava-ontology/pom.xml
+++ b/biojava-ontology/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.biojava</groupId>
     <artifactId>biojava</artifactId>
-    <version>7.2.7-SNAPSHOT</version>
+    <version>7.3.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>biojava-ontology</artifactId>

--- a/biojava-protein-comparison-tool/pom.xml
+++ b/biojava-protein-comparison-tool/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>biojava-protein-comparison-tool</artifactId>
@@ -36,23 +36,23 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-alignment</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 
 		</dependency>
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-core</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-structure</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-structure-gui</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sourceforge.jmol</groupId>

--- a/biojava-protein-disorder/pom.xml
+++ b/biojava-protein-disorder/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>biojava-protein-disorder</artifactId>
 	<packaging>jar</packaging>
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-core</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 		</dependency>
 		<!-- logging dependencies (managed by parent pom, don't set versions or
 			scopes here) -->

--- a/biojava-structure-gui/pom.xml
+++ b/biojava-structure-gui/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>biojava</artifactId>
         <groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>biojava-structure-gui</artifactId>
@@ -27,13 +27,13 @@
         <dependency>
             <groupId>org.biojava</groupId>
             <artifactId>biojava-structure</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.biojava</groupId>
             <artifactId>biojava-core</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
 

--- a/biojava-structure/pom.xml
+++ b/biojava-structure/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>biojava-structure</artifactId>
 	<name>biojava-structure</name>
@@ -51,13 +51,13 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-alignment</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-core</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 

--- a/biojava-survival/pom.xml
+++ b/biojava-survival/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.biojava</groupId>
         <artifactId>biojava</artifactId>
-        <version>7.2.7-SNAPSHOT</version>
+        <version>7.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>biojava-survival</artifactId>

--- a/biojava-ws/pom.xml
+++ b/biojava-ws/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>biojava</artifactId>
 		<groupId>org.biojava</groupId>
-		<version>7.2.7-SNAPSHOT</version>
+		<version>7.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>biojava-ws</artifactId>
 	<name>biojava-ws</name>
@@ -19,7 +19,7 @@
 		<dependency>
 			<groupId>org.biojava</groupId>
 			<artifactId>biojava-core</artifactId>
-			<version>7.2.7-SNAPSHOT</version>
+			<version>7.3.0-SNAPSHOT</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>org.biojava</groupId>
 	<artifactId>biojava</artifactId>
 	<packaging>pom</packaging>
-	<version>7.2.7-SNAPSHOT</version>
+	<version>7.3.0-SNAPSHOT</version>
 	<name>biojava</name>
 	<description>BioJava is an open-source project dedicated to providing a Java framework for processing biological
         data. It provides analytical and statistical routines, parsers for common file formats and allows the


### PR DESCRIPTION
The electron density work and the FileDownloadUtils changes that go with it add public API and change a default, which belongs in a minor release rather than a patch. Their @since tags say 7.3.0, so the project version should agree.

Standalone so it can be taken or dropped independently of the feature work, and so the release manager decides when it lands. 