### PR TITLE
Write the entry identifier as a data item, not only as the block name

### DIFF
--- a/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/AbstractCifFileSupplier.java
+++ b/biojava-structure/src/main/java/org/biojava/nbio/structure/io/cif/AbstractCifFileSupplier.java
@@ -40,8 +40,27 @@ public abstract class AbstractCifFileSupplier<S> implements CifFileSupplier<S> {
         // entity information
         List<EntityInfo> entityInfos = structure.getEntityInfos();
 
+        PdbId pdbId = structure.getPdbId();
+
         MmCifBlockBuilder blockBuilder = CifBuilder.enterFile(StandardSchemata.MMCIF)
-                .enterBlock(structure.getPdbId() == null? "" : structure.getPdbId().getId());
+                .enterBlock(pdbId == null? "" : pdbId.getId());
+
+        if (pdbId != null) {
+            // The block header alone does not carry the identifier for consumers: readers pick it up from
+            // _entry.id (e.g. Jmol) or from _struct.entry_id (BioJava's own CifStructureConsumerImpl).
+            // Both are written so that the identifier survives a write-then-read round trip either way.
+            blockBuilder.enterEntry()
+                    .enterId()
+                    .add(pdbId.getId())
+                    .leaveColumn()
+                    .leaveCategory();
+
+            blockBuilder.enterStruct()
+                    .enterEntryId()
+                    .add(pdbId.getId())
+                    .leaveColumn()
+                    .leaveCategory();
+        }
 
         blockBuilder.enterStructKeywords().enterText()
         .add(String.join(", ", structure.getPDBHeader().getKeywords()))

--- a/biojava-structure/src/test/java/org/biojava/nbio/structure/io/cif/CifFileSupplierImplTest.java
+++ b/biojava-structure/src/test/java/org/biojava/nbio/structure/io/cif/CifFileSupplierImplTest.java
@@ -1,5 +1,6 @@
 package org.biojava.nbio.structure.io.cif;
 
+import org.biojava.nbio.structure.PdbId;
 import org.biojava.nbio.structure.Structure;
 import org.biojava.nbio.structure.io.FileParsingParameters;
 import org.biojava.nbio.structure.io.PDBFileParser;
@@ -40,5 +41,44 @@ public class CifFileSupplierImplTest {
             assertEquals(s.getEntityInfos().get(i).getType(), readStruct.getEntityInfos().get(i).getType());
         }
 
+    }
+
+    /**
+     * The identifier must be written as a data item and not only as the name of the data block: consumers read it
+     * from _entry.id or from _struct.entry_id, so writing the block header alone loses it. See issue #1143.
+     */
+    @Test
+    public void shouldWriteEntryIdAndSurviveRoundTrip() throws IOException {
+        Structure s;
+        try (InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream("/4hhb.cif.gz"))) {
+            s = CifStructureConverter.fromInputStream(inStream);
+        }
+        assertEquals(new PdbId("4HHB"), s.getPdbId());
+
+        String cifText = CifStructureConverter.toText(s);
+        assertTrue("_entry.id must be written", cifText.contains("_entry.id"));
+        assertTrue("_struct.entry_id must be written", cifText.contains("_struct.entry_id"));
+
+        Structure readStruct = CifStructureConverter.fromInputStream(
+                new ByteArrayInputStream(cifText.getBytes()));
+
+        assertEquals(s.getPdbId(), readStruct.getPdbId());
+        assertEquals(s.getPdbId(), readStruct.getPDBHeader().getPdbId());
+    }
+
+    /**
+     * Structures without an identifier must not gain empty entry categories.
+     */
+    @Test
+    public void shouldNotWriteEntryIdWhenPdbIdIsAbsent() throws IOException {
+        Structure s;
+        try (InputStream inStream = new GZIPInputStream(this.getClass().getResourceAsStream("/4hhb.cif.gz"))) {
+            s = CifStructureConverter.fromInputStream(inStream);
+        }
+        s.setPdbId(null);
+
+        String cifText = CifStructureConverter.toText(s);
+        assertFalse(cifText.contains("_entry.id"));
+        assertFalse(cifText.contains("_struct.entry_id"));
     }
 }


### PR DESCRIPTION
Fixes #1143

### The problem

`AbstractCifFileSupplier` wrote the PDB identifier only as the name of the `data_` block, and emitted neither `_entry.id` nor `_struct.entry_id`. Consumers read the identifier as a data item, not from the block header, so it did not survive being written:

- BioJava's own `CifStructureConsumerImpl.consumeStruct` reads `_struct.entry_id`, so `Structure.getPdbId()` came back **null** after a `toText()` / `fromInputStream()` round trip.
- Jmol's mmCIF reader takes `_M.pdbID` from `_entry.id`, so a structure handed over with `openStringInline(structure.toMMCIF())` arrived with no identifier — which in turn breaks anything keyed on the entry, such as `isosurface ... eds`, which needs an entry to fetch the electron density map for.

### The change

Write both categories immediately after entering the block, guarded on the identifier being present (mirroring the existing null check):

```java
blockBuilder.enterEntry().enterId().add(pdbId.getId()).leaveColumn().leaveCategory();
blockBuilder.enterStruct().enterEntryId().add(pdbId.getId()).leaveColumn().leaveCategory();
```

Both are needed, not one: `_entry.id` is the canonical item and the one Jmol reads, while BioJava's own reader only looks at `_struct.entry_id`, so omitting that one would leave BioJava still unable to read back what it just wrote.

`_struct` was not previously written anywhere in this class (only `_struct_keywords`, a separate category), so there is no duplicate-category concern.

### Tests

`CifFileSupplierImplTest` gains two cases — there was previously nothing asserting that an identifier survives `toMMCIF()`:

- `shouldWriteEntryIdAndSurviveRoundTrip` — reads `4hhb.cif.gz`, asserts both items are written, reads the text back and asserts `getPdbId()` still equals `4HHB`.
- `shouldNotWriteEntryIdWhenPdbIdIsAbsent` — a structure with no identifier gains no empty entry categories.

Verified that the round-trip test fails on unpatched `master` (`_entry.id must be written`) and passes with the change; the pre-existing test in that class is unaffected.

### Notes

- Based directly on upstream `master` (`5b29945`); independent of any other open PR.
- Behaviour change is additive — two items appear in written mmCIF files that were absent before, and only when the structure carries an identifier.
